### PR TITLE
Add audio device selector to transcribe + take a stab at Delete/Retry models

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -306,6 +306,33 @@ struct ContentView: View {
     }
 
     // MARK: - Controls
+    var audioDevicesView: some View {
+        Group {
+            #if os(macOS)
+            HStack {
+                if let audioDevices = audioDevices, audioDevices.count > 0 {
+                    Picker("", selection: $selectedAudioInput) {
+                        ForEach(audioDevices, id: \.self) { device in
+                            Text(device.name).tag(device.name)
+                        }
+                    }
+                    .frame(minWidth: 80)
+                    .disabled(isRecording)
+                }
+            }
+            .onAppear {
+                audioDevices = AudioProcessor.getAudioDevices()
+                if let audioDevices = audioDevices,
+                   !audioDevices.isEmpty,
+                   selectedAudioInput == "No Audio Input",
+                   let device = audioDevices.first {
+                    selectedAudioInput = device.name
+                }
+            }
+            #endif
+        }
+    }
+    
     var controlsView: some View {
         VStack {
             basicSettingsView
@@ -360,6 +387,8 @@ struct ContentView: View {
                                 .disabled(modelState != .loaded)
                                 .frame(minWidth: 0, maxWidth: .infinity)
                                 .padding()
+                                
+                                audioDevicesView
 
                                 Button(action: {
                                     withAnimation {
@@ -430,28 +459,7 @@ struct ContentView: View {
                                 .frame(minWidth: 0, maxWidth: .infinity)
                                 .buttonStyle(.borderless)
                                 
-                                #if os(macOS)
-                                HStack {
-                                    if let audioDevices = audioDevices, audioDevices.count > 0 {
-                                        Picker("", selection: $selectedAudioInput) {
-                                            ForEach(audioDevices, id: \.self) { device in
-                                                Text(device.name).tag(device.name)
-                                            }
-                                        }
-                                        .frame(minWidth: 80)
-                                        .disabled(isRecording)
-                                    }
-                                }
-                                .onAppear {
-                                    audioDevices = AudioProcessor.getAudioDevices()
-                                    if let audioDevices = audioDevices,
-                                       !audioDevices.isEmpty,
-                                       selectedAudioInput == "No Audio Input",
-                                       let device = audioDevices.first {
-                                        selectedAudioInput = device.name
-                                    }
-                                }
-                                #endif
+                                audioDevicesView
                             }
                         }
                     default:

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -303,21 +303,6 @@ struct ContentView: View {
                             Text(String(format: "%.1f%%", loadingProgressValue * 100))
                                 .font(.caption)
                                 .foregroundColor(.gray)
-                            
-                            if modelState == .downloading {
-                                Spacer()
-                                
-                                Button(action: {
-                                    resetState()
-                                    loadingProgressValue = 0.0
-                                    loadModel(selectedModel, redownload: true)
-                                    modelState = .loading
-                                }, label: {
-                                    Image(systemName: "arrow.uturn.forward.circle")
-                                })
-                                .help("Restart download")
-                                .buttonStyle(BorderlessButtonStyle())
-                            }
                         }
                         if modelState == .prewarming {
                             Text("Specializing \(selectedModel) for your device...\nThis can take several minutes on first load")


### PR DESCRIPTION
Addresses #13 + adds audio device view in both sections.

1. New delete model button
<img width="299" alt="Screenshot 2024-03-06 at 9 32 03 PM" src="https://github.com/argmaxinc/WhisperKit/assets/336449/79edb1ae-6be0-4c5d-a0e6-537a985465d8">


2. Restart download of model if connection lost
<img width="277" alt="Screenshot 2024-03-06 at 9 49 04 PM" src="https://github.com/argmaxinc/WhisperKit/assets/336449/30c59ced-43bd-4a0c-87a6-6fe9f6c8f4a1">


3. Move audio input selection between the buttons on transcribe.
<img width="694" alt="Screenshot 2024-03-06 at 9 49 17 PM" src="https://github.com/argmaxinc/WhisperKit/assets/336449/c85a102a-2cda-4642-b971-ec36b93d6235">
