### PR TITLE
Fix broken Hugging Face link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ download-models:
 		cd $(MODEL_REPO_DIR) && git reset --hard origin/main; \
 	else \
 		echo "Repository not found, cloning..."; \
-		git clone git@hf.co:$(MODEL_REPO) $(MODEL_REPO_DIR); \
+		$(eval HF_USERNAME := $(shell huggingface-cli whoami | head -n 1)) \
+		git clone https://$(HF_USERNAME):$(HF_TOKEN)@hf.co/$(MODEL_REPO) $(MODEL_REPO_DIR); \
 	fi
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ WhisperKit automatically downloads the recommended model for the device if not s
 let pipe = try? await WhisperKit(model: "large-v3")
 ```
 
-For a list of available models, see our [HuggingFace repo](https://huggingface.co/models/argmaxinc/whisperkit-coreml).
+For a list of available models, see our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml).
 
 ### Generating Models
 
@@ -76,7 +76,11 @@ git clone https://github.com/argmaxinc/whisperkit.git
 cd whisperkit
 ```
 
-Then, setup the enviornment and download the models (**Note**: this will download all available models to your local folder, if you only want to download a specific model, see our [HuggingFace repo](https://huggingface.co/models/argmaxinc/whisperkit-coreml)):
+Then, setup the environment and download the models.
+
+**Note**:
+1. this will download all available models to your local folder, if you only want to download a specific model, see our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml))
+2. before running `download-models`, make sure [git-lfs](https://git-lfs.com) is installed
 
 ```bash
 make setup


### PR DESCRIPTION
The [original link](https://huggingface.co/models/argmaxinc/whisperkit-coreml) to the models on Hugging Face website was broken, so this PR just fixes it.

Edit 1: I didn't have `git-lfs` installed when I ran `download-models`, and I encountered an error while checking out the model repo. So, I added an extra note about that.

Edit 2: despite having `$HF_TOKEN` set and being logged into Hugging Face (verified by `make setup`), I couldn't successfully run `download-models` due to an auth error. So I fixed the Makefile to include HF's username and token when cloning the model's repository (I'm not familiar with `huggingface-cli`, so I'm not sure how to properly fix this). Side note: users who have set an SSH key on the HF website shouldn't run into this auth issue.

ps. Thank you for open sourcing this project!