### PR TITLE
Add `Progress` to `WhisperKit`

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -212,6 +212,16 @@ struct ContentView: View {
             .frame(maxWidth: .infinity)
             .defaultScrollAnchor(.bottom)
             .padding()
+            if let whisperKit,
+               !isRecording,
+               !isTranscribing,
+               whisperKit.progress.fractionCompleted > 0,
+               whisperKit.progress.fractionCompleted < 1 {
+                ProgressView(whisperKit.progress)
+                    .progressViewStyle(.linear)
+                    .labelsHidden()
+                    .padding(.horizontal)
+            }
         }
     }
 


### PR DESCRIPTION
Currently there doesn't seem to be a way to get the current transcription progress to display. This adds a `Progress` to WhisperKit for easily displaying transcription progress in a ProgressView as seen in the modified WhisperAX.

The progress could probably be much more fine grained by updating in the decoder loop (and possibly factoring in model load time/anything else?), but this is a pretty good start I think.