### PR TITLE
Fixed Conformance of 'Float16' warning

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1,16 +1,20 @@
 //  For licensing see accompanying LICENSE.md file.
 //  Copyright © 2024 Argmax, Inc. All rights reserved.
 
+import Accelerate
 import CoreML
 import Hub
 import NaturalLanguage
 import Tokenizers
 
-#if os(watchOS) || arch(arm64)
-@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 public typealias FloatType = Float16
 #else
 public typealias FloatType = Float
+#endif
+
+#if (os(macOS) || targetEnvironment(macCatalyst)) && arch(arm64)
+extension Float16: BNNSScalar {}
 #endif
 
 // MARK: - CoreML

--- a/Sources/WhisperKit/Core/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/TokenSampler.swift
@@ -44,7 +44,7 @@ public class GreedyTokenSampler: TokenSampling {
 
             let logitsDescriptor = BNNSNDArrayDescriptor(
                 data: logitsRawPointer,
-                scalarType: FloatType.self, // FIXME: Float16 here breaks in swift 6
+                scalarType: FloatType.self,
                 shape: .vector(logits.count, stride: 1)
             )!
 


### PR DESCRIPTION
Fixes `Conformance of 'Float16' to 'BNNSScalar' is unavailable in macOS; this is an error in Swift 6` warning

Idea taken from the [docs](https://developer.apple.com/documentation/swift/float16)
> Float16 is available on Apple silicon, and unavailable on Intel when targeting macOS.

and from [swift-numerics](https://github.com/apple/swift-numerics/blob/0111e791a16a08f577078e2e39b5f68918bf29b0/Tests/RealTests/ElementaryFunctionChecks.swift#L149)
