### PR TITLE
Updated swift-transformers, do not use background url session in CLI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "24605a8c0cc974bec5b94a6752eb687bae77db31",
-        "version" : "0.1.3"
+        "revision" : "5105f7238bbb71e66a600408714d52db1c254a7d",
+        "version" : "0.1.4"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "5105f7238bbb71e66a600408714d52db1c254a7d",
-        "version" : "0.1.4"
+        "revision" : "3bd02269b7797ade67c15679a575cd5c6f203ce6",
+        "version" : "0.1.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.3"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.4"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.4"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.5"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -272,10 +272,11 @@ public func resolveAbsolutePath(_ inputPath: String) -> String {
 
 func loadTokenizer(
     for pretrained: ModelVariant,
-    tokenizerFolder: URL? = nil
+    tokenizerFolder: URL? = nil,
+    useBackgroundSession: Bool = true
 ) async throws -> Tokenizer {
     let tokenizerName = tokenizerNameForVariant(pretrained)
-    let hubApi = HubApi(downloadBase: tokenizerFolder)
+    let hubApi = HubApi(downloadBase: tokenizerFolder, useBackgroundSession: useBackgroundSession)
     return try await AutoTokenizer.from(pretrained: tokenizerName, hubApi: hubApi)
 }
 

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -273,7 +273,7 @@ public func resolveAbsolutePath(_ inputPath: String) -> String {
 func loadTokenizer(
     for pretrained: ModelVariant,
     tokenizerFolder: URL? = nil,
-    useBackgroundSession: Bool = true
+    useBackgroundSession: Bool = false
 ) async throws -> Tokenizer {
     let tokenizerName = tokenizerNameForVariant(pretrained)
     let hubApi = HubApi(downloadBase: tokenizerFolder, useBackgroundSession: useBackgroundSession)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -72,7 +72,7 @@ public class WhisperKit: Transcriber {
         prewarm: Bool? = nil,
         load: Bool? = nil,
         download: Bool = true,
-        useBackgroundDownloadSession: Bool = true
+        useBackgroundDownloadSession: Bool = false
     ) async throws {
         self.modelCompute = computeOptions ?? ModelComputeOptions()
         self.audioProcessor = audioProcessor ?? AudioProcessor()
@@ -91,19 +91,18 @@ public class WhisperKit: Transcriber {
             downloadBase: downloadBase,
             modelRepo: modelRepo,
             modelFolder: modelFolder,
-            download: download,
-            useBackgroundDownloadSession: useBackgroundDownloadSession
+            download: download
         )
 
         if let prewarm = prewarm, prewarm {
             Logging.info("Prewarming models...")
-            try await prewarmModels(useBackgroundDownloadSession: useBackgroundDownloadSession)
+            try await prewarmModels()
         }
 
         // If load is not passed in, load based on whether a modelFolder is passed
         if load ?? (modelFolder != nil) {
             Logging.info("Loading models...")
-            try await loadModels(useBackgroundDownloadSession: useBackgroundDownloadSession)
+            try await loadModels()
         }
     }
 
@@ -180,7 +179,7 @@ public class WhisperKit: Transcriber {
     public static func download(
         variant: String,
         downloadBase: URL? = nil,
-        useBackgroundSession: Bool = true,
+        useBackgroundSession: Bool = false,
         from repo: String = "argmaxinc/whisperkit-coreml",
         progressCallback: ((Progress) -> Void)? = nil
     ) async throws -> URL? {
@@ -209,8 +208,7 @@ public class WhisperKit: Transcriber {
         downloadBase: URL? = nil,
         modelRepo: String?,
         modelFolder: String?,
-        download: Bool,
-        useBackgroundDownloadSession: Bool
+        download: Bool
     ) async throws {
         // Determine the model variant to use
         let modelVariant = model ?? WhisperKit.recommendedModels().default
@@ -238,13 +236,12 @@ public class WhisperKit: Transcriber {
         }
     }
 
-    public func prewarmModels(useBackgroundDownloadSession: Bool) async throws {
-        try await loadModels(prewarmMode: true, useBackgroundDownloadSession: useBackgroundDownloadSession)
+    public func prewarmModels() async throws {
+        try await loadModels(prewarmMode: true)
     }
 
     public func loadModels(
-        prewarmMode: Bool = false,
-        useBackgroundDownloadSession: Bool
+        prewarmMode: Bool = false
     ) async throws {
         modelState = prewarmMode ? .prewarming : .loading
 
@@ -411,7 +408,7 @@ public class WhisperKit: Transcriber {
         }
 
         if self.modelState != .loaded {
-            try await loadModels(useBackgroundDownloadSession: useBackgroundDownloadSession)
+            try await loadModels()
         }
 
         var timings = currentTimings!

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -72,7 +72,6 @@ public class WhisperKit: Transcriber {
         load: Bool? = nil,
         download: Bool = true,
         useBackgroundDownloadSession: Bool = true
-    
     ) async throws {
         self.modelCompute = computeOptions ?? ModelComputeOptions()
         self.audioProcessor = audioProcessor ?? AudioProcessor()

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -21,8 +21,6 @@ public class WhisperKit: Transcriber {
     public var modelVariant: ModelVariant = .tiny
     public var modelState: ModelState = .unloaded
     public var modelCompute: ModelComputeOptions
-    public var modelFolder: URL?
-    public var tokenizerFolder: URL?
     public var tokenizer: Tokenizer?
 
     /// Protocols
@@ -48,9 +46,12 @@ public class WhisperKit: Transcriber {
     public var decoderInputs: DecodingInputs?
     public var currentTimings: TranscriptionTimings?
 
+    /// State
     public let progress = Progress()
     
     /// Configuration
+    public var modelFolder: URL?
+    public var tokenizerFolder: URL?
     private let useBackgroundDownloadSession: Bool
 
     public init(

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -59,7 +59,8 @@ struct Transcribe: AsyncParsableCommand {
             tokenizerFolder: downloadTokenizerFolder,
             computeOptions: computeOptions,
             verbose: cliArguments.verbose,
-            logLevel: .debug
+            logLevel: .debug,
+            useBackgroundDownloadSession: false
         )
         print("Models initialized")
 
@@ -152,7 +153,8 @@ struct Transcribe: AsyncParsableCommand {
             tokenizerFolder: downloadTokenizerFolder,
             computeOptions: computeOptions,
             verbose: cliArguments.verbose,
-            logLevel: .debug
+            logLevel: .debug,
+            useBackgroundDownloadSession: false
         )
         print("Models initialized")
 

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -12,7 +12,7 @@ struct Transcribe: AsyncParsableCommand {
         abstract: "Transcribe audio to text using WhisperKit"
     )
 
-    @OptionGroup 
+    @OptionGroup
     var cliArguments: CLIArguments
 
     mutating func run() async throws {
@@ -36,14 +36,14 @@ struct Transcribe: AsyncParsableCommand {
             audioEncoderCompute: cliArguments.audioEncoderComputeUnits.asMLComputeUnits,
             textDecoderCompute: cliArguments.textDecoderComputeUnits.asMLComputeUnits
         )
-        
+
         let downloadTokenizerFolder: URL? =
             if let filePath = cliArguments.downloadTokenizerPath {
                 URL(filePath: filePath)
             } else {
                 nil
             }
-        
+
         let downloadModelFolder: URL? =
             if let filePath = cliArguments.downloadModelPath {
                 URL(filePath: filePath)
@@ -51,7 +51,10 @@ struct Transcribe: AsyncParsableCommand {
                 nil
             }
 
-        print("Initializing models...")
+        if cliArguments.verbose {
+            print("Initializing models...")
+        }
+
         let whisperKit = try await WhisperKit(
             model: cliArguments.model,
             downloadBase: downloadModelFolder,
@@ -62,7 +65,10 @@ struct Transcribe: AsyncParsableCommand {
             logLevel: .debug,
             useBackgroundDownloadSession: false
         )
-        print("Models initialized")
+
+        if cliArguments.verbose {
+            print("Models initialized")
+        }
 
         let options = DecodingOptions(
             verbose: cliArguments.verbose,
@@ -84,7 +90,7 @@ struct Transcribe: AsyncParsableCommand {
         )
 
         let transcribeResult = try await whisperKit.transcribe(
-            audioPath: resolvedAudioPath, 
+            audioPath: resolvedAudioPath,
             decodeOptions: options
         )
 
@@ -137,7 +143,7 @@ struct Transcribe: AsyncParsableCommand {
             } else {
                 nil
             }
-        
+
         let downloadModelFolder: URL? =
             if let filePath = cliArguments.downloadModelPath {
                 URL(filePath: filePath)
@@ -145,7 +151,10 @@ struct Transcribe: AsyncParsableCommand {
                 nil
             }
 
-        print("Initializing models...")
+        if cliArguments.verbose {
+            print("Initializing models...")
+        }
+
         let whisperKit = try await WhisperKit(
             model: cliArguments.model,
             downloadBase: downloadModelFolder,
@@ -156,8 +165,10 @@ struct Transcribe: AsyncParsableCommand {
             logLevel: .debug,
             useBackgroundDownloadSession: false
         )
-        print("Models initialized")
 
+        if cliArguments.verbose {
+            print("Models initialized")
+        }
         let decodingOptions = DecodingOptions(
             verbose: cliArguments.verbose,
             task: .transcribe,


### PR DESCRIPTION
We should not use background url session in CLI because it's throwing an error. Using normal `URLSession` works fine