### PR TITLE
WhisperKit init refactor

### DIFF
--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 final class UnitTests: XCTestCase {
     func testInit() async {
-        let whisperKit = try? await WhisperKit(prewarm: false, load: false, download: false)
+        let whisperKit = try? await WhisperKit(prewarm: false, load: false)
         XCTAssertNotNil(whisperKit)
     }
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 final class UnitTests: XCTestCase {
     func testInit() async {
-        let whisperKit = try? await WhisperKit(prewarm: false, load: false)
+        let whisperKit = try? await WhisperKit(prewarm: false, load: false, download: false)
         XCTAssertNotNil(whisperKit)
     }
 


### PR DESCRIPTION
- added `WhisperMLModel` conformance, no more conditional casting
- `setupModels` -> static `setupModelFolder` which makes `modelFolder` non optional
- removed `download` param, I think it's not needed. When the `modelFolder` param is `nil` we download, otherwise we load the model from the directory

Possible future improvements:
- load models (`featureExtractor`, `audioEncoder` and `textDecoder`) in parallel?
- we could add `forceDownload` param which, in case `modelFolder` is provided will redownload