### PR TITLE
watchOS example & downloading improvements

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,37 +8,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  cache-models:
-    runs-on: macos-14
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup environment
-      run: make setup
-    - name: Cache Models
-      uses: actions/cache@v4
-      with:
-        path: Models
-        key: ${{ runner.os }}-models
-    - name: Download and cache models
-      run: make download-model MODEL=tiny
-
   build-and-test:
     runs-on: macos-14
-    needs: cache-models
     steps:
     - uses: actions/checkout@v4
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.2'
     - name: Setup environment
       run: make setup
-    - name: Cache Models
+    - name: Setup Cache
+      id: model-cache
       uses: actions/cache@v4
       with:
         path: Models
         key: ${{ runner.os }}-models
-    - name: Build
-      run: xcodebuild clean build-for-testing -scheme whisperkit-Package -destination 'platform=macOS' | xcpretty
-    - name: Run tests
+    - name: Download Models
+      if: steps.model-cache.outputs.cache-hit != 'true'
+      run: make download-model MODEL=tiny
+    - name: Install and discover destinations
+      run: |
+        xcodebuild -downloadAllPlatforms
+        echo "Destinations for testing:"
+        xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
+    - name: Build and Test - macOS 
       run: |
         set -o pipefail
-        xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
-        xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=macOS,arch=arm64" | xcpretty
+        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=macOS | xcpretty
+        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=macOS,arch=arm64" | xcpretty
+    - name: Build and Test - iOS
+      run: |
+        set -o pipefail
+        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=iOS | xcpretty
+        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=iOS Simulator,OS=17.2,name=iPhone 15" | xcpretty
+    - name: Build and Test - watchOS
+      run: |
+        set -o pipefail
+        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=watchOS | xcpretty
+        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=watchOS Simulator,OS=10.2,name=Apple Watch Ultra 2 (49mm)" | xcpretty
+    - name: Build and Test - visionOS
+      run: |
+        set -o pipefail
+        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=visionOS | xcpretty
+        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=visionOS Simulator,name=Apple Vision Pro" | xcpretty

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,57 @@
 # Contributing to WhisperKit
 
 ## Overview
+
 We welcome and encourage contributions to WhisperKit! Whether you're fixing bugs, improving documentation, or adding new features from the roadmap, your help is appreciated. This guide will help you get started with contributing to WhisperKit.
 
 ## Getting Started
+
 1. **Fork the Repository**: Start by [forking](https://github.com/argmaxinc/WhisperKit/fork) the WhisperKit repository on GitHub to your personal account.
 
 2. **Clone Your Fork**: Clone your fork to your local machine to start making changes.
+
    ```bash
    git clone https://github.com/[your-username]/whisperkit.git
    cd whisperkit
    ```
 
 ## Setting Up Your Development Environment
+
 1. **Install Dependencies**: Use the provided `Makefile` to set up your environment. Run `make setup` to install necessary dependencies.
+
    ```bash
    make setup
    ```
 
 2. **Download Models**: Run `make download-models` to download the required models to run and test locally.
+
    ```bash
-   make download-models
+   make download-model MODEL=tiny 
    ```
 
 ## Making Changes
+
 1. **Make Your Changes**: Implement your changes, add new features, or fix bugs. Ensure you adhere to the existing coding style. If you're adding new features, make sure to update or add any documentation or tests as needed.
 
 2. **Build and Test**: You can use the `Makefile` to build and test your changes. Run `make build` to build WhisperKit and `make test` to run tests.
+
    ```bash
    make build
    make test
    ```
+
     You can also run and test directly from Xcode. We've provided an example app that contains various use cases, just open the `Examples/WhisperAX/WhisperAX.xcodeproj` file in Xcode and run the app.
 
 ## Submitting Your Changes
+
 1. **Commit Your Changes**: Once you're satisfied with your changes, commit them with a clear and concise commit message.
+
    ```bash
    git commit -am "Add a new feature"
    ```
 
 2. **Push to Your Fork**: Push your changes to your fork on GitHub.
+
    ```bash
    git push origin my-branch
    ```
@@ -49,12 +61,14 @@ We welcome and encourage contributions to WhisperKit! Whether you're fixing bugs
 4. **Code Review**: Wait for the maintainers to review your pull request. Be responsive to feedback and make any necessary changes.
 
 ## Guidelines
+
 - **Code Style**: Follow the existing code style in the project.
 - **Commit Messages**: Write meaningful commit messages that clearly describe the changes.
 - **Documentation**: Update documentation if you're adding new features or making changes that affect how users interact with WhisperKit.
 - **Tests**: Add or update tests for new features or bug fixes.
 
 ## Final Steps
+
 After your pull request has been reviewed and approved, a maintainer will merge it into the main branch. Congratulations, you've successfully contributed to WhisperKit!
 
 Thank you for making WhisperKit better for everyone! ❤️‍🔥

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.pbxproj
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.pbxproj
@@ -7,11 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		161135DF2B3F66DA003C20F6 /* WhisperAXWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 161135DE2B3F66DA003C20F6 /* WhisperAXWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		161136102B3F6C68003C20F6 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1611360F2B3F6C68003C20F6 /* WhisperKit */; };
 		1677AFC22B57618A008C61C0 /* WhisperAXApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1677AFAB2B57618A008C61C0 /* WhisperAXApp.swift */; };
 		1677AFC42B57618A008C61C0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1677AFAE2B57618A008C61C0 /* Preview Assets.xcassets */; };
-		1677AFC82B57618A008C61C0 /* WhisperAXExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1677AFB32B57618A008C61C0 /* WhisperAXExampleView.swift */; };
 		1677AFC92B57618A008C61C0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1677AFB42B57618A008C61C0 /* Assets.xcassets */; };
 		1677AFCA2B57618A008C61C0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1677AFB62B57618A008C61C0 /* Preview Assets.xcassets */; };
 		1677AFD32B5762BC008C61C0 /* WhisperAXWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1677AFB72B57618A008C61C0 /* WhisperAXWatchApp.swift */; };
@@ -29,13 +27,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		161135E02B3F66DA003C20F6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 167B34562B05431E0076F261 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 161135DD2B3F66DA003C20F6;
-			remoteInfo = "Basic Watch App";
-		};
 		161135F12B3F66DC003C20F6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 167B34562B05431E0076F261 /* Project object */;
@@ -67,13 +58,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		161136052B3F66DC003C20F6 /* Embed Watch Content */ = {
+		1621BFDF2B74BF6E007FA014 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
-				161135DF2B3F66DA003C20F6 /* WhisperAXWatch.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -81,10 +71,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		161135D92B3F66DA003C20F6 /* WhisperAXWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WhisperAXWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		161135DE2B3F66DA003C20F6 /* WhisperAXWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WhisperAXWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		161135F02B3F66DC003C20F6 /* WhisperAXWatchAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhisperAXWatchAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		161135FA2B3F66DC003C20F6 /* WhisperAXWatchAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhisperAXWatchAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		161135DE2B3F66DA003C20F6 /* WhisperAX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WhisperAX.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		161135F02B3F66DC003C20F6 /* WhisperAX Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WhisperAX Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		161135FA2B3F66DC003C20F6 /* WhisperAX Watch AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WhisperAX Watch AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1677AFA62B57618A008C61C0 /* WhisperAX_Watch_AppUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhisperAX_Watch_AppUITests.swift; sourceTree = "<group>"; };
 		1677AFA72B57618A008C61C0 /* WhisperAX_Watch_AppUITestsLaunchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhisperAX_Watch_AppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		1677AFA92B57618A008C61C0 /* WhisperAX.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = WhisperAX.entitlements; sourceTree = "<group>"; };
@@ -103,7 +92,6 @@
 		167B345E2B05431E0076F261 /* WhisperAX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WhisperAX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		167B34712B05431F0076F261 /* WhisperAXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhisperAXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		167B347B2B05431F0076F261 /* WhisperAXUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WhisperAXUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		169755022B58A17000C57DDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,7 +219,6 @@
 			isa = PBXGroup;
 			children = (
 				1677AFE02B57678E008C61C0 /* Assets.xcassets */,
-				169755022B58A17000C57DDC /* Info.plist */,
 				1677AFA92B57618A008C61C0 /* WhisperAX.entitlements */,
 			);
 			path = Resources;
@@ -265,10 +252,9 @@
 				167B345E2B05431E0076F261 /* WhisperAX.app */,
 				167B34712B05431F0076F261 /* WhisperAXTests.xctest */,
 				167B347B2B05431F0076F261 /* WhisperAXUITests.xctest */,
-				161135D92B3F66DA003C20F6 /* WhisperAXWatch.app */,
-				161135DE2B3F66DA003C20F6 /* WhisperAXWatch.app */,
-				161135F02B3F66DC003C20F6 /* WhisperAXWatchAppTests.xctest */,
-				161135FA2B3F66DC003C20F6 /* WhisperAXWatchAppUITests.xctest */,
+				161135DE2B3F66DA003C20F6 /* WhisperAX.app */,
+				161135F02B3F66DC003C20F6 /* WhisperAX Watch AppTests.xctest */,
+				161135FA2B3F66DC003C20F6 /* WhisperAX Watch AppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -283,26 +269,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		161135D82B3F66DA003C20F6 /* WhisperAXWatch */ = {
+		161135DD2B3F66DA003C20F6 /* WhisperAX Watch App */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 161136062B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatch" */;
-			buildPhases = (
-				161135D72B3F66DA003C20F6 /* Resources */,
-				161136052B3F66DC003C20F6 /* Embed Watch Content */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				161135E12B3F66DA003C20F6 /* PBXTargetDependency */,
-			);
-			name = WhisperAXWatch;
-			productName = Basic;
-			productReference = 161135D92B3F66DA003C20F6 /* WhisperAXWatch.app */;
-			productType = "com.apple.product-type.application.watchapp2-container";
-		};
-		161135DD2B3F66DA003C20F6 /* WhisperAXWatchApp */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 161136022B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchApp" */;
+			buildConfigurationList = 161136022B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch App" */;
 			buildPhases = (
 				161135DA2B3F66DA003C20F6 /* Sources */,
 				161135DB2B3F66DA003C20F6 /* Frameworks */,
@@ -312,17 +281,17 @@
 			);
 			dependencies = (
 			);
-			name = WhisperAXWatchApp;
+			name = "WhisperAX Watch App";
 			packageProductDependencies = (
 				1611360F2B3F6C68003C20F6 /* WhisperKit */,
 			);
 			productName = "Basic Watch App";
-			productReference = 161135DE2B3F66DA003C20F6 /* WhisperAXWatch.app */;
+			productReference = 161135DE2B3F66DA003C20F6 /* WhisperAX.app */;
 			productType = "com.apple.product-type.application";
 		};
-		161135EF2B3F66DC003C20F6 /* WhisperAXWatchAppTests */ = {
+		161135EF2B3F66DC003C20F6 /* WhisperAX Watch AppTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 161136092B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchAppTests" */;
+			buildConfigurationList = 161136092B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch AppTests" */;
 			buildPhases = (
 				161135EC2B3F66DC003C20F6 /* Sources */,
 				161135ED2B3F66DC003C20F6 /* Frameworks */,
@@ -333,14 +302,14 @@
 			dependencies = (
 				161135F22B3F66DC003C20F6 /* PBXTargetDependency */,
 			);
-			name = WhisperAXWatchAppTests;
+			name = "WhisperAX Watch AppTests";
 			productName = "Basic Watch AppTests";
-			productReference = 161135F02B3F66DC003C20F6 /* WhisperAXWatchAppTests.xctest */;
+			productReference = 161135F02B3F66DC003C20F6 /* WhisperAX Watch AppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		161135F92B3F66DC003C20F6 /* WhisperAXWatchAppUITests */ = {
+		161135F92B3F66DC003C20F6 /* WhisperAX Watch AppUITests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1611360C2B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchAppUITests" */;
+			buildConfigurationList = 1611360C2B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch AppUITests" */;
 			buildPhases = (
 				161135F62B3F66DC003C20F6 /* Sources */,
 				161135F72B3F66DC003C20F6 /* Frameworks */,
@@ -351,9 +320,9 @@
 			dependencies = (
 				161135FC2B3F66DC003C20F6 /* PBXTargetDependency */,
 			);
-			name = WhisperAXWatchAppUITests;
+			name = "WhisperAX Watch AppUITests";
 			productName = "Basic Watch AppUITests";
-			productReference = 161135FA2B3F66DC003C20F6 /* WhisperAXWatchAppUITests.xctest */;
+			productReference = 161135FA2B3F66DC003C20F6 /* WhisperAX Watch AppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		167B345D2B05431E0076F261 /* WhisperAX */ = {
@@ -363,6 +332,7 @@
 				167B345A2B05431E0076F261 /* Sources */,
 				167B345B2B05431E0076F261 /* Frameworks */,
 				167B345C2B05431E0076F261 /* Resources */,
+				1621BFDF2B74BF6E007FA014 /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
@@ -420,12 +390,9 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1510;
+				LastSwiftUpdateCheck = 1520;
 				LastUpgradeCheck = 1520;
 				TargetAttributes = {
-					161135D82B3F66DA003C20F6 = {
-						CreatedOnToolsVersion = 15.1;
-					};
 					161135DD2B3F66DA003C20F6 = {
 						CreatedOnToolsVersion = 15.1;
 					};
@@ -470,22 +437,14 @@
 				167B345D2B05431E0076F261 /* WhisperAX */,
 				167B34702B05431F0076F261 /* WhisperAXTests */,
 				167B347A2B05431F0076F261 /* WhisperAXUITests */,
-				161135D82B3F66DA003C20F6 /* WhisperAXWatch */,
-				161135DD2B3F66DA003C20F6 /* WhisperAXWatchApp */,
-				161135EF2B3F66DC003C20F6 /* WhisperAXWatchAppTests */,
-				161135F92B3F66DC003C20F6 /* WhisperAXWatchAppUITests */,
+				161135DD2B3F66DA003C20F6 /* WhisperAX Watch App */,
+				161135EF2B3F66DC003C20F6 /* WhisperAX Watch AppTests */,
+				161135F92B3F66DC003C20F6 /* WhisperAX Watch AppUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		161135D72B3F66DA003C20F6 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		161135DC2B3F66DA003C20F6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -567,7 +526,6 @@
 			files = (
 				1677AFE62B57704E008C61C0 /* ContentView.swift in Sources */,
 				1677AFC22B57618A008C61C0 /* WhisperAXApp.swift in Sources */,
-				1677AFC82B57618A008C61C0 /* WhisperAXExampleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -591,19 +549,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		161135E12B3F66DA003C20F6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 161135DD2B3F66DA003C20F6 /* WhisperAXWatchApp */;
-			targetProxy = 161135E02B3F66DA003C20F6 /* PBXContainerItemProxy */;
-		};
 		161135F22B3F66DC003C20F6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 161135DD2B3F66DA003C20F6 /* WhisperAXWatchApp */;
+			target = 161135DD2B3F66DA003C20F6 /* WhisperAX Watch App */;
 			targetProxy = 161135F12B3F66DC003C20F6 /* PBXContainerItemProxy */;
 		};
 		161135FC2B3F66DC003C20F6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 161135DD2B3F66DA003C20F6 /* WhisperAXWatchApp */;
+			target = 161135DD2B3F66DA003C20F6 /* WhisperAX Watch App */;
 			targetProxy = 161135FB2B3F66DC003C20F6 /* PBXContainerItemProxy */;
 		};
 		167B34732B05431F0076F261 /* PBXTargetDependency */ = {
@@ -630,15 +583,17 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone for transcription.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKWatchOnly = YES;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.argmax.whisperkit.WhisperAX;
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAXWatch.watchkitapp;
-				PRODUCT_NAME = WhisperAXWatch;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitapp;
+				PRODUCT_NAME = WhisperAX;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -659,15 +614,17 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone for transcription.";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				INFOPLIST_KEY_WKWatchOnly = YES;
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.argmax.whisperkit.WhisperAX;
+				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAXWatch.watchkitapp;
-				PRODUCT_NAME = WhisperAXWatch;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitapp;
+				PRODUCT_NAME = WhisperAX;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -675,39 +632,6 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
-			};
-			name = Release;
-		};
-		161136072B3F66DC003C20F6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JSGZDY54HP;
-				INFOPLIST_KEY_CFBundleDisplayName = Basic;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		161136082B3F66DC003C20F6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JSGZDY54HP;
-				INFOPLIST_KEY_CFBundleDisplayName = Basic;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -721,7 +645,7 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic-Watch-AppTests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitapp.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -742,7 +666,7 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic-Watch-AppTests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitapp.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -763,7 +687,7 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic-Watch-AppUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitappUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -783,7 +707,7 @@
 				DEVELOPMENT_TEAM = JSGZDY54HP;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.swift-whisper-kit.Basic-Watch-AppUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.argmax.whisperkit.WhisperAX.watchkitappUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -914,6 +838,7 @@
 		167B34862B05431F0076F261 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WhisperAX/Resources/WhisperAX.entitlements;
@@ -925,9 +850,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = WhisperAX/Resources/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone for transcription.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -957,6 +881,7 @@
 		167B34872B05431F0076F261 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WhisperAX/Resources/WhisperAX.entitlements;
@@ -968,9 +893,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = WhisperAX/Resources/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to record audio from the microphone for transcription.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -1094,7 +1018,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		161136022B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchApp" */ = {
+		161136022B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				161136032B3F66DC003C20F6 /* Debug */,
@@ -1103,16 +1027,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		161136062B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatch" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				161136072B3F66DC003C20F6 /* Debug */,
-				161136082B3F66DC003C20F6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		161136092B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchAppTests" */ = {
+		161136092B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch AppTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1611360A2B3F66DC003C20F6 /* Debug */,
@@ -1121,7 +1036,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1611360C2B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAXWatchAppUITests" */ = {
+		1611360C2B3F66DC003C20F6 /* Build configuration list for PBXNativeTarget "WhisperAX Watch AppUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1611360D2B3F66DC003C20F6 /* Debug */,

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "5e4031ee16afd10d208c1aee9b49f4def6ca5264",
-        "version" : "0.1.1"
+        "revision" : "564442fba36b0b694d730a62d0593e5f54043b55"
       }
     }
   ],

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1,12 +1,16 @@
-//  For licensing see accompanying LICENSE.md file.
-//  Copyright © 2024 Argmax, Inc. All rights reserved.
+//
+//  ContentView.swift
+//  WhisperAX
+//
+//  Created by Zach Nagengast on 1/16/24.
+//
 
 import SwiftUI
 import WhisperKit
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #elseif canImport(AppKit)
-import AppKit
+    import AppKit
 #endif
 import AVFoundation
 
@@ -42,7 +46,6 @@ struct ContentView: View {
     @AppStorage("silenceThreshold") private var silenceThreshold: Double = 0.3
     @AppStorage("useVAD") private var useVAD: Bool = true
 
-
     @State private var loadingProgressValue: Float = 0.0
     @State private var specializationProgressRatio: Float = 0.7
     @State private var isFilePickerPresented = false
@@ -60,14 +63,13 @@ struct ContentView: View {
     @State private var unconfirmedSegments: [TranscriptionSegment] = []
     @State private var unconfirmedText: [String] = []
 
-
     @State private var showAdvancedOptions: Bool = false
     @State private var transcriptionTask: Task<Void, Never>? = nil
 
     @State private var selectedCategoryId: MenuItem.ID?
     private var menu = [
         MenuItem(name: "Transcribe", image: "book.pages"),
-        MenuItem(name: "Stream", image: "waveform.badge.mic")
+        MenuItem(name: "Stream", image: "waveform.badge.mic"),
     ]
 
     struct MenuItem: Identifiable, Hashable {
@@ -147,20 +149,18 @@ struct ContentView: View {
                     .frame(minWidth: 0, maxWidth: .infinity)
                 }
             })
-
         }
         .onAppear {
             Task {
                 whisperKit = try await WhisperKit(verbose: true, logLevel: .debug)
             }
 
-#if os(macOS)
-            selectedCategoryId = menu.first(where: { $0.name == selectedTab })?.id
-#endif
+            #if os(macOS)
+                selectedCategoryId = menu.first(where: { $0.name == selectedTab })?.id
+            #endif
             fetchModels()
         }
     }
-
 
     // MARK: - Transcription
 
@@ -169,7 +169,7 @@ struct ContentView: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 1) {
                     let startIndex = max(bufferEnergy.count - 300, 0)
-                    ForEach(Array(bufferEnergy.enumerated())[startIndex...], id: \.element) { index, energy in
+                    ForEach(Array(bufferEnergy.enumerated())[startIndex...], id: \.element) { _, energy in
                         ZStack {
                             RoundedRectangle(cornerRadius: 2)
                                 .frame(width: 2, height: CGFloat(energy) * 24)
@@ -183,7 +183,7 @@ struct ContentView: View {
             .frame(height: 24)
             .scrollIndicators(.never)
             ScrollView {
-                VStack(alignment: .leading) {  // Ensure alignment is set to .leading
+                VStack(alignment: .leading) {
                     ForEach(Array(confirmedSegments.enumerated()), id: \.element) { _, segment in
                         let timestampText = enableTimestamps ? "[\(String(format: "%.2f", segment.start)) --> \(String(format: "%.2f", segment.end))]" : ""
                         Text(timestampText + segment.text)
@@ -193,7 +193,7 @@ struct ContentView: View {
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    ForEach(Array(unconfirmedSegments.enumerated()), id: \.element) { index, segment in
+                    ForEach(Array(unconfirmedSegments.enumerated()), id: \.element) { _, segment in
                         let timestampText = enableTimestamps ? "[\(String(format: "%.2f", segment.start)) --> \(String(format: "%.2f", segment.end))]" : ""
                         Text(timestampText + segment.text)
                             .font(.headline)
@@ -201,12 +201,12 @@ struct ContentView: View {
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    Text("\(unconfirmedText.joined(separator: "\n"))" )
+                    Text("\(unconfirmedText.joined(separator: "\n"))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("\(currentText)" )
+                    Text("\(currentText)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
@@ -251,22 +251,22 @@ struct ContentView: View {
                             .scaleEffect(0.5)
                     }
 
-#if os(macOS)
-                    Button(action: {
-                        if let folder = whisperKit?.modelFolder {
-                            NSWorkspace.shared.open(folder)
-                        }
-                    }, label: {
-                        Image(systemName: "folder")
-                    })
-                    .buttonStyle(BorderlessButtonStyle())
-#endif
+                    #if os(macOS)
+                        Button(action: {
+                            if let folder = whisperKit?.modelFolder {
+                                NSWorkspace.shared.open(folder)
+                            }
+                        }, label: {
+                            Image(systemName: "folder")
+                        })
+                        .buttonStyle(BorderlessButtonStyle())
+                    #endif
                     Button(action: {
                         if let url = URL(string: "https://huggingface.co/\(repoName)") {
                             #if os(macOS)
-                            NSWorkspace.shared.open(url)
+                                NSWorkspace.shared.open(url)
                             #else
-                            UIApplication.shared.open(url)
+                                UIApplication.shared.open(url)
                             #endif
                         }
                     }, label: {
@@ -292,7 +292,7 @@ struct ContentView: View {
                         HStack {
                             ProgressView(value: loadingProgressValue, total: 1.0)
                                 .progressViewStyle(LinearProgressViewStyle())
-                                .frame(maxWidth: .infinity)  // This makes the progress bar expand to fill the available width
+                                .frame(maxWidth: .infinity)
 
                             Text(String(format: "%.1f%%", loadingProgressValue * 100))
                                 .font(.caption)
@@ -494,20 +494,20 @@ struct ContentView: View {
     }
 
     var advancedSettingsView: some View {
-#if os(iOS)
-        NavigationView {
-            settingsForm
-                .navigationBarTitleDisplayMode(.inline)
-        }
-#else
-        VStack {
-            Text("Decoding Options")
-                .font(.title2)
-                .padding()
-            settingsForm
-                .frame(minWidth: 500, minHeight: 500)
-        }
-#endif
+        #if os(iOS)
+            NavigationView {
+                settingsForm
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+        #else
+            VStack {
+                Text("Decoding Options")
+                    .font(.title2)
+                    .padding()
+                settingsForm
+                    .frame(minWidth: 500, minHeight: 500)
+            }
+        #endif
     }
 
     var settingsForm: some View {
@@ -517,7 +517,6 @@ struct ContentView: View {
                 InfoButton("Toggling this will include/exclude timestamps in both the UI and the prefill tokens.\nEither <|notimestamps|> or <|0.00|> will be forced based on this setting unless \"Prompt Prefill\" is de-selected.")
                 Spacer()
                 Toggle("", isOn: $enableTimestamps)
-
             }
             .padding(.horizontal)
 
@@ -598,7 +597,6 @@ struct ContentView: View {
                 }
             }
             .padding(.horizontal)
-
         }
         .navigationTitle("Decoding Options")
         .toolbar(content: {
@@ -662,7 +660,8 @@ struct ContentView: View {
         localModels = WhisperKit.formatModelFiles(localModels)
         for model in localModels {
             if !availableModels.contains(model),
-               !disabledModels.contains(model){
+               !disabledModels.contains(model)
+            {
                 availableModels.append(model)
             }
         }
@@ -674,7 +673,8 @@ struct ContentView: View {
             let remoteModels = try await WhisperKit.fetchAvailableModels(from: repoName)
             for model in remoteModels {
                 if !availableModels.contains(model),
-                   !disabledModels.contains(model){
+                   !disabledModels.contains(model)
+                {
                     availableModels.append(model)
                 }
             }
@@ -685,23 +685,23 @@ struct ContentView: View {
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
 
         switch microphoneStatus {
-            case .notDetermined:
-                return await withCheckedContinuation { continuation in
-                    AVCaptureDevice.requestAccess(for: .audio) { granted in
-                        continuation.resume(returning: granted)
-                    }
+        case .notDetermined:
+            return await withCheckedContinuation { continuation in
+                AVCaptureDevice.requestAccess(for: .audio) { granted in
+                    continuation.resume(returning: granted)
                 }
-            case .restricted, .denied:
-                print("Microphone access denied")
-                return false
-            case .authorized:
-                return true
-            @unknown default:
-                fatalError("Unknown authorization status")
+            }
+        case .restricted, .denied:
+            print("Microphone access denied")
+            return false
+        case .authorized:
+            return true
+        @unknown default:
+            fatalError("Unknown authorization status")
         }
     }
 
-    func loadModel(_ model: String) {
+    func loadModel(_ model: String, redownload: Bool = false) {
         print("Selected Model: \(UserDefaults.standard.string(forKey: "selectedModel") ?? "nil")")
 
         whisperKit = nil
@@ -709,7 +709,9 @@ struct ContentView: View {
             whisperKit = try await WhisperKit(
                 verbose: true,
                 logLevel: .debug,
-                prewarm: false
+                prewarm: false,
+                load: false,
+                download: false
             )
             guard let whisperKit = whisperKit else {
                 return
@@ -724,7 +726,7 @@ struct ContentView: View {
                 folder = URL(fileURLWithPath: localModelPath).appendingPathComponent("openai_whisper-\(model)")
             } else {
                 // Download the model
-                folder = try await WhisperKit.load(variant: model, from: repoName, progressCallback: { progress in
+                folder = try await WhisperKit.download(variant: model, from: repoName, progressCallback: { progress in
                     DispatchQueue.main.async {
                         loadingProgressValue = Float(progress.fractionCompleted) * specializationProgressRatio
                         modelState = .downloading
@@ -746,8 +748,21 @@ struct ContentView: View {
                 }
 
                 // Prewarm models
-                try await whisperKit.prewarmModels()
-                progressBarTask.cancel()
+                do {
+                    try await whisperKit.prewarmModels()
+                    progressBarTask.cancel()
+                } catch {
+                    print("Error prewarming models, retrying: \(error.localizedDescription)")
+                    progressBarTask.cancel()
+                    if !redownload {
+                        loadModel(model, redownload: true)
+                        return
+                    } else {
+                        // Redownloading failed, error out
+                        modelState = .unloaded
+                        return
+                    }
+                }
 
                 await MainActor.run {
                     // Set the loading progress to 90% of the way after prewarm
@@ -802,32 +817,32 @@ struct ContentView: View {
 
     func handleFilePicker(result: Result<[URL], Error>) {
         switch result {
-            case .success(let urls):
-                guard let selectedFileURL = urls.first else { return }
-                if selectedFileURL.startAccessingSecurityScopedResource() {
-                    do {
-                        // Access the document data from the file URL
-                        let audioFileData = try Data(contentsOf: selectedFileURL)
+        case let .success(urls):
+            guard let selectedFileURL = urls.first else { return }
+            if selectedFileURL.startAccessingSecurityScopedResource() {
+                do {
+                    // Access the document data from the file URL
+                    let audioFileData = try Data(contentsOf: selectedFileURL)
 
-                        // Create a unique file name to avoid overwriting any existing files
-                        let uniqueFileName = UUID().uuidString + "." + selectedFileURL.pathExtension
+                    // Create a unique file name to avoid overwriting any existing files
+                    let uniqueFileName = UUID().uuidString + "." + selectedFileURL.pathExtension
 
-                        // Construct the temporary file URL in the app's temp directory
-                        let tempDirectoryURL = FileManager.default.temporaryDirectory
-                        let localFileURL = tempDirectoryURL.appendingPathComponent(uniqueFileName)
+                    // Construct the temporary file URL in the app's temp directory
+                    let tempDirectoryURL = FileManager.default.temporaryDirectory
+                    let localFileURL = tempDirectoryURL.appendingPathComponent(uniqueFileName)
 
-                        // Write the data to the temp directory
-                        try audioFileData.write(to: localFileURL)
+                    // Write the data to the temp directory
+                    try audioFileData.write(to: localFileURL)
 
-                        print("File saved to temporary directory: \(localFileURL)")
+                    print("File saved to temporary directory: \(localFileURL)")
 
-                        transcribeFile(path: selectedFileURL.path)
-                    } catch {
-                        print("File selection error: \(error.localizedDescription)")
-                    }
+                    transcribeFile(path: selectedFileURL.path)
+                } catch {
+                    print("File selection error: \(error.localizedDescription)")
                 }
-            case .failure(let error):
-                print("File selection error: \(error.localizedDescription)")
+            }
+        case let .failure(error):
+            print("File selection error: \(error.localizedDescription)")
         }
     }
 
@@ -862,7 +877,7 @@ struct ContentView: View {
                     return
                 }
 
-                try? audioProcessor.startRecordingLive { buffer in
+                try? audioProcessor.startRecordingLive { _ in
                     DispatchQueue.main.async {
                         bufferEnergy = whisperKit?.audioProcessor.relativeEnergy ?? []
                     }
@@ -895,7 +910,6 @@ struct ContentView: View {
                 }
             }
         }
-
     }
 
     // MARK: Transcribe Logic
@@ -944,7 +958,6 @@ struct ContentView: View {
             withoutTimestamps: !enableTimestamps,
             clipTimestamps: seekClip
         )
-
 
         // Early stopping checks
         let decodingCallback: ((TranscriptionProgress) -> Bool?) = { progress in
@@ -1068,7 +1081,6 @@ struct ContentView: View {
         // Run transcribe
         lastBufferSize = currentBuffer.count
 
-
         let transcription = try await transcribeAudioSamples(Array(currentBuffer))
 
         // We need to run this next part on the main thread
@@ -1116,7 +1128,7 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-#if os(macOS)
+    #if os(macOS)
         .frame(width: 800, height: 500)
-#endif
+    #endif
 }

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -1,48 +1,690 @@
 //  For licensing see accompanying LICENSE.md file.
 //  Copyright © 2024 Argmax, Inc. All rights reserved.
 
+import AVFoundation
+import Charts
+import CoreML
 import SwiftUI
 import WhisperKit
 
 struct WhisperAXWatchView: View {
     @State private var whisperKit: WhisperKit?
-    @State private var transcription = "Tap below to start"
+    @State private var currentText = "Tap below to start"
+    @State private var isTranscribing = false
+    @State private var isRecording = false
+    @State private var energyToDisplayCount = 100
+    // TODO: Make this configurable in the UI
+    @State var modelStorage: String = "huggingface/models/argmaxinc/whisperkit-coreml"
+
+    @AppStorage("selectedModel") private var selectedModel: String = WhisperKit.recommendedModels().default
+    @AppStorage("selectedTab") private var selectedTab: String = "Transcribe"
+    @AppStorage("selectedTask") private var selectedTask: String = "transcribe"
+    @AppStorage("selectedLanguage") private var selectedLanguage: String = "english"
+    @AppStorage("repoName") private var repoName: String = "argmaxinc/whisperkit-coreml"
+    @AppStorage("enableTimestamps") private var enableTimestamps: Bool = false
+    @AppStorage("enablePromptPrefill") private var enablePromptPrefill: Bool = true
+    @AppStorage("enableCachePrefill") private var enableCachePrefill: Bool = true
+    @AppStorage("enableSpecialCharacters") private var enableSpecialCharacters: Bool = false
+    @AppStorage("enableEagerDecoder") private var enableEagerDecoder: Bool = false
+    @AppStorage("temperatureStart") private var temperatureStart: Double = 0
+    @AppStorage("fallbackCount") private var fallbackCount: Double = 4
+    @AppStorage("compressionCheckWindow") private var compressionCheckWindow: Double = 20
+    @AppStorage("sampleLength") private var sampleLength: Double = 224
+    @AppStorage("silenceThreshold") private var silenceThreshold: Double = 0.3
+    @AppStorage("useVAD") private var useVAD: Bool = true
+
+    @State private var modelState: ModelState = .unloaded
+    @State private var localModels: [String] = []
+    @State private var localModelPath: String = ""
+    @State private var availableModels: [String] = []
+    @State private var availableLanguages: [String] = []
+    @State private var disabledModels: [String] = WhisperKit.recommendedModels().disabled
+
+    @State private var loadingProgressValue: Float = 0.0
+    @State private var specializationProgressRatio: Float = 0.7
+    @State private var currentLag: TimeInterval = 0
+    @State private var currentFallbacks: Int = 0
+    @State private var lastBufferSize: Int = 0
+    @State private var lastConfirmedSegmentEndSeconds: Float = 0
+    @State private var requiredSegmentsForConfirmation: Int = 2
+    @State private var bufferEnergy: [EnergyValue] = []
+    @State private var confirmedSegments: [TranscriptionSegment] = []
+    @State private var unconfirmedSegments: [TranscriptionSegment] = []
+    @State private var unconfirmedText: [String] = []
+
+    @State private var transcriptionTask: Task<Void, Never>? = nil
+
+    @State private var selectedCategoryId: MenuItem.ID?
+    private var menu = [
+        MenuItem(name: "Start Transcribing", image: "waveform.badge.mic"),
+    ]
+
+    struct MenuItem: Identifiable, Hashable {
+        var id = UUID()
+        var name: String
+        var image: String
+    }
+
+    struct EnergyValue: Identifiable {
+        let id = UUID()
+        var index: Int
+        var value: Float
+    }
 
     var body: some View {
-        VStack {
-            Image(systemName: "mic.circle")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text(transcription)
-                .lineLimit(nil)
-                .multilineTextAlignment(.center)
-                .padding()
-                .fixedSize(horizontal: false, vertical: true)
-            Button(whisperKit == nil ? "Loading WhisperKit..." : "Transcribe Example") {
-                transcribeAudio()
+        NavigationSplitView {
+            if WhisperKit.deviceName().hasPrefix("Watch7") {
+                modelSelectorView
+                    .navigationTitle("WhisperAX")
+                    .navigationBarTitleDisplayMode(.automatic)
+
+                if modelState == .loaded {
+                    List(menu, selection: $selectedCategoryId) { item in
+                        HStack {
+                            Image(systemName: item.image)
+                            Text(item.name)
+                                .scaledToFit()
+                                .minimumScaleFactor(0.5)
+                                .font(.system(.title3))
+                                .bold()
+                                .padding(.horizontal)
+                        }
+                    }
+                    .foregroundColor(.primary)
+                    .navigationTitle("WhisperAX")
+                    .navigationBarTitleDisplayMode(.automatic)
+                }
+            } else {
+                VStack {
+                    Image(systemName: "exclamationmark.applewatch")
+                        .foregroundColor(.red)
+                        .font(.system(size: 80))
+                        .padding()
+
+                    Text("Sorry, this app\nrequires Apple Watch\nSeries 9 or Ultra 2")
+                        .scaledToFill()
+                        .minimumScaleFactor(0.5)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                }
+                .navigationTitle("WhisperAX")
+                .navigationBarTitleDisplayMode(.inline)
             }
-            .font(.footnote)
-            .disabled(whisperKit == nil)
+
+        } detail: {
+            streamingView
         }
-        .padding()
         .onAppear {
-            Task {
-                try await prepareWhisper()
+            fetchModels()
+        }
+    }
+
+    var modelStatusView: some View {
+        HStack {
+            Image(systemName: "circle.fill")
+                .foregroundStyle(modelState == .loaded ? .green : (modelState == .unloaded ? .red : .yellow))
+                .symbolEffect(.variableColor, isActive: modelState != .loaded && modelState != .unloaded)
+            Text(modelState.description)
+                .font(.footnote)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    var modelSelectorView: some View {
+        Group {
+            VStack {
+                modelStatusView
+                    .padding(.top)
+                HStack {
+                    if availableModels.count > 0 {
+                        Picker("", selection: $selectedModel) {
+                            ForEach(availableModels, id: \.self) { model in
+                                HStack {
+                                    let modelIcon = localModels.contains { $0 == model.description } ? "checkmark.circle" : "arrow.down.circle.dotted"
+                                    Text("\(Image(systemName: modelIcon)) \(model.description)").tag(model.description)
+                                        .scaledToFit()
+                                        .minimumScaleFactor(0.5)
+                                }
+                            }
+                        }
+                        .frame(height: 80)
+                        .pickerStyle(.wheel)
+                        .onChange(of: selectedModel, initial: false) { _, _ in
+                            resetState()
+                            modelState = .unloaded
+                        }
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                            .scaleEffect(0.5)
+                    }
+                }
+
+                if modelState == .unloaded {
+                    Button {
+                        resetState()
+                        loadModel(selectedModel)
+                        modelState = .loading
+                    } label: {
+                        Text("Load Model")
+                    }
+                    .buttonStyle(.bordered)
+                } else if loadingProgressValue < 1.0 {
+                    VStack {
+                        HStack {
+                            ProgressView(value: loadingProgressValue, total: 1.0)
+                                .progressViewStyle(LinearProgressViewStyle())
+                                .frame(maxWidth: .infinity)
+
+                            Text(String(format: "%.1f%%", loadingProgressValue * 100))
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                        if modelState == .prewarming {
+                            Text("Specializing \(selectedModel)...")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
             }
         }
     }
 
-    func prepareWhisper() async throws {
-        let modelPath = Bundle.main.bundlePath
-        whisperKit = try await WhisperKit(modelFolder: modelPath)
-    }
+    var streamingView: some View {
+        ZStack(alignment: .bottom) {
+            VStack {
+                Spacer()
+                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: Alignment.topLeading)
+                HStack(alignment: .bottom) {
+                    if isRecording {
+                        Chart(bufferEnergy) {
+                            BarMark(
+                                x: .value("", $0.index),
+                                y: .value("", $0.value),
+                                width: 2,
+                                stacking: .center
+                            )
+                            .cornerRadius(1)
+                            .foregroundStyle($0.value > Float(silenceThreshold) ? .green : .red)
+                        }
+                        .chartXAxis(.hidden)
+                        .chartXScale(domain: [0, energyToDisplayCount])
+                        .chartYAxis(.hidden)
+                        .chartYScale(domain: [-0.5, 0.5])
+                        .frame(height: 45)
+                        .padding(.bottom)
+                    }
+                }
+            }
+            .ignoresSafeArea()
 
-    func transcribeAudio() {
-        guard let whisperKit = whisperKit else { return }
-        Task {
-            // TODO: implement
+            ScrollView(.vertical) {
+                VStack(alignment: .leading) {
+                    Spacer()
+                        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: Alignment.topLeading)
+                    ForEach(Array(confirmedSegments.enumerated()), id: \.element) { _, segment in
+                        Text(segment.text)
+                            .font(.headline)
+                            .fontWeight(.bold)
+                            .tint(.green)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    ForEach(Array(unconfirmedSegments.enumerated()), id: \.element) { _, segment in
+                        Text(segment.text)
+                            .font(.headline)
+                            .fontWeight(.light)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .defaultScrollAnchor(.bottom)
+        }
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                let currentTranscription = (confirmedSegments.map { $0.text } + unconfirmedSegments.map { $0.text }).joined(separator: " ")
+                ShareLink(item: currentTranscription, label: {
+                    Image(systemName: "square.and.arrow.up")
+                })            }
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    withAnimation {
+                        toggleRecording(shouldLoop: true)
+                    }
+                } label: {
+                    Image(systemName: !isRecording ? "record.circle" : "stop.circle.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 28, height: 28)
+                        .foregroundColor(modelState != .loaded ? .gray : .red)
+                }
+                .contentTransition(.symbolEffect(.replace))
+                .buttonStyle(BorderlessButtonStyle())
+                .disabled(modelState != .loaded)
+                .frame(minWidth: 0, maxWidth: .infinity)
+            }
         }
     }
+
+    // MARK: Logic
+
+    func resetState() {
+        isRecording = false
+        isTranscribing = false
+        whisperKit?.audioProcessor.stopRecording()
+        currentText = ""
+        unconfirmedText = []
+
+        currentLag = 0
+        currentFallbacks = 0
+        lastBufferSize = 0
+        lastConfirmedSegmentEndSeconds = 0
+        requiredSegmentsForConfirmation = 2
+        bufferEnergy = []
+        confirmedSegments = []
+        unconfirmedSegments = []
+    }
+
+    func fetchModels() {
+        availableModels = ["base", "base.en", "tiny", "tiny.en"]
+        let devices = MLModel.availableComputeDevices
+        print("Available devices: \(devices)")
+        // First check what's already downloaded
+        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let modelPath = documents.appendingPathComponent(modelStorage).path
+
+            // Check if the directory exists
+            if FileManager.default.fileExists(atPath: modelPath) {
+                localModelPath = modelPath
+                do {
+                    let downloadedModels = try FileManager.default.contentsOfDirectory(atPath: modelPath)
+                    for model in downloadedModels where !localModels.contains(model) && model.starts(with: "openai") {
+                        localModels.append(model)
+                    }
+                } catch {
+                    print("Error enumerating files at \(modelPath): \(error.localizedDescription)")
+                }
+            }
+        }
+
+        localModels = WhisperKit.formatModelFiles(localModels)
+        for model in localModels {
+            if !availableModels.contains(model),
+               !disabledModels.contains(model)
+            {
+                availableModels.append(model)
+            }
+        }
+
+        print("Found locally: \(localModels)")
+        print("Previously selected model: \(selectedModel)")
+
+//        Task {
+//            let remoteModels = try await WhisperKit.fetchAvailableModels(from: repoName)
+//            for model in remoteModels {
+//                if !availableModels.contains(model),
+//                   !disabledModels.contains(model){
+//                    availableModels.append(model)
+//                }
+//            }
+//        }
+    }
+
+    func loadModel(_ model: String, redownload: Bool = false) {
+        print("Selected Model: \(selectedModel)")
+
+        whisperKit = nil
+        Task {
+            whisperKit = try await WhisperKit(
+                verbose: true,
+                logLevel: .debug,
+                prewarm: false,
+                load: false,
+                download: false
+            )
+            guard let whisperKit = whisperKit else {
+                return
+            }
+
+            let recommended = WhisperKit.recommendedModels()
+
+            var folder: URL?
+
+            // Check if the model is available locally
+            if localModels.contains(model) && !redownload {
+                // Get local model folder URL from localModels
+                // TODO: Make this configurable in the UI
+                // TODO: Handle incomplete downloads
+                folder = URL(fileURLWithPath: localModelPath).appendingPathComponent("openai_whisper-\(model)")
+            } else {
+                // Download the model
+                folder = try await WhisperKit.download(variant: model, from: repoName, progressCallback: { progress in
+                    DispatchQueue.main.async {
+                        loadingProgressValue = Float(progress.fractionCompleted) * specializationProgressRatio
+                        modelState = .downloading
+                    }
+                })
+            }
+
+            if let modelFolder = folder {
+                whisperKit.modelFolder = modelFolder
+
+                await MainActor.run {
+                    // Set the loading progress to 90% of the way after prewarm
+                    loadingProgressValue = specializationProgressRatio
+                    modelState = .prewarming
+                }
+
+                let progressBarTask = Task {
+                    await updateProgressBar(targetProgress: 0.9, maxTime: 240)
+                }
+
+                // Prewarm models
+                do {
+                    try await whisperKit.prewarmModels()
+                    progressBarTask.cancel()
+                } catch {
+                    print("Error prewarming models, retrying: \(error.localizedDescription)")
+                    progressBarTask.cancel()
+                    if !redownload {
+                        loadModel(model, redownload: true)
+                        return
+                    } else {
+                        // Redownloading failed, error out
+                        modelState = .unloaded
+                        return
+                    }
+                }
+
+                await MainActor.run {
+                    // Set the loading progress to 90% of the way after prewarm
+                    loadingProgressValue = specializationProgressRatio + 0.9 * (1 - specializationProgressRatio)
+                    modelState = .loading
+                }
+
+                try await whisperKit.loadModels()
+
+                await MainActor.run {
+                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
+                    loadingProgressValue = 1.0
+                    modelState = whisperKit.modelState
+                }
+            }
+        }
+    }
+
+    func updateProgressBar(targetProgress: Float, maxTime: TimeInterval) async {
+        let initialProgress = loadingProgressValue
+        let decayConstant = -log(1 - targetProgress) / Float(maxTime)
+
+        let startTime = Date()
+
+        while true {
+            let elapsedTime = Date().timeIntervalSince(startTime)
+
+            // Break down the calculation
+            let decayFactor = exp(-decayConstant * Float(elapsedTime))
+            let progressIncrement = (1 - initialProgress) * (1 - decayFactor)
+            let currentProgress = initialProgress + progressIncrement
+
+            await MainActor.run {
+                loadingProgressValue = currentProgress
+            }
+
+            if currentProgress >= targetProgress {
+                break
+            }
+
+            do {
+                try await Task.sleep(nanoseconds: 100_000_000)
+            } catch {
+                break
+            }
+        }
+    }
+
+    func toggleRecording(shouldLoop: Bool) {
+        isRecording.toggle()
+
+        if isRecording {
+            resetState()
+            startRecording()
+        } else {
+            stopRecording()
+        }
+    }
+
+    func startRecording() {
+        guard let whisperKit = whisperKit else { return }
+        Task(priority: .userInitiated) {
+//                guard await requestMicrophoneIfNeeded() else {
+//                    print("Microphone access was not granted.")
+//                    return
+//                }
+
+            try? whisperKit.audioProcessor.startRecordingLive { _ in
+                DispatchQueue.main.async {
+                    var energyToDisplay: [EnergyValue] = []
+                    for (idx, val) in whisperKit.audioProcessor.relativeEnergy.suffix(energyToDisplayCount).enumerated() {
+                        energyToDisplay.append(EnergyValue(index: idx, value: val))
+                    }
+                    bufferEnergy = energyToDisplay
+                }
+            }
+
+            // Delay the timer start by 1 second
+            isRecording = true
+            isTranscribing = true
+            realtimeLoop()
+        }
+    }
+
+    func stopRecording() {
+        guard let whisperKit = whisperKit else { return }
+        whisperKit.audioProcessor.stopRecording()
+    }
+
+    func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
+        guard let whisperKit = whisperKit else { return nil }
+
+        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
+        let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
+        let seekClip = [lastConfirmedSegmentEndSeconds]
+
+        let options = DecodingOptions(
+            verbose: false,
+            task: task,
+            language: languageCode,
+            temperatureFallbackCount: 3, // limit fallbacks for realtime
+            sampleLength: Int(sampleLength), // reduced sample length for realtime
+            skipSpecialTokens: true,
+            clipTimestamps: seekClip
+        )
+
+        // Early stopping checks
+        let decodingCallback: ((TranscriptionProgress) -> Bool?) = { progress in
+            DispatchQueue.main.async {
+                let fallbacks = Int(progress.timings.totalDecodingFallbacks)
+                if progress.text.count < currentText.count {
+                    if fallbacks == self.currentFallbacks {
+                        self.unconfirmedText.append(currentText)
+                    } else {
+                        print("Fallback occured: \(fallbacks)")
+                    }
+                }
+                self.currentText = progress.text
+                self.currentFallbacks = fallbacks
+            }
+            // Check early stopping
+            let currentTokens = progress.tokens
+            let checkWindow = Int(compressionCheckWindow)
+            if currentTokens.count > checkWindow {
+                let checkTokens: [Int] = currentTokens.suffix(checkWindow)
+                let compressionRatio = compressionRatio(of: checkTokens)
+                if compressionRatio > options.compressionRatioThreshold! {
+                    return false
+                }
+            }
+            if progress.avgLogprob! < options.logProbThreshold! {
+                return false
+            }
+
+            return nil
+        }
+
+        let transcription = try await whisperKit.transcribe(audioArray: samples, decodeOptions: options, callback: decodingCallback)
+        return transcription
+    }
+
+    // MARK: Streaming Logic
+
+    func realtimeLoop() {
+        transcriptionTask = Task {
+            while isRecording && isTranscribing {
+                do {
+                    try await transcribeCurrentBuffer()
+                } catch {
+                    print("Error: \(error.localizedDescription)")
+                    break
+                }
+            }
+        }
+    }
+
+    func transcribeCurrentBuffer() async throws {
+        guard let whisperKit = whisperKit else { return }
+
+        // Retrieve the current audio buffer from the audio processor
+        let currentBuffer = whisperKit.audioProcessor.audioSamples
+
+        // Calculate the size and duration of the next buffer segment
+        let nextBufferSize = currentBuffer.count - lastBufferSize
+        let nextBufferSeconds = Float(nextBufferSize) / Float(WhisperKit.sampleRate)
+
+        // Only run the transcribe if the next buffer has at least 1 second of audio
+        guard nextBufferSeconds > 1 else {
+            await MainActor.run {
+                if currentText == "" {
+                    currentText = "Waiting for speech..."
+                }
+            }
+            try await Task.sleep(nanoseconds: 100_000_000) // sleep for 100ms for next buffer
+            return
+        }
+
+        if useVAD {
+            // Retrieve the current relative energy values from the audio processor
+            let currentRelativeEnergy = whisperKit.audioProcessor.relativeEnergy
+
+            // Calculate the number of energy values to consider based on the duration of the next buffer
+            // Each energy value corresponds to 1 buffer length (100ms of audio), hence we divide by 0.1
+            let energyValuesToConsider = Int(nextBufferSeconds / 0.1)
+
+            // Extract the relevant portion of energy values from the currentRelativeEnergy array
+            let nextBufferEnergies = currentRelativeEnergy.suffix(energyValuesToConsider)
+
+            // Determine the number of energy values to check for voice presence
+            // Considering up to the last 1 second of audio, which translates to 10 energy values
+            let numberOfValuesToCheck = max(10, nextBufferEnergies.count - 10)
+
+            // Check if any of the energy values in the considered range exceed the silence threshold
+            // This indicates the presence of voice in the buffer
+            let voiceDetected = nextBufferEnergies.prefix(numberOfValuesToCheck).contains { $0 > Float(silenceThreshold) }
+
+            // Only run the transcribe if the next buffer has voice
+            guard voiceDetected else {
+                await MainActor.run {
+                    if currentText == "" {
+                        currentText = "Waiting for speech..."
+                    }
+                }
+
+                //                if nextBufferSeconds > 30 {
+                //                    // This is a completely silent segment of 30s, so we can purge the audio and confirm anything pending
+                //                    lastConfirmedSegmentEndSeconds = 0
+                //                    whisperKit.audioProcessor.purgeAudioSamples(keepingLast: 2 * WhisperKit.sampleRate) // keep last 2s to include VAD overlap
+                //                    currentBuffer = whisperKit.audioProcessor.audioSamples
+                //                    lastBufferSize = 0
+                //                    confirmedSegments.append(contentsOf: unconfirmedSegments)
+                //                    unconfirmedSegments = []
+                //                }
+
+                // Sleep for 100ms and check the next buffer
+                try await Task.sleep(nanoseconds: 100_000_000)
+                return
+            }
+        }
+
+        // Run transcribe
+        lastBufferSize = currentBuffer.count
+
+        let transcription = try await transcribeAudioSamples(Array(currentBuffer))
+
+        // We need to run this next part on the main thread
+        await MainActor.run {
+            currentText = ""
+            unconfirmedText = []
+            guard let segments = transcription?.segments else {
+                return
+            }
+
+//            self.tokensPerSecond = transcription?.timings?.tokensPerSecond ?? 0
+//            self.realTimeFactor = transcription?.timings?.realTimeFactor ?? 0
+//            self.firstTokenTime = transcription?.timings?.firstTokenTime ?? 0
+//            self.pipelineStart = transcription?.timings?.pipelineStart ?? 0
+//            self.currentLag = transcription?.timings?.decodingLoop ?? 0
+
+            // Logic for moving segments to confirmedSegments
+            if segments.count > requiredSegmentsForConfirmation {
+                // Calculate the number of segments to confirm
+                let numberOfSegmentsToConfirm = segments.count - requiredSegmentsForConfirmation
+
+                // Confirm the required number of segments
+                let confirmedSegmentsArray = Array(segments.prefix(numberOfSegmentsToConfirm))
+                let remainingSegments = Array(segments.suffix(requiredSegmentsForConfirmation))
+
+                // Update lastConfirmedSegmentEnd based on the last confirmed segment
+                if let lastConfirmedSegment = confirmedSegmentsArray.last, lastConfirmedSegment.end > lastConfirmedSegmentEndSeconds {
+                    lastConfirmedSegmentEndSeconds = lastConfirmedSegment.end
+
+                    // Add confirmed segments to the confirmedSegments array
+                    if !self.confirmedSegments.contains(confirmedSegmentsArray) {
+                        self.confirmedSegments.append(contentsOf: confirmedSegmentsArray)
+                    }
+                }
+
+                // Update transcriptions to reflect the remaining segments
+                self.unconfirmedSegments = remainingSegments
+            } else {
+                // Handle the case where segments are fewer or equal to required
+                self.unconfirmedSegments = segments
+            }
+        }
+    }
+
+//    func requestMicrophoneIfNeeded() async -> Bool {
+//        let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+//
+//        switch microphoneStatus {
+//            case .notDetermined:
+//                return await withCheckedContinuation { continuation in
+//                    AVCaptureDevice.requestAccess(for: .audio) { granted in
+//                        continuation.resume(returning: granted)
+//                    }
+//                }
+//            case .restricted, .denied:
+//                print("Microphone access denied")
+//                return false
+//            case .authorized:
+//                return true
+//            @unknown default:
+//                fatalError("Unknown authorization status")
+//        }
+//    }
 }
 
 #Preview {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup setup-huggingface-cli setup-model-repo download-models download-model build build-cli test 
+.PHONY: setup setup-huggingface-cli setup-model-repo download-models download-model build build-cli test clean-package-caches
 
 PIP_COMMAND := pip3
 PYTHON_COMMAND := python3
@@ -43,10 +43,12 @@ setup-model-repo:
 	@mkdir -p $(BASE_COMPILED_DIR)
 	@if [ -d "$(MODEL_REPO_DIR)/.git" ]; then \
 		echo "Repository exists, resetting..."; \
+		export GIT_LFS_SKIP_SMUDGE=1; \
 		cd $(MODEL_REPO_DIR) && git fetch --all && git reset --hard origin/main && git clean -fdx; \
 	else \
 		echo "Repository not found, initializing..."; \
-		GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/$(MODEL_REPO) $(MODEL_REPO_DIR); \
+		export GIT_LFS_SKIP_SMUDGE=1; \
+		git clone https://huggingface.co/$(MODEL_REPO) $(MODEL_REPO_DIR); \
 	fi
 
 # Download all models
@@ -80,3 +82,7 @@ build-cli:
 test:
 	@echo "Running tests..."
 	@swift test -v
+
+clean-package-caches:
+	@trash ~/Library/Caches/org.swift.swiftpm/repositories
+	@trash ~/Library/Developer/Xcode/DerivedData

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ setup:
 	@echo "Checking for git-lfs..."
 	@which git-lfs > /dev/null || (echo "Installing git-lfs..." && brew install git-lfs)
 	@echo "git-lfs is installed."
-	@echo "Checking for xcpretty..."
-	@which xcpretty > /dev/null || (echo "Installing xcpretty..." && gem install xcpretty)
-	@echo "xcpretty is installed."
 	@echo "Done 🚀"
 
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "5e4031ee16afd10d208c1aee9b49f4def6ca5264",
-        "version" : "0.1.1"
+        "revision" : "564442fba36b0b694d730a62d0593e5f54043b55"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "whisperkit",
-    platforms: [.iOS(.v16), .macOS(.v13)],
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+        .watchOS(.v10),
+        .visionOS(.v1)
+    ],
     products: [
         .library(
             name: "WhisperKit",
@@ -16,8 +21,8 @@ let package = Package(
             targets: ["WhisperKitCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", "0.1.1"..<"0.2.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", revision: "564442fba36b0b694d730a62d0593e5f54043b55"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Our goal is to make WhisperKit better and better over time and we'd love your he
 
 ## License
 
-WhisperKit is released under the MIT License. See [LICENSE.md](LICENSE.md) for more details.
+WhisperKit is released under the MIT License. See [LICENSE](LICENSE) for more details.
 
 ## Citation
 

--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -14,7 +14,7 @@ public protocol AudioEncoding {
     func encodeFeatures(_ features: MLMultiArray) async throws -> MLMultiArray?
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class AudioEncoder: AudioEncoding, WhisperMLModel {
     public var model: MLModel?
 

--- a/Sources/WhisperKit/Core/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/AudioProcessor.swift
@@ -132,7 +132,7 @@ public extension AudioProcessing {
     }
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class AudioProcessor: NSObject, AudioProcessing {
     public var audioEngine: AVAudioEngine?
     public var audioSamples: ContiguousArray<Float> = []
@@ -270,7 +270,7 @@ public class AudioProcessor: NSObject, AudioProcessing {
         // Calculate the maximum sample value of the signal
         vDSP_maxmgv(signal, 1, &maxEnergy, vDSP_Length(signal.count))
 
-        // Calculate the minumum sample value of the signal
+        // Calculate the minimum sample value of the signal
         vDSP_minmgv(signal, 1, &minEnergy, vDSP_Length(signal.count))
 
         return (rmsEnergy, maxEnergy, minEnergy)
@@ -309,7 +309,7 @@ public class AudioProcessor: NSObject, AudioProcessing {
 
 // MARK: - Streaming
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public extension AudioProcessor {
     /// We have a new buffer, process and store it.
     /// Note: Assumes audio is 16khz mono
@@ -354,7 +354,7 @@ public extension AudioProcessor {
         }
 
         let bufferSize = AVAudioFrameCount(minBufferLength) // 100ms - 400ms supported
-        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) { [weak self] (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) { [weak self] (buffer: AVAudioPCMBuffer, _: AVAudioTime) in
             guard let self = self else { return }
             var buffer = buffer
             if !buffer.format.sampleRate.isEqual(to: Double(WhisperKit.sampleRate)) {

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -12,7 +12,7 @@ public protocol FeatureExtracting {
     func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> MLMultiArray?
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class FeatureExtractor: FeatureExtracting, WhisperMLModel {
     public var model: MLModel?
 

--- a/Sources/WhisperKit/Core/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/LogitsFilter.swift
@@ -9,7 +9,7 @@ public protocol LogitsFiltering {
     func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class SuppressTokensFilter: LogitsFiltering {
     let suppressTokens: [Int]
     private let tokenIndexes: [[NSNumber]]
@@ -29,7 +29,7 @@ public class SuppressTokensFilter: LogitsFiltering {
     }
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class SuppressBlankFilter: LogitsFiltering {
     let tokenizer: Tokenizer
     let sampleBegin: Int
@@ -52,7 +52,7 @@ public class SuppressBlankFilter: LogitsFiltering {
     }
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class TimestampRulesFilter: LogitsFiltering {
     let tokenizer: Tokenizer
     let sampleBegin: Int

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -5,8 +5,8 @@ import CoreML
 import Hub
 import Tokenizers
 
-#if arch(arm64)
-    @available(macOS 11.0, iOS 14.0, *)
+#if os(watchOS) || arch(arm64)
+    @available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
     public typealias FloatType = Float16
 #else
     public typealias FloatType = Float
@@ -193,7 +193,7 @@ public struct DecodingInputs {
 ///   - noSpeechThreshold: If the no speech probability is higher than this value AND the average log
 ///                        probability over sampled tokens is below `logProbThreshold`, consider the segment as silent.
 
-@available(macOS 14, iOS 17, tvOS 14, watchOS 10, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public struct DecodingOptions {
     public var verbose: Bool
     public var task: DecodingTask
@@ -455,7 +455,7 @@ public class MelSpectrogramInput: MLFeatureProvider {
 }
 
 /// Model Prediction Output Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class MelSpectrogramOutput: MLFeatureProvider {
     /// Source provided by CoreML
     private let provider: MLFeatureProvider
@@ -493,7 +493,7 @@ public class MelSpectrogramOutput: MLFeatureProvider {
 // MARK: AudioEncoder
 
 /// Model Prediction Input Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class AudioEncoderInput: MLFeatureProvider {
     /// melspectrogram_features as 1 × {80,128} × 1 × 3000 4-dimensional array of floats
     public var melspectrogram_features: MLMultiArray
@@ -519,7 +519,7 @@ public class AudioEncoderInput: MLFeatureProvider {
 }
 
 /// Model Prediction Output Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class AudioEncoderOutput: MLFeatureProvider {
     /// Source provided by CoreML
     private let provider: MLFeatureProvider
@@ -557,7 +557,7 @@ public class AudioEncoderOutput: MLFeatureProvider {
 // MARK: TextDecoder
 
 /// Model Prediction Input Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class TextDecoderInput: MLFeatureProvider {
     /// input_ids as 1 element vector of 32-bit integers
     public var input_ids: MLMultiArray
@@ -625,7 +625,7 @@ public class TextDecoderInput: MLFeatureProvider {
 }
 
 /// Model Prediction Output Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class TextDecoderOutput: MLFeatureProvider {
     /// Source provided by CoreML
     private let provider: MLFeatureProvider
@@ -720,7 +720,7 @@ public class TextDecoderCachePrefillInput: MLFeatureProvider {
 }
 
 /// Model Prediction Output Type
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class TextDecoderCachePrefillOutput: MLFeatureProvider {
     /// Source provided by CoreML
     private let provider: MLFeatureProvider

--- a/Sources/WhisperKit/Core/SegmentSeeker.swift
+++ b/Sources/WhisperKit/Core/SegmentSeeker.swift
@@ -4,12 +4,12 @@
 import Foundation
 import Tokenizers
 
-@available(macOS 14, iOS 17, tvOS 14, watchOS 10, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public protocol SegmentSeeking {
     func findSeekPointAndSegments(decodingResult: DecodingResult, options: DecodingOptions, allSegmentsCount: Int, currentSeek seek: Int, segmentSize: Int, sampleRate: Int, timeToken: Int, specialToken: Int, tokenizer: Tokenizer) -> (Int, [TranscriptionSegment]?)
 }
 
-@available(macOS 14, iOS 17, tvOS 14, watchOS 10, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class SegmentSeeker: SegmentSeeking {
     public init() {}
 

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -5,7 +5,7 @@ import Accelerate
 import CoreML
 import Tokenizers
 
-@available(macOS 14, iOS 17, tvOS 14, watchOS 10, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public protocol TextDecoding {
     var tokenizer: Tokenizer? { get set }
     var prefillData: WhisperMLModel? { get set }
@@ -43,7 +43,7 @@ public protocol TextDecoding {
     )
 }
 
-@available(macOS 14, iOS 17, tvOS 14, watchOS 10, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public extension TextDecoding {
     func prepareDecoderInputs(withPrompt initialPrompt: [Int]) -> DecodingInputs? {
         let tokenShape = [NSNumber(value: 1), NSNumber(value: initialPrompt.count)]
@@ -223,7 +223,7 @@ public class TextDecoderContextPrefill: WhisperMLModel {
     public var model: MLModel?
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class TextDecoder: TextDecoding, WhisperMLModel {
     public var model: MLModel?
     public var tokenizer: Tokenizer?

--- a/Sources/WhisperKit/Core/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/TokenSampler.swift
@@ -16,7 +16,7 @@ public struct SamplingResult {
     public var completed: Bool
 }
 
-@available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 public class GreedyTokenSampler: TokenSampling {
     public var temperature: FloatType
     public var eotToken: Int

--- a/Sources/WhisperKitCLI/transcribe.swift
+++ b/Sources/WhisperKitCLI/transcribe.swift
@@ -7,7 +7,7 @@ import Foundation
 
 import WhisperKit
 
-@available(macOS 14, iOS 17, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 @main
 struct WhisperKitCLI: AsyncParsableCommand {
     @Option(help: "Path to audio file")
@@ -83,7 +83,6 @@ struct WhisperKitCLI: AsyncParsableCommand {
         guard FileManager.default.fileExists(atPath: resolvedAudioPath) else {
             fatalError("Resource path does not exist \(resolvedAudioPath)")
         }
-
 
         let computeOptions = ModelComputeOptions(
             audioEncoderCompute: audioEncoderComputeUnits.asMLComputeUnits,

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -5,7 +5,7 @@ import CoreML
 @testable import WhisperKit
 import XCTest
 
-@available(macOS 14, iOS 17, *)
+@available(macOS 14, iOS 17, watchOS 10, visionOS 1, *)
 final class FunctionalTests: XCTestCase {
     func testInitLarge() async {
         let modelPath = largev3ModelPath()
@@ -38,7 +38,7 @@ final class FunctionalTests: XCTestCase {
             )
         }
     }
-    
+
     func testRealTimeFactorTiny() async throws {
         let modelPath = tinyModelPath()
 
@@ -104,7 +104,6 @@ final class FunctionalTests: XCTestCase {
         }
 
         let dispatchSemaphore = DispatchSemaphore(value: 0)
-
 
         Task {
             let pipe = try? await WhisperKit(model: "large-v3")


### PR DESCRIPTION
You can try out the watchOS example on any Series 9 or Ultra 2 apple watch. In order to build to it, just change the target in the WhisperAX example app:
<img width="317" alt="image" src="https://github.com/argmaxinc/WhisperKit/assets/1981179/c4ca5c07-d7d5-4d7c-ad42-5de86ee66c38">

Supported models are:
- base
- base.en
- tiny
- tiny.en

<details>
  <summary>Screenshots</summary>
  
  ![Screenshot loading](https://github.com/argmaxinc/WhisperKit/assets/1981179/e120b814-3f32-4763-8dde-8acdfdf148c9)
  ![Screenshot loaded](https://github.com/argmaxinc/WhisperKit/assets/1981179/6929967b-bd59-448d-b83b-9afea79f2486)
  ![Screenshot 2024-02-13 at 10 11 43 PM](https://github.com/argmaxinc/WhisperKit/assets/1981179/b4fe6abe-296f-4641-8eec-d19a0451528f)
  
</details>


In addition to the WatchOS example app, this PR includes a fix for downloading models when there is a partial download already in the filesystem. This includes the following changes:

- New init parameter to allow downloading if modelFolder is nil (default true)
- `modelFolder` is now an optional
- **Breaking change**: `load` has been renamed to `download` for clarity

