### PR TITLE
skip functional tests for models that are not downloaded.

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -813,7 +813,7 @@ struct ContentView: View {
                         localModels.append(model)
                     }
                     
-                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -1009,7 +1009,7 @@ struct ContentView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
+        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -751,7 +751,7 @@ struct ContentView: View {
                 try await whisperKit.loadModels()
 
                 await MainActor.run {
-                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -920,7 +920,7 @@ struct ContentView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
+        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -751,7 +751,7 @@ struct ContentView: View {
                 try await whisperKit.loadModels()
 
                 await MainActor.run {
-                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -920,7 +920,7 @@ struct ContentView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
+        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -409,7 +409,7 @@ struct WhisperAXWatchView: View {
                 try await whisperKit.loadModels()
 
                 await MainActor.run {
-                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -491,7 +491,7 @@ struct WhisperAXWatchView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
+        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -409,7 +409,7 @@ struct WhisperAXWatchView: View {
                 try await whisperKit.loadModels()
 
                 await MainActor.run {
-                    availableLanguages = whisperKit.tokenizer?.langauges.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -491,7 +491,7 @@ struct WhisperAXWatchView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.langauges[selectedLanguage] ?? "en"
+        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -919,7 +919,7 @@ public extension Tokenizer {
         return false
     }
 
-    var langauges: [String: String] { [
+    var languages: [String: String] { [
         "english": "en",
         "chinese": "zh",
         "german": "de",

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -931,7 +931,7 @@ public extension Tokenizer {
         return false
     }
 
-    var langauges: [String: String] { [
+    var languages: [String: String] { [
         "english": "en",
         "chinese": "zh",
         "german": "de",

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -919,7 +919,7 @@ public extension Tokenizer {
         return false
     }
 
-    var languages: [String: String] { [
+    var langauges: [String: String] { [
         "english": "en",
         "chinese": "zh",
         "german": "de",

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -827,6 +827,24 @@ final class UnitTests: XCTestCase {
             XCTAssertEqual(mergedAlignmentTiming[i].probability, expectedWordTimings[i].probability, "Probability at index \(i) does not match")
         }
     }
+    
+    func testGitLFSPointerFile() {
+        // Assumption:
+        // 1 - the openai_whisper-tiny is downloaded locally. This means that the proxyFile is an actual data file.
+        // 2 - the openai_whisper-large-v3_turbo is not downloaded locally. This means that the proxyFile is pointer file.
+        let proxyFile = "AudioEncoder.mlmodelc/coremldata.bin"
+
+        // First, we check that a data file is not considered a git lfs pointer file.
+        var filePath = URL(filePath: tinyModelPath()).appending(path: proxyFile)
+        var isPointerFile = isGitLFSPointerFile(url: filePath)
+        XCTAssertEqual(isPointerFile, false, "Assuming whisper-tiny was downloaded, \(proxyFile) should not be a git-lfs pointer file.")
+        
+        // Second, we check that a pointer file is considered so.
+        let modelDir = largev3TurboModelPath()
+        filePath = URL(filePath: modelDir).appending(path: proxyFile)
+        isPointerFile = isGitLFSPointerFile(url: filePath)
+        XCTAssertEqual(isPointerFile, true, "Assuming whisper-large-v3_turbo was not downloaded, \(proxyFile) should be a git-lfs pointer file.")
+    }
 }
 
 // MARK: Helpers
@@ -904,6 +922,15 @@ extension XCTestCase {
         return modelPath
     }
 
+    func largev3TurboModelPath() -> String {
+        let modelDir = "whisperkit-coreml/openai_whisper-large-v3_turbo"
+        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
+            print("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
+            return ""
+        }
+        return modelPath
+    }
+
     func allModelPaths() -> [String] {
         let fileManager = FileManager.default
         var modelPaths: [String] = []
@@ -921,6 +948,13 @@ extension XCTestCase {
             for folderURL in directoryContents {
                 let resourceValues = try folderURL.resourceValues(forKeys: Set(resourceKeys))
                 if resourceValues.isDirectory == true {
+                    // Check if the directory contains actual data files, or if it contains pointer files.
+                    // As a proxy, use the MelSpectrogramc.mlmodel/coredata.bin file.
+                    let proxyFileToCheck = folderURL.appendingPathComponent("MelSpectrogram.mlmodelc/coremldata.bin")
+                    if isGitLFSPointerFile(url: proxyFileToCheck) {
+                        continue
+                    }
+                    
                     // Check if the directory name contains the quantization pattern
                     // Only test large quantized models
                     let dirName = folderURL.lastPathComponent
@@ -934,6 +968,25 @@ extension XCTestCase {
         }
 
         return modelPaths
+    }
+    
+    // Function to check if the beginning of the file matches a Git LFS pointer pattern
+    func isGitLFSPointerFile(url: URL) -> Bool {
+        do {
+            let fileHandle = try FileHandle(forReadingFrom: url)
+            // Read the first few bytes of the file to get enough for the Git LFS pointer signature
+            let data = fileHandle.readData(ofLength: 512) // Read first 512 bytes
+            fileHandle.closeFile()
+
+            if let string = String(data: data, encoding: .utf8),
+               string.starts(with: "version https://git-lfs.github.com/") {
+                return true
+            }
+        } catch {
+            print("Failed to read file: \(error)")
+        }
+        
+        return false
     }
 
     func trackForMemoryLeaks(on instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {


### PR DESCRIPTION
hi all, it seems that functional tests require two models to be downloaded: openai_whisper-tiny (because of `testRealTimeFactorTiny()`) and openai_whisper-large-v3 (because of `testInitLarge()` and `testRealTimeFactorLarge()`). This should probably be added to the CONTRIBUTING.md, however this PR does not make this change.

Another functional test, `testOutputAll()` - actually `allModelPaths()`, assumes that folders in `./Models/whisperkit-coreml`, which are created from the `make setup-model-repo`, contain actual models, while in fact only models explicitly downloaded with `make download-model MODEL=x` or `make download-models` are present.

`testOutputAll()` fails if not all models have been downloaded, which is not ideal. Running all tests for all models (takes a long time and) makes sense in some scenarios, but probably not to test some code changes. 

I've implemented some changes so that `allModelPaths()` only returns folders that contain downloaded models. This is done by checking if a proxy file (`MelSpectrogram.mlmodelc/coremldata.bin`) is a git lfs pointer file (starting with `version https://…`). If it is, then the folder is not included.