### PR TITLE
Fix memory leak from non-async MLModel prediction

### DIFF
--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -46,7 +46,7 @@ public class AudioEncoder: AudioEncoding, WhisperMLModel {
 
         try Task.checkCancellation()
 
-        let outputFeatures = try await model.prediction(from: modelInputs, options: MLPredictionOptions())
+        let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())
 
         let output = AudioEncoderOutput(features: outputFeatures)
 

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -35,7 +35,7 @@ public class FeatureExtractor: FeatureExtracting, WhisperMLModel {
 
         try Task.checkCancellation()
 
-        let outputFeatures = try await model.prediction(from: modelInputs, options: MLPredictionOptions())
+        let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())
 
         let output = MelSpectrogramOutput(features: outputFeatures)
 

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -176,7 +176,7 @@ public extension TextDecoding {
 
         try Task.checkCancellation()
 
-        let outputFeatures = try await prefillModel.prediction(from: modelInputs, options: MLPredictionOptions())
+        let outputFeatures = try await prefillModel.asyncPrediction(from: modelInputs, options: MLPredictionOptions())
 
         let output = TextDecoderCachePrefillOutput(features: outputFeatures)
 
@@ -291,7 +291,7 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
 
         try Task.checkCancellation()
 
-        let outputFeatures = try await model.prediction(from: modelInputs, options: MLPredictionOptions())
+        let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())
 
         let output = TextDecoderOutput(features: outputFeatures)
 

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -39,6 +39,21 @@ extension MLMultiArray {
     }
 }
 
+extension MLModel {
+    func asyncPrediction(
+        from input: MLFeatureProvider,
+        options: MLPredictionOptions
+    ) async throws -> MLFeatureProvider {
+        if #available(macOS 14, iOS 17, watchOS 10, visionOS 1, *) {
+            return try await prediction(from: input, options: options)
+        } else {
+            return try await Task {
+                try prediction(from: input, options: options)
+            }.value
+        }
+    }
+}
+
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 func initMLMultiArray(shape: [NSNumber], dataType: MLMultiArrayDataType, initialValue: Any) -> MLMultiArray {
     let multiArray = try! MLMultiArray(shape: shape, dataType: dataType)


### PR DESCRIPTION
After #40, all calls to `MLModel.prediction` were automatically switched from the async variant to the sync variant since they have the same name but async is only available on 14+.  The switch to the sync variant resulted in memory leaks due to resources allocated in `prediction` never getting released, so apps ran out of memory when transcribing a few minutes of audio. 

I added `MLModel.asyncPrediction`, which uses the async variation when available, which has no memory leak issues. On iOS 16 and macOS 13, the prediction is wrapped in a task which acts as an autoreleasepool. This should fix the issue on both 13 and 14+.

Tested on:
- iPhone 15 Pro (iOS 17.4)
- iPhone SE 2nd Gen (iOS 16.6)
- Macbook Pro (macOS 14.0)