### PR TITLE
Use GPU for audio encoder on macOS 13

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -135,7 +135,7 @@ public struct ModelComputeOptions {
 
     public init(
         melCompute: MLComputeUnits = .cpuAndGPU,
-        audioEncoderCompute: MLComputeUnits = .cpuAndNeuralEngine,
+        audioEncoderCompute: MLComputeUnits? = nil,
         textDecoderCompute: MLComputeUnits = .cpuAndNeuralEngine,
         prefillCompute: MLComputeUnits = .cpuOnly
     ) {
@@ -146,10 +146,16 @@ public struct ModelComputeOptions {
             self.prefillCompute = .cpuOnly
             return
         }
+        
         self.melCompute = melCompute
-        self.audioEncoderCompute = audioEncoderCompute
-        self.textDecoderCompute = textDecoderCompute
         self.prefillCompute = prefillCompute
+        self.textDecoderCompute = textDecoderCompute
+        
+        if #available(macOS 14.0, *) {
+            self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndNeuralEngine
+        } else {
+            self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndGPU
+        }
     }
 }
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -151,7 +151,7 @@ public struct ModelComputeOptions {
         self.prefillCompute = prefillCompute
         self.textDecoderCompute = textDecoderCompute
         
-        if #available(macOS 14.0, *) {
+        if #available(macOS 14.0, iOS 17.0, watchOS 10, visionOS 1, *) {
             self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndNeuralEngine
         } else {
             self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndGPU

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -21,7 +21,6 @@ struct CLIArguments: ParsableArguments {
 
     @Option(help: "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var audioEncoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
-    
     @Option(help: "Compute units for text decoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var textDecoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
 

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -20,8 +20,14 @@ struct CLIArguments: ParsableArguments {
     var downloadTokenizerPath: String?
 
     @Option(help: "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
-    var audioEncoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
-
+    var audioEncoderComputeUnits: ComputeUnits {
+        if #available(macOS 14.0, *) {
+            return .cpuAndNeuralEngine
+        } else {
+            return .cpuAndGpu
+        }
+    }
+    
     @Option(help: "Compute units for text decoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var textDecoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
 

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -20,13 +20,7 @@ struct CLIArguments: ParsableArguments {
     var downloadTokenizerPath: String?
 
     @Option(help: "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
-    var audioEncoderComputeUnits: ComputeUnits {
-        if #available(macOS 14.0, *) {
-            return .cpuAndNeuralEngine
-        } else {
-            return .cpuAndGpu
-        }
-    }
+    var audioEncoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
     
     @Option(help: "Compute units for text decoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var textDecoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -32,9 +32,19 @@ struct Transcribe: AsyncParsableCommand {
             print("Transcribing audio at \(cliArguments.audioPath)")
         }
 
+        var audioEncoderComputeUnits = cliArguments.audioEncoderComputeUnits.asMLComputeUnits
+        let textDecoderComputeUnits = cliArguments.textDecoderComputeUnits.asMLComputeUnits
+        
+        // Use gpu for audio encoder on macOS below 14
+        if audioEncoderComputeUnits == .cpuAndNeuralEngine {
+            if #unavailable(macOS 14.0) {
+                audioEncoderComputeUnits = .cpuAndGPU
+            }
+        }
+        
         let computeOptions = ModelComputeOptions(
-            audioEncoderCompute: cliArguments.audioEncoderComputeUnits.asMLComputeUnits,
-            textDecoderCompute: cliArguments.textDecoderComputeUnits.asMLComputeUnits
+            audioEncoderCompute: audioEncoderComputeUnits,
+            textDecoderCompute: textDecoderComputeUnits
         )
 
         let downloadTokenizerFolder: URL? =


### PR DESCRIPTION
Some of the audio encoder models have unexpected outputs using the neural engine on macOS 13, this will set the default to GPU. It can still be overridden by passing in your own `ModelComputeOptions` object into the `computeOptions` property of the WhisperKit() init method.

Example with jfk.wav, with fix:
```
And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.
```

Without fix:
```
<|startoftranscript|><|en|><|transcribe|><|translate|><|translate|><|si|>.<|si|><|si|>,<|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|si|><|endoftext|>
```