### PR TITLE
Add pre-merge and pre-release tests

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - id: reviews
         env:
+          GH_TOKEN: ${{ github.token }}
           pr: ${{ github.event.number }}
         run: |
           state=$(gh pr view "$pr" \
@@ -35,7 +36,7 @@ jobs:
 
   pre-merge-tests:
     needs: [check-approvals]
-    if: needs.check-approvals.outputs.reviews == 'approved' || github.event_name == 'workflow_dispatch'
+    if: needs.check-approvals.outputs.reviews == 'APPROVED' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/unit-tests.yml
     with:
       ios-version: '16.1'

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -7,6 +7,10 @@ on:
     types: [submitted]  
   workflow_dispatch:
 
+concurrency: 
+    group: ${{ github.head_ref }}
+    cancel-in-progress: true
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-    group: ${{ github.head_ref }}
+    group: ${{ github.ref_name }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -11,7 +11,6 @@ jobs:
     with:
       ios-version: '17.2'
       macos-runner: 'macos-14'
-      environment: 'development'
       
   pre-merge-tests:
     needs: build-and-test

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches: [ "main" ]
   pull_request_review:
-    types: [submitted]  
+    types: [submitted]
   workflow_dispatch:
 
 concurrency: 
-    group: ${{ github.ref_name }}
-    cancel-in-progress: true
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:
@@ -17,9 +17,25 @@ jobs:
     with:
       ios-version: '17.2'
       macos-runner: 'macos-14'
-      
+
+  check-approvals:
+    runs-on: ubuntu-latest
+    outputs:
+      reviews: ${{ steps.reviews.outputs.state }}
+    steps:
+      - id: reviews
+        env:
+          pr: ${{ github.event.number }}
+        run: |
+          state=$(gh pr view "$pr" \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --json reviewDecision \
+                  --jq '.reviewDecision')
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+
   pre-merge-tests:
-    if: ${{ (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'workflow_dispatch'}}
+    needs: [check-approvals]
+    if: needs.check-approvals.outputs.reviews == 'approved' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/unit-tests.yml
     with:
       ios-version: '16.1'

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -3,6 +3,8 @@ name: Development Tests
 on:
   pull_request:
     branches: [ "main" ]
+  pull_request_review:
+    types: [submitted]  
   workflow_dispatch:
 
 jobs:
@@ -13,8 +15,8 @@ jobs:
       macos-runner: 'macos-14'
       
   pre-merge-tests:
+    if: ${{ (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') || github.event_name == 'workflow_dispatch'}}
     uses: ./.github/workflows/unit-tests.yml
     with:
       ios-version: '16.1'
       macos-runner: 'macos-13-xlarge'
-      environment: 'pre-release'

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -1,0 +1,23 @@
+name: Development Tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      ios-version: '17.2'
+      macos-runner: 'macos-14'
+      environment: 'development'
+      
+  pre-merge-tests:
+    needs: build-and-test
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.build-and-test.result == 'success') }}
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      ios-version: '16.1'
+      macos-runner: 'macos-13-xlarge'
+      environment: 'pre-release'

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -13,8 +13,6 @@ jobs:
       macos-runner: 'macos-14'
       
   pre-merge-tests:
-    needs: build-and-test
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.build-and-test.result == 'success') }}
     uses: ./.github/workflows/unit-tests.yml
     with:
       ios-version: '16.1'

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -7,20 +7,16 @@ on:
 
 jobs:
   build-and-test-all-platforms:
-    timeout-minutes: 10
     strategy:
       matrix:
         include:
           - os: macos-13-xlarge
             ios-version: "16.1"  # Oldest available version
-            environment: 'development'
           - os: macos-14
             ios-version: "17.2"  # Latest available version
-            environment: 'development'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: ./.github/workflows/unit-tests.yml
       with:
         ios-version: ${{ matrix.ios-version }}
         macos-runner: ${{ matrix.os }}
-        environment: ${{ matrix.environment }}

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,0 +1,26 @@
+name: Pre-Release Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test-all-platforms:
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - os: macos-13-xlarge
+            ios-version: "16.1"  # Oldest available version
+            environment: 'development'
+          - os: macos-14
+            ios-version: "17.2"  # Latest available version
+            environment: 'development'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: ./.github/workflows/unit-tests.yml
+      with:
+        ios-version: ${{ matrix.ios-version }}
+        macos-runner: ${{ matrix.os }}
+        environment: ${{ matrix.environment }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,63 +1,63 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ios-version:
+        required: true
+        type: string
+      macos-runner:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
 
 jobs:
   build-and-test:
-    strategy:
-      matrix:
-        os: [macos-13-xlarge, macos-14]
-        include:
-          - os: macos-13-xlarge
-            ios-version: "16.1" # oldest available version
-          - os: macos-14
-            ios-version: "17.2" # latest available version
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ inputs.macos-runner }}
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '15.2'
-    - name: Setup environment
-      run: make setup
-    - name: Setup Cache
-      id: model-cache
-      uses: actions/cache@v4
-      with:
-        path: Models
-        key: ${{ runner.os }}-models
-    - name: Download Models
-      if: steps.model-cache.outputs.cache-hit != 'true'
-      run: make download-model MODEL=tiny
-    - name: Install and discover destinations
-      run: |
-        xcodebuild -downloadAllPlatforms
-        echo "Destinations for testing:"
-        xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
-    - name: Build and Test - macOS 
-      run: |
-        set -o pipefail
-        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=macOS | xcpretty
-        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=macOS,arch=arm64" | xcpretty
-    - name: Build and Test - iOS
-      run: |
-        set -o pipefail
-        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=iOS | xcpretty
-        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=iOS Simulator,OS=${{ matrix.ios-version }},name=iPhone 15" | xcpretty
-    - name: Build and Test - watchOS
-      if: matrix.os == 'macos-14'
-      run: |
-        set -o pipefail
-        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=watchOS | xcpretty
-        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=watchOS Simulator,OS=10.2,name=Apple Watch Ultra 2 (49mm)" | xcpretty
-    - name: Build and Test - visionOS
-      if: matrix.os == 'macos-14'
-      run: |
-        set -o pipefail
-        xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=visionOS | xcpretty
-        xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=visionOS Simulator,name=Apple Vision Pro" | xcpretty
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.2'
+      - name: Setup environment
+        run: make setup
+      - name: Setup Cache
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: Models
+          key: ${{ runner.os }}-models
+      - name: Download Models
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: make download-model MODEL=tiny
+      - name: Install and discover destinations
+        run: |
+          xcodebuild -downloadAllPlatforms
+          echo "Destinations for testing:"
+          xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
+      - name: Build and Test - macOS 
+        run: |
+          set -o pipefail
+          xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=macOS | xcpretty
+          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=macOS,arch=arm64" | xcpretty
+      - name: Build and Test - iOS
+        run: |
+          set -o pipefail
+          xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=iOS | xcpretty
+          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15" | xcpretty
+      - name: Build and Test - watchOS
+        if: ${{ inputs.macos-runner == 'macos-14' }}
+        run: |
+          set -o pipefail
+          xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=watchOS | xcpretty
+          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=watchOS Simulator,OS=10.2,name=Apple Watch Ultra 2 (49mm)" | xcpretty
+      - name: Build and Test - visionOS
+        if: ${{ inputs.macos-runner == 'macos-14' }}
+        run: |
+          set -o pipefail
+          xcodebuild clean build-for-testing -scheme whisperkit-Package -destination generic/platform=visionOS | xcpretty
+          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination "platform=visionOS Simulator,name=Apple Vision Pro" | xcpretty

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,16 +9,11 @@ on:
       macos-runner:
         required: true
         type: string
-      environment:
-        required: false
-        default: ''
-        type: string
 
 jobs:
   unit-tests:
+    name: unit-tests-${{ inputs.macos-runner }}
     runs-on: ${{ inputs.macos-runner }}
-    if: ${{ inputs.environment != '' }}
-    environment: ${{ inputs.environment }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ on:
         type: string
       environment:
         required: false
+        default: ''
         type: string
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,14 +10,15 @@ on:
         required: true
         type: string
       environment:
-        required: true
+        required: false
         type: string
 
 jobs:
-  build-and-test:
+  unit-tests:
     runs-on: ${{ inputs.macos-runner }}
+    if: ${{ inputs.environment != '' }}
     environment: ${{ inputs.environment }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # WhisperKit
 
-[![Unit Tests](https://github.com/argmaxinc/whisperkit/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/argmaxinc/whisperkit/actions/workflows/unit-tests.yml)
+[![Tests](https://github.com/argmaxinc/whisperkit/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/argmaxinc/whisperkit/actions/workflows/pre-release-tests.yml)
 [![License](https://img.shields.io/github/license/argmaxinc/whisperkit?logo=github&logoColor=969da4&label=License&labelColor=353a41&color=32d058)](LICENSE.md)
 [![Supported Swift Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fargmaxinc%2FWhisperKit%2Fbadge%3Ftype%3Dswift-versions&labelColor=353a41&color=32d058)](https://swiftpackageindex.com/argmaxinc/WhisperKit) [![Supported Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fargmaxinc%2FWhisperKit%2Fbadge%3Ftype%3Dplatforms&labelColor=353a41&color=32d058)](https://swiftpackageindex.com/argmaxinc/WhisperKit)
 


### PR DESCRIPTION
These tests should only run on approval or merge, which should reduce the macos-13-xlarge runner usage. Also adds a 10 min timeout.