### PR TITLE
Tokenizer refactor, tests cleanup

### DIFF
--- a/Sources/WhisperKit/Core/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/LogitsFilter.swift
@@ -28,14 +28,20 @@ public class SuppressTokensFilter: LogitsFiltering {
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public class SuppressBlankFilter: LogitsFiltering {
-    let suppressBlankTokens: [Int]
+    let specialTokens: SpecialTokens
     let sampleBegin: Int
     private let suppressTokenIndexes: [[NSNumber]]
 
-    public init(suppressBlankTokens: [Int], sampleBegin: Int) {
-        self.suppressBlankTokens = suppressBlankTokens
+    public init(
+        specialTokens: SpecialTokens,
+        sampleBegin: Int
+    ) {
+        self.specialTokens = specialTokens
         self.sampleBegin = sampleBegin
-        self.suppressTokenIndexes = suppressBlankTokens.map { [0, 0, $0 as NSNumber] }
+        self.suppressTokenIndexes = [
+            [0, 0, specialTokens.whitespaceToken as NSNumber],
+            [0, 0, specialTokens.endToken as NSNumber]
+        ]
     }
 
     public func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray {
@@ -50,30 +56,18 @@ public class SuppressBlankFilter: LogitsFiltering {
 /// Implementation based on https://github.com/openai/whisper/blob/master/whisper/decoding.py#L441
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public class TimestampRulesFilter: LogitsFiltering {
-    let transcribeToken: Int
-    let translateToken: Int
-    let noTimestampsToken: Int
-    let timeTokenBegin: Int
-    let endToken: Int
+    let specialTokens: SpecialTokens
     let sampleBegin: Int
     let maxInitialTimestampIndex: Int?
     let isModelMultilingual: Bool
 
     public init(
-        transcribeToken: Int,
-        translateToken: Int,
-        noTimestampsToken: Int,
-        timeTokenBegin: Int,
-        endToken: Int,
+        specialTokens: SpecialTokens,
         sampleBegin: Int,
         maxInitialTimestampIndex: Int?,
         isModelMultilingual: Bool
     ) {
-        self.transcribeToken = transcribeToken
-        self.translateToken = translateToken
-        self.noTimestampsToken = noTimestampsToken
-        self.timeTokenBegin = timeTokenBegin
-        self.endToken = endToken
+        self.specialTokens = specialTokens
         self.sampleBegin = sampleBegin
         self.maxInitialTimestampIndex = maxInitialTimestampIndex
         self.isModelMultilingual = isModelMultilingual
@@ -84,24 +78,24 @@ public class TimestampRulesFilter: LogitsFiltering {
             return logits
         }
         // suppress <|notimestamps|> which is handled by `withoutTimestamps`
-        logits.fill(indexes: [[0, 0, noTimestampsToken as NSNumber]], with: -FloatType.infinity)
+        logits.fill(indexes: [[0, 0, specialTokens.noTimestampsToken as NSNumber]], with: -FloatType.infinity)
 
         if tokens.count > sampleBegin {
             // timestamps have to appear in pairs, except directly before EOT; mask logits accordingly
             let sampledTokens = tokens[sampleBegin...]
-            let lastWasTimestamp = sampledTokens.count >= 1 && sampledTokens.last! >= timeTokenBegin
-            let penultimateWasTimestamp = sampledTokens.count < 2 || sampledTokens.dropLast().last! >= timeTokenBegin
+            let lastWasTimestamp = sampledTokens.count >= 1 && sampledTokens.last! >= specialTokens.timeTokenBegin
+            let penultimateWasTimestamp = sampledTokens.count < 2 || sampledTokens.dropLast().last! >= specialTokens.timeTokenBegin
             if lastWasTimestamp {
                 if penultimateWasTimestamp {
                     // has to be non-timestamp
-                    logits.fillLastDimension(indexes: timeTokenBegin..<logits.count, with: -FloatType.infinity)
+                    logits.fillLastDimension(indexes: specialTokens.timeTokenBegin..<logits.count, with: -FloatType.infinity)
                 } else {
                     // cannot be normal text tokens
-                    logits.fillLastDimension(indexes: 0..<endToken, with: -FloatType.infinity)
+                    logits.fillLastDimension(indexes: 0..<specialTokens.endToken, with: -FloatType.infinity)
                 }
             }
 
-            let timestamps = sampledTokens.filter { $0 >= timeTokenBegin }
+            let timestamps = sampledTokens.filter { $0 >= specialTokens.timeTokenBegin }
             if let lastTimestamp = timestamps.last {
                 // timestamps shouldn't decrease; forbid timestamp tokens smaller than the last
                 // also force each segment to have a nonzero length, to prevent infinite looping
@@ -111,23 +105,23 @@ public class TimestampRulesFilter: LogitsFiltering {
                     } else {
                         lastTimestamp + 1
                     }
-                logits.fillLastDimension(indexes: timeTokenBegin..<timestampLast, with: -FloatType.infinity)
+                logits.fillLastDimension(indexes: specialTokens.timeTokenBegin..<timestampLast, with: -FloatType.infinity)
             }
         }
 
        if tokens.count == sampleBegin {
            // suppress generating non-timestamp tokens at the beginning
-           logits.fillLastDimension(indexes: 0..<timeTokenBegin, with: -FloatType.infinity)
+           logits.fillLastDimension(indexes: 0..<specialTokens.timeTokenBegin, with: -FloatType.infinity)
            if let maxInitialTimestampIndex {
                // apply the `maxInitialTimestamp` option
-               let lastAllowed = timeTokenBegin + maxInitialTimestampIndex + 1
+               let lastAllowed = specialTokens.timeTokenBegin + maxInitialTimestampIndex + 1
                logits.fillLastDimension(indexes: lastAllowed..<logits.count, with: -FloatType.infinity)
            }
        }
 
         // if sum of probability over timestamps is above any other token, sample timestamp
-        if sumOfProbabilityOverTimestampsIsAboveAnyOtherToken(logits: logits, timeTokenBegin: timeTokenBegin) {
-            logits.fillLastDimension(indexes: 0..<timeTokenBegin, with: -FloatType.infinity)
+        if sumOfProbabilityOverTimestampsIsAboveAnyOtherToken(logits: logits, timeTokenBegin: specialTokens.timeTokenBegin) {
+            logits.fillLastDimension(indexes: 0..<specialTokens.timeTokenBegin, with: -FloatType.infinity)
         }
         return logits
     }
@@ -135,7 +129,7 @@ public class TimestampRulesFilter: LogitsFiltering {
     private func sampleBegin(for tokens: [Int]) -> Int? {
         if isModelMultilingual {
             // NOTE: for multilingual model we don't want to supress "<|transcribe|>" or "<|translate|>" tokens
-            if let taskTokenIndex = tokens.prefix(3).firstIndex(where: { $0 == transcribeToken || $0 == translateToken }) {
+            if let taskTokenIndex = tokens.prefix(3).firstIndex(where: { $0 == specialTokens.transcribeToken || $0 == specialTokens.translateToken }) {
                 return max(taskTokenIndex + 1, sampleBegin)
             } else {
                 return nil

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -966,9 +966,9 @@ struct WhisperTokenizerWrapper: WhisperTokenizer {
         return false
     }
 
-    /// Tokenizes the given texta into individual words and associated tokens
-    /// - Parameter tokenIds: Array of tokens to split
-    /// - Returns: Tuple containing and array of the split words and and all tokens for each word
+    /// Decodes token ids into individual words and per-word subtokens
+    /// - Parameter tokenIds: Array of tokens to decode and then split 
+    /// - Returns: Tuple containing and array of the split words and all tokens for each word
     func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
         let decodedWords = tokenizer.decode(tokens: tokenIds.filter { $0 < specialTokens.specialTokenBegin })
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -836,52 +836,73 @@ public class TextDecoderCachePrefillOutput: MLFeatureProvider {
     }
 }
 
-// MARK: Tokenizer
+// MARK: SpecialTokens
 
-public extension Tokenizer {
-    var whitespaceToken: Int { convertTokenToId(" ") ?? Self.defaultWhitespaceToken }
-    var specialTokenBegin: Int { convertTokenToId("<|endoftext|>") ?? Self.defaultSpecialTokenBegin }
-    var endToken: Int { convertTokenToId("<|endoftext|>") ?? Self.defaultEndToken }
-    var startOfTranscriptToken: Int { convertTokenToId("<|startoftranscript|>") ?? Self.defaultStartOfTranscriptToken }
-    var englishToken: Int { convertTokenToId("<|en|>") ?? Self.defaultEnglishToken }
-    var transcribeToken: Int { convertTokenToId("<|transcribe|>") ?? Self.defaultTranscribeToken }
-    var translateToken: Int { convertTokenToId("<|translate|>") ?? Self.defaultTranslateToken }
-    var noSpeechToken: Int { convertTokenToId("<|nospeech|>") ?? Self.defaultNoSpeechToken }
-    var noTimestampsToken: Int { convertTokenToId("<|notimestamps|>") ?? Self.defaultNoTimestampsToken }
-    var timeTokenBegin: Int { convertTokenToId("<|0.00|>") ?? Self.defaultTimeTokenBegin }
+public struct SpecialTokens {
+    public let endToken: Int
+    public let englishToken: Int
+    public let noSpeechToken: Int
+    public let noTimestampsToken: Int
+    public let specialTokenBegin: Int
+    public let startOfTranscriptToken: Int
+    public let timeTokenBegin: Int
+    public let transcribeToken: Int
+    public let translateToken: Int
+    public let whitespaceToken: Int
 
-    /// Default values for each token, using base vocab
-    internal static var defaultWhitespaceToken: Int { 220 }
-    internal static var defaultSpecialTokenBegin: Int { 50257 }
-    internal static var defaultEndToken: Int { 50257 }
-    internal static var defaultStartOfTranscriptToken: Int { 50258 }
-    internal static var defaultEnglishToken: Int { 50259 }
-    internal static var defaultTranscribeToken: Int { 50359 }
-    internal static var defaultTranslateToken: Int { 50358 }
-    internal static var defaultNoSpeechToken: Int { 50362 }
-    internal static var defaultNoTimestampsToken: Int { 50363 }
-    internal static var defaultTimeTokenBegin: Int { 50364 }
-
-    /// Tokenizes the given text into individual words and associated tokens
-    /// - Parameter tokenIds: Array of tokens to split
-    /// - Returns: Tuple containing and array of the split words and and all tokens for each word
-    func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
-        let decodedWords = decode(tokens: tokenIds.filter { $0 < specialTokenBegin })
-
-        // Detect language of input text
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(decodedWords)
-        let languageCode = recognizer.dominantLanguage?.rawValue
-
-        if ["zh", "ja", "th", "lo", "my", "yue"].contains(languageCode) {
-            return splitTokensOnUnicode(tokens: tokenIds)
-        } else {
-            return splitTokensOnSpaces(tokens: tokenIds)
-        }
+    public init(
+        endToken: Int,
+        englishToken: Int,
+        noSpeechToken: Int,
+        noTimestampsToken: Int,
+        specialTokenBegin: Int,
+        startOfTranscriptToken: Int,
+        timeTokenBegin: Int,
+        transcribeToken: Int,
+        translateToken: Int,
+        whitespaceToken: Int
+    ) {
+        self.endToken = endToken
+        self.englishToken = englishToken
+        self.noSpeechToken = noSpeechToken
+        self.noTimestampsToken = noTimestampsToken
+        self.specialTokenBegin = specialTokenBegin
+        self.startOfTranscriptToken = startOfTranscriptToken
+        self.timeTokenBegin = timeTokenBegin
+        self.transcribeToken = transcribeToken
+        self.translateToken = translateToken
+        self.whitespaceToken = whitespaceToken
     }
+}
 
-    func splitTokensOnUnicode(tokens: [Int]) -> (words: [String], wordTokens: [[Int]]) {
-        let decodedFull = decode(tokens: tokens)
+public protocol WhisperTokenizer: Tokenizer {
+    var specialTokens: SpecialTokens { get }
+    
+    func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]])
+}
+
+struct WhisperTokenizerWrapper: WhisperTokenizer {
+    let tokenizer: any Tokenizer
+    let specialTokens: SpecialTokens
+
+    init(tokenizer: any Tokenizer) {
+        self.tokenizer = tokenizer
+        self.specialTokens = SpecialTokens(
+            endToken: tokenizer.convertTokenToId("<|endoftext|>") ?? Self.defaultEndToken,
+            englishToken: tokenizer.convertTokenToId("<|en|>") ?? Self.defaultEnglishToken,
+            noSpeechToken: tokenizer.convertTokenToId("<|nospeech|>") ?? Self.defaultNoSpeechToken,
+            noTimestampsToken: tokenizer.convertTokenToId("<|notimestamps|>") ?? Self.defaultNoTimestampsToken,
+            specialTokenBegin: tokenizer.convertTokenToId("<|endoftext|>") ?? Self.defaultSpecialTokenBegin,
+            startOfTranscriptToken: tokenizer.convertTokenToId("<|startoftranscript|>") ?? Self.defaultStartOfTranscriptToken,
+            timeTokenBegin: tokenizer.convertTokenToId("<|0.00|>") ?? Self.defaultTimeTokenBegin,
+            transcribeToken: tokenizer.convertTokenToId("<|transcribe|>") ?? Self.defaultTranscribeToken,
+            translateToken: tokenizer.convertTokenToId("<|translate|>") ?? Self.defaultTranslateToken,
+            whitespaceToken: tokenizer.convertTokenToId(" ") ?? Self.defaultWhitespaceToken
+        )
+    }
+    
+    private func splitTokensOnUnicode(tokens: [Int]) -> (words: [String], wordTokens: [[Int]]) {
+        let decodedFull = tokenizer.decode(tokens: tokens)
         let replacementString = "\u{fffd}"
 
         var words: [String] = []
@@ -891,7 +912,7 @@ public extension Tokenizer {
 
         for token in tokens {
             currentTokens.append(token)
-            let decoded = decode(tokens: currentTokens)
+            let decoded = tokenizer.decode(tokens: currentTokens)
 
             var hasUnicodeInFullString = false
             if let range = decoded.range(of: replacementString) {
@@ -909,13 +930,13 @@ public extension Tokenizer {
         return (words, wordTokens)
     }
 
-    func splitTokensOnSpaces(tokens: [Int]) -> (words: [String], wordTokens: [[Int]]) {
+    private func splitTokensOnSpaces(tokens: [Int]) -> (words: [String], wordTokens: [[Int]]) {
         let (subwords, subwordTokensList) = splitTokensOnUnicode(tokens: tokens)
         var words: [String] = []
         var wordTokens: [[Int]] = []
 
         for (subword, subwordTokens) in zip(subwords, subwordTokensList) {
-            let special = subwordTokens.first! >= specialTokenBegin
+            let special = subwordTokens.first! >= specialTokens.specialTokenBegin
             let withSpace = subword.hasPrefix(" ")
             var punctuation = false
             if let strippedSubword = UnicodeScalar(subword.trimmingCharacters(in: .whitespaces)) {
@@ -933,7 +954,7 @@ public extension Tokenizer {
         return (words, wordTokens)
     }
 
-    func isPunctuation(_ text: String, tokenRange: Range<String.Index>, tag: NLTag?) -> Bool {
+    private func isPunctuation(_ text: String, tokenRange: Range<String.Index>, tag: NLTag?) -> Bool {
         let punctuationCharacters = CharacterSet.punctuationCharacters
         let token = String(text[tokenRange])
         print(token)
@@ -945,118 +966,198 @@ public extension Tokenizer {
         return false
     }
 
-    var languages: [String: String] { [
-        "english": "en",
-        "chinese": "zh",
-        "german": "de",
-        "spanish": "es",
-        "russian": "ru",
-        "korean": "ko",
-        "french": "fr",
-        "japanese": "ja",
-        "portuguese": "pt",
-        "turkish": "tr",
-        "polish": "pl",
-        "catalan": "ca",
-        "dutch": "nl",
-        "arabic": "ar",
-        "swedish": "sv",
-        "italian": "it",
-        "indonesian": "id",
-        "hindi": "hi",
-        "finnish": "fi",
-        "vietnamese": "vi",
-        "hebrew": "he",
-        "ukrainian": "uk",
-        "greek": "el",
-        "malay": "ms",
-        "czech": "cs",
-        "romanian": "ro",
-        "danish": "da",
-        "hungarian": "hu",
-        "tamil": "ta",
-        "norwegian": "no",
-        "thai": "th",
-        "urdu": "ur",
-        "croatian": "hr",
-        "bulgarian": "bg",
-        "lithuanian": "lt",
-        "latin": "la",
-        "maori": "mi",
-        "malayalam": "ml",
-        "welsh": "cy",
-        "slovak": "sk",
-        "telugu": "te",
-        "persian": "fa",
-        "latvian": "lv",
-        "bengali": "bn",
-        "serbian": "sr",
-        "azerbaijani": "az",
-        "slovenian": "sl",
-        "kannada": "kn",
-        "estonian": "et",
-        "macedonian": "mk",
-        "breton": "br",
-        "basque": "eu",
-        "icelandic": "is",
-        "armenian": "hy",
-        "nepali": "ne",
-        "mongolian": "mn",
-        "bosnian": "bs",
-        "kazakh": "kk",
-        "albanian": "sq",
-        "swahili": "sw",
-        "galician": "gl",
-        "marathi": "mr",
-        "punjabi": "pa",
-        "sinhala": "si",
-        "khmer": "km",
-        "shona": "sn",
-        "yoruba": "yo",
-        "somali": "so",
-        "afrikaans": "af",
-        "occitan": "oc",
-        "georgian": "ka",
-        "belarusian": "be",
-        "tajik": "tg",
-        "sindhi": "sd",
-        "gujarati": "gu",
-        "amharic": "am",
-        "yiddish": "yi",
-        "lao": "lo",
-        "uzbek": "uz",
-        "faroese": "fo",
-        "haitian creole": "ht",
-        "pashto": "ps",
-        "turkmen": "tk",
-        "nynorsk": "nn",
-        "maltese": "mt",
-        "sanskrit": "sa",
-        "luxembourgish": "lb",
-        "myanmar": "my",
-        "tibetan": "bo",
-        "tagalog": "tl",
-        "malagasy": "mg",
-        "assamese": "as",
-        "tatar": "tt",
-        "hawaiian": "haw",
-        "lingala": "ln",
-        "hausa": "ha",
-        "bashkir": "ba",
-        "javanese": "jw",
-        "sundanese": "su",
-        "cantonese": "yue",
-        "burmese": "my",
-        "valencian": "ca",
-        "flemish": "nl",
-        "haitian": "ht",
-        "letzeburgesch": "lb",
-        "pushto": "ps",
-        "panjabi": "pa",
-        "moldavian": "ro",
-        "moldovan": "ro",
-        "sinhalese": "si",
-        "castilian": "es",
-        "mandarin": "zh",
-    ] }
+    /// Tokenizes the given texta into individual words and associated tokens
+    /// - Parameter tokenIds: Array of tokens to split
+    /// - Returns: Tuple containing and array of the split words and and all tokens for each word
+    func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
+        let decodedWords = tokenizer.decode(tokens: tokenIds.filter { $0 < specialTokens.specialTokenBegin })
+
+        // Detect language of input text
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(decodedWords)
+        let languageCode = recognizer.dominantLanguage?.rawValue
+
+        if ["zh", "ja", "th", "lo", "my", "yue"].contains(languageCode) {
+            return splitTokensOnUnicode(tokens: tokenIds)
+        } else {
+            return splitTokensOnSpaces(tokens: tokenIds)
+        }
+    }
+
+    var languages: [String: String] {
+        [
+            "english": "en",
+            "chinese": "zh",
+            "german": "de",
+            "spanish": "es",
+            "russian": "ru",
+            "korean": "ko",
+            "french": "fr",
+            "japanese": "ja",
+            "portuguese": "pt",
+            "turkish": "tr",
+            "polish": "pl",
+            "catalan": "ca",
+            "dutch": "nl",
+            "arabic": "ar",
+            "swedish": "sv",
+            "italian": "it",
+            "indonesian": "id",
+            "hindi": "hi",
+            "finnish": "fi",
+            "vietnamese": "vi",
+            "hebrew": "he",
+            "ukrainian": "uk",
+            "greek": "el",
+            "malay": "ms",
+            "czech": "cs",
+            "romanian": "ro",
+            "danish": "da",
+            "hungarian": "hu",
+            "tamil": "ta",
+            "norwegian": "no",
+            "thai": "th",
+            "urdu": "ur",
+            "croatian": "hr",
+            "bulgarian": "bg",
+            "lithuanian": "lt",
+            "latin": "la",
+            "maori": "mi",
+            "malayalam": "ml",
+            "welsh": "cy",
+            "slovak": "sk",
+            "telugu": "te",
+            "persian": "fa",
+            "latvian": "lv",
+            "bengali": "bn",
+            "serbian": "sr",
+            "azerbaijani": "az",
+            "slovenian": "sl",
+            "kannada": "kn",
+            "estonian": "et",
+            "macedonian": "mk",
+            "breton": "br",
+            "basque": "eu",
+            "icelandic": "is",
+            "armenian": "hy",
+            "nepali": "ne",
+            "mongolian": "mn",
+            "bosnian": "bs",
+            "kazakh": "kk",
+            "albanian": "sq",
+            "swahili": "sw",
+            "galician": "gl",
+            "marathi": "mr",
+            "punjabi": "pa",
+            "sinhala": "si",
+            "khmer": "km",
+            "shona": "sn",
+            "yoruba": "yo",
+            "somali": "so",
+            "afrikaans": "af",
+            "occitan": "oc",
+            "georgian": "ka",
+            "belarusian": "be",
+            "tajik": "tg",
+            "sindhi": "sd",
+            "gujarati": "gu",
+            "amharic": "am",
+            "yiddish": "yi",
+            "lao": "lo",
+            "uzbek": "uz",
+            "faroese": "fo",
+            "haitian creole": "ht",
+            "pashto": "ps",
+            "turkmen": "tk",
+            "nynorsk": "nn",
+            "maltese": "mt",
+            "sanskrit": "sa",
+            "luxembourgish": "lb",
+            "myanmar": "my",
+            "tibetan": "bo",
+            "tagalog": "tl",
+            "malagasy": "mg",
+            "assamese": "as",
+            "tatar": "tt",
+            "hawaiian": "haw",
+            "lingala": "ln",
+            "hausa": "ha",
+            "bashkir": "ba",
+            "javanese": "jw",
+            "sundanese": "su",
+            "cantonese": "yue",
+            "burmese": "my",
+            "valencian": "ca",
+            "flemish": "nl",
+            "haitian": "ht",
+            "letzeburgesch": "lb",
+            "pushto": "ps",
+            "panjabi": "pa",
+            "moldavian": "ro",
+            "moldovan": "ro",
+            "sinhalese": "si",
+            "castilian": "es",
+            "mandarin": "zh",
+        ]
+    }
+}
+
+extension WhisperTokenizerWrapper: Tokenizer {
+    func tokenize(text: String) -> [String] {
+        tokenizer.tokenize(text: text)
+    }
+    
+    func encode(text: String) -> [Int] {
+        tokenizer.encode(text: text)
+    }
+    
+    func decode(tokens: [Int]) -> String {
+        tokenizer.decode(tokens: tokens)
+    }
+    
+    func convertTokenToId(_ token: String) -> Int? {
+        tokenizer.convertTokenToId(token)
+    }
+    
+    func convertIdToToken(_ id: Int) -> String? {
+        tokenizer.convertIdToToken(id)
+    }
+    
+    var bosToken: String? {
+        tokenizer.bosToken
+    }
+    
+    var bosTokenId: Int? {
+        tokenizer.bosTokenId
+    }
+    
+    var eosToken: String? {
+        tokenizer.eosToken
+    }
+    
+    var eosTokenId: Int? {
+        tokenizer.eosTokenId
+    }
+    
+    var unknownToken: String? {
+        tokenizer.unknownToken
+    }
+    
+    var unknownTokenId: Int? {
+        tokenizer.unknownTokenId
+    }
+}
+
+extension WhisperTokenizerWrapper {
+    /// Default values for each token, using base vocab
+    static var defaultWhitespaceToken: Int { 220 }
+    static var defaultSpecialTokenBegin: Int { 50257 }
+    static var defaultEndToken: Int { 50257 }
+    static var defaultStartOfTranscriptToken: Int { 50258 }
+    static var defaultEnglishToken: Int { 50259 }
+    static var defaultTranscribeToken: Int { 50359 }
+    static var defaultTranslateToken: Int { 50358 }
+    static var defaultNoSpeechToken: Int { 50362 }
+    static var defaultNoTimestampsToken: Int { 50363 }
+    static var defaultTimeTokenBegin: Int { 50364 }
 }

--- a/Sources/WhisperKit/Core/SegmentSeeker.swift
+++ b/Sources/WhisperKit/Core/SegmentSeeker.swift
@@ -17,13 +17,13 @@ public protocol SegmentSeeking {
         sampleRate: Int,
         timeToken: Int,
         specialToken: Int,
-        tokenizer: Tokenizer
+        tokenizer: WhisperTokenizer
     ) -> (Int, [TranscriptionSegment]?)
 
     func addWordTimestamps(
         segments: [TranscriptionSegment],
         alignmentWeights: MLMultiArray,
-        tokenizer: Tokenizer,
+        tokenizer: WhisperTokenizer,
         seek: Int,
         segmentSize: Int,
         prependPunctuations: String,
@@ -50,7 +50,7 @@ public class SegmentSeeker: SegmentSeeking {
         sampleRate: Int,
         timeToken: Int,
         specialToken: Int,
-        tokenizer: Tokenizer
+        tokenizer: WhisperTokenizer
     ) -> (Int, [TranscriptionSegment]?) {
         // check if we need to skip this segment entirely
         // if so, reset currentSegments, continue to next window, otherwise:
@@ -116,7 +116,7 @@ public class SegmentSeeker: SegmentSeeking {
                 let endTimestampSeconds = Float(timestampTokens.last! - timeToken) * secondsPerTimeToken
 
                 // Decode segment text
-                let wordTokens = slicedTokens.filter { $0 < tokenizer.specialTokenBegin }
+                let wordTokens = slicedTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
                 let slicedTextTokens = options.skipSpecialTokens ? wordTokens : slicedTokens
                 let sliceText = tokenizer.decode(tokens: slicedTextTokens)
 
@@ -156,7 +156,7 @@ public class SegmentSeeker: SegmentSeeking {
             }
 
             // Decode segment text
-            let wordTokens = decodingResult.tokens.filter { $0 < tokenizer.specialTokenBegin }
+            let wordTokens = decodingResult.tokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
             let segmentTextTokens = options.skipSpecialTokens ? wordTokens : decodingResult.tokens
             let segmentText = tokenizer.decode(tokens: segmentTextTokens)
 
@@ -315,7 +315,7 @@ public class SegmentSeeker: SegmentSeeking {
         wordTokenIds: [Int],
         alignmentWeights: MLMultiArray,
         tokenLogProbs: [Float],
-        tokenizer: Tokenizer,
+        tokenizer: WhisperTokenizer,
         timings: TranscriptionTimings? = nil
     ) throws -> [WordTiming] {
         // TODO: Use accelerate framework for these two, they take roughly the same time
@@ -384,7 +384,7 @@ public class SegmentSeeker: SegmentSeeking {
     public func addWordTimestamps(
         segments: [TranscriptionSegment],
         alignmentWeights: MLMultiArray,
-        tokenizer: Tokenizer,
+        tokenizer: WhisperTokenizer,
         seek: Int,
         segmentSize: Int,
         prependPunctuations: String,
@@ -477,14 +477,14 @@ public class SegmentSeeker: SegmentSeeking {
 
         for segment in segments {
             var savedTokens = 0
-            let textTokens = segment.tokens.filter { $0 < tokenizer.specialTokenBegin }
+            let textTokens = segment.tokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
             var wordsInSegment = [WordTiming]()
 
             for timing in mergedAlignment[wordIndex...] where savedTokens < textTokens.count {
                 wordIndex += 1
 
                 // Remove special tokens and retokenize if needed
-                let timingTokens = timing.tokens.filter { $0 < tokenizer.specialTokenBegin }
+                let timingTokens = timing.tokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
                 if timingTokens.isEmpty {
                     continue
                 }

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -105,7 +105,7 @@ public extension TextDecoding {
         return decoderInputs
     }
 
-    func prefillDecoderInputs(_ decoderInputs: DecodingInputs, withOptions options: DecodingOptions?, multilingual: Bool) async throws -> DecodingInputs {
+    func prefillDecoderInputs(_ decoderInputs: DecodingInputs, withOptions options: DecodingOptions?) async throws -> DecodingInputs {
         guard let tokenizer = tokenizer else {
             // Tokenizer required for prefill
             throw WhisperError.tokenizerUnavailable()
@@ -118,9 +118,9 @@ public extension TextDecoding {
 
         var languageToken: Int = tokenizer.specialTokens.englishToken
         var taskToken: Int = tokenizer.specialTokens.transcribeToken
-        if let options = options,
-           multilingual // Multilingual models require language and task tokens
-        {
+
+        // Multilingual models require language and task tokens
+        if let options = options, isModelMultilingual {
             // Set languageToken
             let languageTokenString = "<|\(options.language ?? "en")|>"
             languageToken = tokenizer.convertTokenToId(languageTokenString) ?? tokenizer.specialTokens.englishToken

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -7,14 +7,15 @@ import Tokenizers
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public protocol TextDecoding {
-    var tokenizer: Tokenizer? { get set }
+    var tokenizer: WhisperTokenizer? { get set }
     var prefillData: WhisperMLModel? { get set }
+    var isModelMultilingual: Bool { get set }
     var logitsSize: Int? { get }
     var kvCacheEmbedDim: Int? { get }
     var kvCacheMaxSequenceLength: Int? { get }
     var windowSize: Int? { get }
     var embedSize: Int? { get }
-
+    
     func predictLogits(
         inputIds: MLMultiArray,
         cacheLength: MLMultiArray,
@@ -113,25 +114,25 @@ public extension TextDecoding {
         var prefilledDecoderInputs = decoderInputs
 
         // Setup prefill tokens based on task and language
-        var prefillTokens: [Int] = [tokenizer.startOfTranscriptToken] // SOT
+        var prefillTokens: [Int] = [tokenizer.specialTokens.startOfTranscriptToken] // SOT
 
-        var languageToken: Int = tokenizer.englishToken
-        var taskToken: Int = tokenizer.transcribeToken
+        var languageToken: Int = tokenizer.specialTokens.englishToken
+        var taskToken: Int = tokenizer.specialTokens.transcribeToken
         if let options = options,
            multilingual // Multilingual models require language and task tokens
         {
             // Set languageToken
             let languageTokenString = "<|\(options.language ?? "en")|>"
-            languageToken = tokenizer.convertTokenToId(languageTokenString) ?? tokenizer.englishToken
+            languageToken = tokenizer.convertTokenToId(languageTokenString) ?? tokenizer.specialTokens.englishToken
             prefillTokens.append(languageToken)
 
             // Set taskToken
             let taskTokenString = "<|\(options.task)|>"
-            taskToken = tokenizer.convertTokenToId(taskTokenString) ?? tokenizer.transcribeToken
+            taskToken = tokenizer.convertTokenToId(taskTokenString) ?? tokenizer.specialTokens.transcribeToken
             prefillTokens.append(taskToken)
         }
 
-        let timestampsToken = options?.withoutTimestamps ?? false ? tokenizer.noTimestampsToken : tokenizer.timeTokenBegin // withoutTimestamps must be non-nil and true in order to disable it
+        let timestampsToken = options?.withoutTimestamps ?? false ? tokenizer.specialTokens.noTimestampsToken : tokenizer.specialTokens.timeTokenBegin // withoutTimestamps must be non-nil and true in order to disable it
         prefillTokens.append(timestampsToken)
 
         prefilledDecoderInputs.initialPrompt = prefillTokens
@@ -142,7 +143,7 @@ public extension TextDecoding {
         {
             // Prefilling kv cache data requires non-nil task and language tokens, set defaults if not provided
             // Task tokens are remapped to 0->transcribe and 1->translate for the prefill lookup table
-            let task = MLMultiArray.from([taskToken == tokenizer.transcribeToken ? 0 : 1])
+            let task = MLMultiArray.from([taskToken == tokenizer.specialTokens.transcribeToken ? 0 : 1])
             let lang = MLMultiArray.from([languageToken])
             guard let prefillOutput = try await self.prefillKVCache(withTask: task, andLanguage: lang) else {
                 Logging.error("Unable to prefill cache")
@@ -237,8 +238,9 @@ public class TextDecoderContextPrefill: WhisperMLModel {
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public class TextDecoder: TextDecoding, WhisperMLModel {
     public var model: MLModel?
-    public var tokenizer: Tokenizer?
+    public var tokenizer: WhisperTokenizer?
     public var prefillData: WhisperMLModel?
+    public var isModelMultilingual: Bool = false
 
     public var logitsSize: Int? {
         return getModelOutputDimention(model, named: "logits", position: 2)
@@ -343,7 +345,7 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
         if options.suppressBlank {
             logitsFilters.append(
                 SuppressBlankFilter(
-                    suppressBlankTokens: [tokenizer.whitespaceToken, tokenizer.endToken],
+                    specialTokens: tokenizer.specialTokens,
                     sampleBegin: prefilledIndex
                 )
             )
@@ -362,14 +364,10 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
                 }
             logitsFilters.append(
                 TimestampRulesFilter(
-                    transcribeToken: tokenizer.transcribeToken,
-                    translateToken: tokenizer.translateToken,
-                    noTimestampsToken: tokenizer.noTimestampsToken,
-                    timeTokenBegin: tokenizer.timeTokenBegin,
-                    endToken: tokenizer.endToken,
+                    specialTokens: tokenizer.specialTokens,
                     sampleBegin: intialPromptIndex,
                     maxInitialTimestampIndex: maxInitialTimestampIndex,
-                    isModelMultilingual: isModelMultilingual(logitsDim: logitsSize)
+                    isModelMultilingual: isModelMultilingual
                 )
             )
         }
@@ -539,7 +537,7 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             tokenProbs.append([token: segmentLogProbs[index]])
         }
 
-        let wordTokens = segmentTokens.filter { $0 < tokenizer.specialTokenBegin }
+        let wordTokens = segmentTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         let compressionRatio = compressionRatio(of: wordTokens)
 
         var temperature = options.temperature

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -287,10 +287,15 @@ func loadTokenizer(
     for pretrained: ModelVariant,
     tokenizerFolder: URL? = nil,
     useBackgroundSession: Bool = false
-) async throws -> Tokenizer {
+) async throws -> WhisperTokenizer {
     let tokenizerName = tokenizerNameForVariant(pretrained)
     let hubApi = HubApi(downloadBase: tokenizerFolder, useBackgroundSession: useBackgroundSession)
-    return try await AutoTokenizer.from(pretrained: tokenizerName, hubApi: hubApi)
+    return try await WhisperTokenizerWrapper(
+        tokenizer: AutoTokenizer.from(
+            pretrained: tokenizerName,
+            hubApi: hubApi
+        )
+    )
 }
 
 func formatTimestamp(_ timestamp: Float) -> String {

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -443,7 +443,7 @@ public class WhisperKit: Transcriber {
         let prefillStartTime = CFAbsoluteTimeGetCurrent()
         var prefilledCacheSize = 0
         if options.usePrefillPrompt {
-            guard let prefilledInputs = try? await textDecoder.prefillDecoderInputs(decoderInputs, withOptions: options, multilingual: modelVariant.isMultilingual) else {
+            guard let prefilledInputs = try? await textDecoder.prefillDecoderInputs(decoderInputs, withOptions: options) else {
                 throw WhisperError.prefillFailed()
             }
             decoderInputs = prefilledInputs

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -7,29 +7,33 @@ import XCTest
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 final class FunctionalTests: XCTestCase {
-    func testInitLarge() async {
-        let modelPath = largev3ModelPath()
-        let whisperKit = try? await WhisperKit(modelFolder: modelPath, logLevel: .error)
-        XCTAssertNotNil(whisperKit)
+    func testInitLarge() async throws {
+        try await XCTAssertNoThrowAsync(
+            await WhisperKit(modelFolder: largev3ModelPath(), logLevel: .error)
+        )
     }
 
     func testOutputAll() async throws {
-        let modelPaths = allModelPaths()
+        let modelPaths = try allModelPaths()
 
         for modelPath in modelPaths {
             let modelName = modelPath.split(separator: "/").last!
             print("[Integration] Testing model \(modelName)")
-            guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-                XCTFail("Audio file not found")
-                return
-            }
+            let audioFilePath = try XCTUnwrap(
+                Bundle.module.path(forResource: "jfk", ofType: "wav"),
+                "Audio file not found"
+            )
 
-            let whisperKit = try await WhisperKit(modelFolder: modelPath, verbose: true, logLevel: .debug)
+            let whisperKit = try await WhisperKit(
+                modelFolder: modelPath,
+                verbose: true,
+                logLevel: .debug
+            )
 
-            guard let transcriptionResult = try await whisperKit.transcribe(audioPath: audioFilePath) else {
-                XCTFail("Transcription failed")
-                return
-            }
+            let transcriptionResult = try await XCTUnwrapAsync(
+                await whisperKit.transcribe(audioPath: audioFilePath),
+                "Transcription failed"
+            )
 
             print("[Integration] \(transcriptionResult.text)")
             XCTAssertEqual(
@@ -41,27 +45,27 @@ final class FunctionalTests: XCTestCase {
     }
 
     func testRealTimeFactorTiny() async throws {
-        let modelPath = tinyModelPath()
+        let modelPath = try tinyModelPath()
 
         let metrics: [XCTMetric] = [XCTMemoryMetric(), XCTStorageMetric(), XCTClockMetric()]
 
         let measureOptions = XCTMeasureOptions.default
         measureOptions.iterationCount = 5
 
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
 
         let whisperKit = try await WhisperKit(modelFolder: modelPath)
 
         measure(metrics: metrics, options: measureOptions) {
             let dispatchSemaphore = DispatchSemaphore(value: 0)
             Task {
-                guard let transcriptionResult = try await whisperKit.transcribe(audioPath: audioFilePath) else {
-                    XCTFail("Transcription failed")
-                    return
-                }
+                let transcriptionResult = try await XCTUnwrapAsync(
+                    await whisperKit.transcribe(audioPath: audioFilePath),
+                    "Transcription failed"
+                )
                 XCTAssertGreaterThan(transcriptionResult.text.count, 0)
                 dispatchSemaphore.signal()
             }
@@ -70,27 +74,27 @@ final class FunctionalTests: XCTestCase {
     }
 
     func testRealTimeFactorLarge() async throws {
-        let modelPath = largev3ModelPath()
+        let modelPath = try largev3ModelPath()
 
         let metrics: [XCTMetric] = [XCTMemoryMetric(), XCTStorageMetric(), XCTClockMetric()]
 
         let measureOptions = XCTMeasureOptions.default
         measureOptions.iterationCount = 5
 
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
 
         let whisperKit = try await WhisperKit(modelFolder: modelPath, verbose: false)
 
         measure(metrics: metrics, options: measureOptions) {
             let dispatchSemaphore = DispatchSemaphore(value: 0)
             Task {
-                guard let transcriptionResult = try await whisperKit.transcribe(audioPath: audioFilePath) else {
-                    XCTFail("Transcription failed")
-                    return
-                }
+                let transcriptionResult = try await XCTUnwrapAsync(
+                    await whisperKit.transcribe(audioPath: audioFilePath),
+                    "Transcription failed"
+                )
                 XCTAssertGreaterThan(transcriptionResult.text.count, 0)
                 dispatchSemaphore.signal()
             }
@@ -98,44 +102,38 @@ final class FunctionalTests: XCTestCase {
         }
     }
 
-    func testBaseImplementation() {
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+    func testBaseImplementation() throws {
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
 
         let dispatchSemaphore = DispatchSemaphore(value: 0)
 
         Task {
-            let pipe = try? await WhisperKit(model: "large-v3")
-            let transcription = try? await pipe!.transcribe(audioPath: audioFilePath)?.text
-            XCTAssertGreaterThan(transcription!.count, 0)
+            let whisperKit = try await XCTUnwrapAsync(await WhisperKit(model: "large-v3"))
+            let transcriptionResult = try await XCTUnwrapAsync(
+                await whisperKit.transcribe(audioPath: audioFilePath),
+                "Transcription failed"
+            )
+            XCTAssertGreaterThan(transcriptionResult.text.count, 0)
             dispatchSemaphore.signal()
         }
 
         dispatchSemaphore.wait()
     }
 
-    func testAsyncImplementation() async {
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+    func testAsyncImplementation() async throws {
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
+        let whisperKit = try await WhisperKit(model: "large-v3")
+        let transcriptionResult = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioPath: audioFilePath),
+            "Transcription failed"
+        )
 
-        let pipe = try? await WhisperKit(model: "large-v3")
-        let transcription = try? await pipe!.transcribe(audioPath: audioFilePath)?.text
-        XCTAssertGreaterThan(transcription!.count, 0)
-    }
-
-    func testAsyncThrowingImplementation() async throws {
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
-
-        let pipe = try await WhisperKit(model: "large-v3")
-        let transcription = try await pipe.transcribe(audioPath: audioFilePath)?.text
-
-        XCTAssertGreaterThan(transcription!.count, 0)
+        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
     }
 }

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -1,0 +1,252 @@
+import CoreML
+import Foundation
+@testable import WhisperKit
+import XCTest
+
+enum TestError: Error {
+    case missingFile(String)
+    case missingDirectory(String)
+}
+
+@discardableResult
+func XCTUnwrapAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async throws -> T {
+    let evaluated = try? await expression()
+    return try XCTUnwrap(evaluated, message(), file: file, line: line)
+}
+
+@discardableResult
+func XCTUnwrapAsync<T>(
+    _ expression: @autoclosure () async throws -> T?,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async throws -> T {
+    let evaluated = try? await expression()
+    return try XCTUnwrap(evaluated, message(), file: file, line: line)
+}
+
+func XCTAssertNoThrowAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+    } catch {
+        XCTFail(message(), file: file, line: line)
+    }
+}
+
+func XCTAssertNoThrowAsync<T>(
+    _ expression: @autoclosure () async throws -> T?,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+    } catch {
+        XCTFail(message(), file: file, line: line)
+    }
+}
+
+func XCTAssertNoThrowAsync(
+    _ expression: @autoclosure () async throws -> Void,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await expression()
+    } catch {
+        XCTFail(message(), file: file, line: line)
+    }
+}
+
+// MARK: Helpers
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+extension MLMultiArray {
+    /// Create `MLMultiArray` of shape [1, 1, arr.count] and fill up the last
+    /// dimension with with values from arr.
+    static func logits(_ arr: [FloatType]) throws -> MLMultiArray {
+        let logits = try MLMultiArray(shape: [1, 1, arr.count] as [NSNumber], dataType: .float16)
+        let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(logits.dataPointer))
+        for (index, value) in arr.enumerated() {
+            let linearOffset = logits.linearOffset(for: [0, 0, index as NSNumber])
+            ptr[linearOffset] = value
+        }
+        return logits
+    }
+
+    /// Get the data from `MLMultiArray` for given dimension
+    func data(for dimension: Int) -> [FloatType] {
+        let count = shape[dimension].intValue
+        let indexes = stride(from: 0, to: count, by: 1).map { [0, 0, $0 as NSNumber] }
+        var result = [FloatType]()
+        let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(dataPointer))
+        for index in indexes {
+            let linearOffset = linearOffset(for: index as [NSNumber])
+            result.append(ptr[linearOffset])
+        }
+        return result
+    }
+}
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+extension XCTestCase {
+    func transcribe(
+        with variant: ModelVariant,
+        options: DecodingOptions,
+        audioFile: String = "jfk.wav",
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws -> TranscriptionResult? {
+        let modelPath: String
+        switch variant {
+            case .largev3:
+                modelPath = try largev3ModelPath()
+            default:
+                modelPath = try tinyModelPath()
+        }
+        let computeOptions = ModelComputeOptions(
+            melCompute: .cpuOnly,
+            audioEncoderCompute: .cpuOnly,
+            textDecoderCompute: .cpuOnly,
+            prefillCompute: .cpuOnly
+        )
+        let whisperKit = try await WhisperKit(modelFolder: modelPath, computeOptions: computeOptions, verbose: true, logLevel: .debug)
+        trackForMemoryLeaks(on: whisperKit, file: file, line: line)
+
+        let audioComponents = audioFile.components(separatedBy: ".")
+        guard let audioFileURL = Bundle.module.path(forResource: audioComponents.first, ofType: audioComponents.last) else {
+            throw TestError.missingFile("Missing audio file")
+        }
+        return try await whisperKit.transcribe(audioPath: audioFileURL, decodeOptions: options)
+    }
+
+    func tinyModelPath() throws -> String {
+        let modelDir = "whisperkit-coreml/openai_whisper-tiny"
+        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
+            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
+        }
+        return modelPath
+    }
+
+    func largev3ModelPath() throws -> String {
+        let modelDir = "whisperkit-coreml/openai_whisper-large-v3" // use faster to compile model for tests
+        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
+            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
+        }
+        return modelPath
+    }
+
+    func largev3TurboModelPath() throws -> String {
+        let modelDir = "whisperkit-coreml/openai_whisper-large-v3_turbo"
+        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
+            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
+        }
+        return modelPath
+    }
+
+    func allModelPaths() throws -> [String] {
+        let fileManager = FileManager.default
+        var modelPaths: [String] = []
+        let directory = "whisperkit-coreml"
+        let resourceKeys: [URLResourceKey] = [.isDirectoryKey]
+        guard let baseurl = Bundle.module.resourceURL?.appendingPathComponent(directory) else {
+            throw TestError.missingDirectory("Base URL for directory \(directory) not found.")
+        }
+        let directoryContents = try fileManager.contentsOfDirectory(at: baseurl, includingPropertiesForKeys: resourceKeys, options: .skipsHiddenFiles)
+        for folderURL in directoryContents {
+            let resourceValues = try folderURL.resourceValues(forKeys: Set(resourceKeys))
+            if resourceValues.isDirectory == true {
+                // Check if the directory contains actual data files, or if it contains pointer files.
+                // As a proxy, use the MelSpectrogramc.mlmodel/coredata.bin file.
+                let proxyFileToCheck = folderURL.appendingPathComponent("MelSpectrogram.mlmodelc/coremldata.bin")
+                if try isGitLFSPointerFile(url: proxyFileToCheck) {
+                    continue
+                }
+                
+                // Check if the directory name contains the quantization pattern
+                // Only test large quantized models
+                let dirName = folderURL.lastPathComponent
+                if !(dirName.contains("q") && !dirName.contains("large")) {
+                    modelPaths.append(folderURL.absoluteString)
+                }
+            }
+        }
+        return modelPaths
+    }
+    
+    // Function to check if the beginning of the file matches a Git LFS pointer pattern
+    func isGitLFSPointerFile(url: URL) throws -> Bool {
+        let fileHandle = try FileHandle(forReadingFrom: url)
+        // Read the first few bytes of the file to get enough for the Git LFS pointer signature
+        let data = fileHandle.readData(ofLength: 512) // Read first 512 bytes
+        fileHandle.closeFile()
+        if let string = String(data: data, encoding: .utf8),
+           string.starts(with: "version https://git-lfs.github.com/") {
+            return true
+        }
+        return false
+    }
+
+    func trackForMemoryLeaks(on instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+        addTeardownBlock { [weak instance] in
+            XCTAssertNil(instance, "Detected potential memory leak", file: file, line: line)
+        }
+    }
+}
+
+extension String {
+    var normalized: String {
+        // Trim whitespace and newlines
+        let trimmedString = self.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Convert to lowercase
+        let lowercaseString = trimmedString.lowercased()
+
+        // Remove punctuation
+        let noPunctuationString = lowercaseString.components(separatedBy: .punctuationCharacters).joined()
+
+        // Replace multiple spaces with a single space
+        let singleSpacedString = noPunctuationString.replacingOccurrences(of: " +", with: " ", options: .regularExpression)
+
+        return singleSpacedString
+    }
+}
+
+extension SpecialTokens {
+    static func `default`(
+        endToken: Int = 0,
+        englishToken: Int = 0,
+        noSpeechToken: Int = 0,
+        noTimestampsToken: Int = 0,
+        specialTokenBegin: Int = 0,
+        startOfTranscriptToken: Int = 0,
+        timeTokenBegin: Int = 0,
+        transcribeToken: Int = 0,
+        translateToken: Int = 0,
+        whitespaceToken: Int = 0
+    ) -> SpecialTokens {
+        SpecialTokens.init(
+            endToken: endToken,
+            englishToken: englishToken,
+            noSpeechToken: noSpeechToken,
+            noTimestampsToken: noTimestampsToken,
+            specialTokenBegin: specialTokenBegin,
+            startOfTranscriptToken: startOfTranscriptToken,
+            timeTokenBegin: timeTokenBegin,
+            transcribeToken: transcribeToken,
+            translateToken: translateToken,
+            whitespaceToken: whitespaceToken
+        )
+    }
+}

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -236,7 +236,7 @@ extension SpecialTokens {
         translateToken: Int = 0,
         whitespaceToken: Int = 0
     ) -> SpecialTokens {
-        SpecialTokens.init(
+        SpecialTokens(
             endToken: endToken,
             englishToken: englishToken,
             noSpeechToken: noSpeechToken,

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -10,26 +10,30 @@ import XCTest
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 final class UnitTests: XCTestCase {
-    func testInit() async {
-        let whisperKit = try? await WhisperKit(prewarm: false, load: false, download: false)
-        XCTAssertNotNil(whisperKit)
-    }
 
     // MARK: - Model Loading Test
+    
+    func testInit() async throws {
+        try await XCTUnwrapAsync(
+            await WhisperKit(prewarm: false, load: false, download: false),
+            "Failed to init WhisperKit"
+        )
+    }
 
-    func testInitTiny() async {
-        let modelPath = tinyModelPath()
-        let whisperKit = try? await WhisperKit(modelFolder: modelPath, logLevel: .error)
-        XCTAssertNotNil(whisperKit)
+    func testInitTiny() async throws {
+        try await XCTUnwrapAsync(
+            await WhisperKit(modelFolder: tinyModelPath(), logLevel: .error),
+            "Failed to init WhisperKit"
+        )
     }
 
     // MARK: - Audio Tests
 
-    func testAudioFileLoading() {
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+    func testAudioFileLoading() throws {
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
         let audioBuffer = AudioProcessor.loadAudio(fromPath: audioFilePath)
         XCTAssertNotNil(audioBuffer, "Failed to load audio file at path: \(audioFilePath)")
         XCTAssertEqual(audioBuffer!.format.sampleRate, 16000)
@@ -50,16 +54,20 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(paddedSamples?.count, 1600, "Padded or trimmed samples count is not as expected")
     }
 
-    func testAudioResample() {
-        guard let audioFileURL = Bundle.module.url(forResource: "jfk", withExtension: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
-        let audioFile = try? AVAudioFile(forReading: audioFileURL)
+    func testAudioResample() throws {
+        let audioFileURL = try XCTUnwrap(
+            Bundle.module.url(forResource: "jfk", withExtension: "wav"),
+            "Audio file not found"
+        )
+        let audioFile = try AVAudioFile(forReading: audioFileURL)
 
         let targetSampleRate = 44100.0
         let targetChannelCount: AVAudioChannelCount = 2
-        let resampledAudio = AudioProcessor.resampleAudio(fromFile: audioFile!, toSampleRate: targetSampleRate, channelCount: 2)
+        let resampledAudio = AudioProcessor.resampleAudio(
+            fromFile: audioFile,
+            toSampleRate: targetSampleRate,
+            channelCount: 2
+        )
         XCTAssertNotNil(resampledAudio, "Failed to resample audio")
         XCTAssertEqual(resampledAudio?.format.sampleRate, targetSampleRate, "Resampled audio sample rate is not as expected")
         XCTAssertEqual(resampledAudio?.format.channelCount, targetChannelCount, "Resampled audio channels is not as expected")
@@ -82,19 +90,19 @@ final class UnitTests: XCTestCase {
 
     // MARK: - Feature Extractor Tests
 
-    func testLogmelOutput() async {
+    func testLogmelOutput() async throws {
         let audioSamples = [Float](repeating: 0.0, count: 16000)
-        guard let paddedSamples = AudioProcessor.padOrTrimAudio(fromArray: audioSamples, startAt: 0, toLength: 480_000) else {
-            XCTFail("Failed to pad audio samples")
-            return
-        }
+        let paddedSamples = try XCTUnwrap(
+            AudioProcessor.padOrTrimAudio(fromArray: audioSamples, startAt: 0, toLength: 480_000),
+            "Failed to pad audio samples"
+        )
         var featureExtractor = FeatureExtractor()
-        let modelPath = URL(filePath: tinyModelPath()).appending(path: "MelSpectrogram.mlmodelc")
-        try? await featureExtractor.loadModel(at: modelPath, computeUnits: ModelComputeOptions().melCompute)
-        guard let melSpectrogram = try? await featureExtractor.logMelSpectrogram(fromAudio: paddedSamples) else {
-            XCTFail("Failed to produce Mel spectrogram from audio samples")
-            return
-        }
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "MelSpectrogram.mlmodelc")
+        try await featureExtractor.loadModel(at: modelPath, computeUnits: ModelComputeOptions().melCompute)
+        let melSpectrogram = try await XCTUnwrapAsync(
+            await featureExtractor.logMelSpectrogram(fromAudio: paddedSamples),
+            "Failed to produce Mel spectrogram from audio samples"
+        )
         let expectedShape: [NSNumber] = [1, 80, 1, 3000]
         XCTAssertNotNil(melSpectrogram, "Failed to produce Mel spectrogram from audio samples")
         XCTAssertEqual(melSpectrogram.shape, expectedShape, "Mel spectrogram shape is not as expected")
@@ -126,67 +134,73 @@ final class UnitTests: XCTestCase {
 
     // MARK: - Encoder Tests
 
-    func testEncoderOutput() async {
+    func testEncoderOutput() async throws {
         var audioEncoder = AudioEncoder()
-        let modelPath = URL(filePath: tinyModelPath()).appending(path: "AudioEncoder.mlmodelc")
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "AudioEncoder.mlmodelc")
         try? await audioEncoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().audioEncoderCompute)
 
-        let encoderInput = try! MLMultiArray(shape: [1, 80, 1, 3000], dataType: .float16)
+        let encoderInput = try MLMultiArray(shape: [1, 80, 1, 3000], dataType: .float16)
         let expectedShape: [NSNumber] = [1, 384, 1, 1500]
 
-        let encoderOutput = try? await audioEncoder.encodeFeatures(encoderInput)
+        let encoderOutput = try await audioEncoder.encodeFeatures(encoderInput)
         XCTAssertNotNil(encoderOutput, "Failed to encode features")
         XCTAssertEqual(encoderOutput?.shape, expectedShape, "Encoder output shape is not as expected")
     }
 
     // MARK: - Decoder Tests
 
-    func testDecoderOutput() async {
+    func testDecoderOutput() async throws {
         var textDecoder = TextDecoder()
         let decodingOptions = DecodingOptions()
-        let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
-        do {
-            try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
-            textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
-        } catch {
-            XCTFail("Failed to load the model/tokenizer \(error)")
-            return
-        }
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        await XCTAssertNoThrowAsync(
+            try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute),
+            "Failed to load the model"
+        )
+        textDecoder.tokenizer = try await XCTUnwrapAsync(
+            await loadTokenizer(for: .tiny),
+            "Failed to load the tokenizer"
+        )
 
-        let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
+        let tokenSampler = GreedyTokenSampler(
+            temperature: 0,
+            eotToken: textDecoder.tokenizer!.specialTokens.endToken,
+            decodingOptions: decodingOptions
+        )
 
-        let encoderInput = try! MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
-        let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
+        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let inputs = try XCTUnwrap(
+            textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.specialTokens.startOfTranscriptToken]),
+            "Failed to prepare decoder inputs"
+        )
         let expectedShape = 1
 
-        guard let inputs = decoderInputs else {
-            XCTFail("Failed to prepare decoder inputs")
-            return
-        }
-
-        let decoderOutput = try! await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
+        let decoderOutput = try await textDecoder.decodeText(
+            from: encoderInput,
+            using: inputs,
+            sampler: tokenSampler,
+            options: decodingOptions
+        )
         XCTAssertNotNil(decoderOutput, "Failed to decode text")
         XCTAssertEqual(decoderOutput.count, expectedShape, "Decoder output shape is not as expected")
     }
 
     // MARK: - Tokenizer Tests
 
-    func testDecoderTokenizer() async {
+    func testDecoderTokenizer() async throws {
         // This token index does not change with v3
         let tokenText = "<|startoftranscript|>"
 
         let textDecoder = TextDecoder()
-        textDecoder.tokenizer = try! await loadTokenizer(for: .tiny)
-        let encodedToken = textDecoder.tokenizer!.convertTokenToId(tokenText)!
-        let decodedToken = textDecoder.tokenizer!.decode(tokens: [encodedToken])
+        textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
+        let encodedToken = try XCTUnwrap(textDecoder.tokenizer?.convertTokenToId(tokenText))
+        let decodedToken = try XCTUnwrap(textDecoder.tokenizer?.decode(tokens: [encodedToken]))
 
-        textDecoder.tokenizer = try! await loadTokenizer(for: .largev3)
-        let encodedTokenLarge = textDecoder.tokenizer!.convertTokenToId(tokenText)!
-        let decodedTokenLarge = textDecoder.tokenizer?.decode(tokens: [encodedTokenLarge])
+        textDecoder.tokenizer = try await loadTokenizer(for: .largev3)
+        let encodedTokenLarge = try XCTUnwrap(textDecoder.tokenizer?.convertTokenToId(tokenText))
+        let decodedTokenLarge = try XCTUnwrap(textDecoder.tokenizer?.decode(tokens: [encodedTokenLarge]))
 
         // Test successful tokenizing
-        XCTAssertNotNil(decodedToken)
-        XCTAssertNotNil(decodedTokenLarge)
         XCTAssertEqual(tokenText, decodedToken)
         XCTAssertEqual(tokenText, decodedTokenLarge)
         XCTAssertEqual(decodedToken, decodedTokenLarge)
@@ -197,17 +211,15 @@ final class UnitTests: XCTestCase {
         // This token index changes with v3
         let tokenTextShifted = "<|0.00|>"
 
-        textDecoder.tokenizer = try? await loadTokenizer(for: .tiny)
-        let encodedTokenShifted = textDecoder.tokenizer!.convertTokenToId(tokenTextShifted)!
-        let decodedTokenShifted = textDecoder.tokenizer?.decode(tokens: [encodedTokenShifted])
+        textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
+        let encodedTokenShifted = try XCTUnwrap(textDecoder.tokenizer?.convertTokenToId(tokenTextShifted))
+        let decodedTokenShifted = try XCTUnwrap(textDecoder.tokenizer?.decode(tokens: [encodedTokenShifted]))
 
-        textDecoder.tokenizer = try? await loadTokenizer(for: .largev3)
-        let encodedTokenLargeShifted = textDecoder.tokenizer!.convertTokenToId(tokenTextShifted)!
-        let decodedTokenLargeShifted = textDecoder.tokenizer?.decode(tokens: [encodedTokenLargeShifted])
+        textDecoder.tokenizer = try await loadTokenizer(for: .largev3)
+        let encodedTokenLargeShifted = try XCTUnwrap(textDecoder.tokenizer?.convertTokenToId(tokenTextShifted))
+        let decodedTokenLargeShifted = try XCTUnwrap(textDecoder.tokenizer?.decode(tokens: [encodedTokenLargeShifted]))
 
         // Test success tokenizing
-        XCTAssertNotNil(decodedTokenShifted)
-        XCTAssertNotNil(decodedTokenLargeShifted)
         XCTAssertEqual(tokenTextShifted, decodedTokenShifted)
         XCTAssertEqual(tokenTextShifted, decodedTokenLargeShifted)
 
@@ -215,31 +227,35 @@ final class UnitTests: XCTestCase {
         XCTAssertNotEqual(encodedTokenShifted, encodedTokenLargeShifted)
     }
 
-    func testTokenizerOutput() async {
+    func testTokenizerOutput() async throws {
         let tokenInputs = [50364, 400, 370, 452, 7177, 6280, 1029, 406, 437, 428, 1941, 393, 360, 337, 291, 1029, 437, 291, 393, 360, 337, 428, 1941, 13, 50889]
 
-        let tokenizer = try? await loadTokenizer(for: .largev3)
-
-        let decodedText = tokenizer!.decode(tokens: tokenInputs)
+        let tokenizer = try await loadTokenizer(for: .largev3)
+        let decodedText = tokenizer.decode(tokens: tokenInputs)
 
         XCTAssertNotNil(decodedText)
         XCTAssertEqual(decodedText, "<|notimestamps|> And so my fellow Americans ask not what your country can do for you ask what you can do for your country.<|10.48|>")
     }
 
-    func testWindowing() async {
+    func testWindowing() async throws {
         let computeOptions = ModelComputeOptions(
             melCompute: .cpuOnly
         )
-        let whisperKit = try? await WhisperKit(modelFolder: tinyModelPath(), computeOptions: computeOptions, verbose: true, logLevel: .debug)
+        let whisperKit = try await WhisperKit(
+            modelFolder: tinyModelPath(),
+            computeOptions: computeOptions,
+            verbose: true,
+            logLevel: .debug
+        )
 
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
-        guard let audioBuffer = AudioProcessor.loadAudio(fromPath: audioFilePath) else {
-            XCTFail("Failed to load audio buffer")
-            return
-        }
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
+        let audioBuffer = try XCTUnwrap(
+            AudioProcessor.loadAudio(fromPath: audioFilePath),
+            "Failed to load audio buffer"
+        )
 
         let audioSamples = AudioProcessor.convertBufferToArray(buffer: audioBuffer)
         let silence = [Float](repeating: 0.0, count: 30 * 16000)
@@ -247,25 +263,26 @@ final class UnitTests: XCTestCase {
 
         let options = DecodingOptions(usePrefillPrompt: true, withoutTimestamps: false)
 
-        let result = try? await whisperKit!.transcribe(audioArray: multiWindowSamples, decodeOptions: options)
-        XCTAssertEqual(result?.segments.count, 3, "Expected 3 segments")
+        let transcribeResult = try await whisperKit.transcribe(audioArray: multiWindowSamples, decodeOptions: options)
+        let result = try XCTUnwrap(transcribeResult)
+        XCTAssertEqual(result.segments.count, 3, "Expected 3 segments")
 
         // Compare last timestamp to the length of the audio
-        guard let endTimestamp = result?.segments.last!.end else {
-            XCTFail("Failed to get end time")
-            return
-        }
+        let endTimestamp = try XCTUnwrap(
+            result.segments.last?.end,
+            "Failed to get end time"
+        )
         XCTAssertEqual(endTimestamp, Float(multiWindowSamples.count / 16000), accuracy: 1.0, "Expected last timestamp to be near the length of the audio")
     }
 
-    func testSplitToWordTokens() async {
-        let tokenizer = try? await loadTokenizer(for: .tiny)
+    func testSplitToWordTokens() async throws {
+        let tokenizer = try await loadTokenizer(for: .tiny)
 
         // Hello, world! This is a test, isn't it?
         let tokenIds = [50364, 2425, 11, 1002, 0, 50414, 50414, 639, 307, 257, 220, 31636, 11, 1943, 380, 309, 30, 50257]
-        let originalWords = tokenIds.map { tokenizer!.convertIdToToken($0) }
+        let originalWords = tokenIds.map { tokenizer.convertIdToToken($0) }
 
-        let (words, wordTokens) = tokenizer!.splitToWordTokens(tokenIds: tokenIds)
+        let (words, wordTokens) = tokenizer.splitToWordTokens(tokenIds: tokenIds)
 
         let expectedWords = ["<|0.00|>", " Hello", ",", " world", "!", "<|1.00|>", "<|1.00|>", " This", " is", " a", " test", ",", " isn't", " it", "?", "<|endoftext|>"]
         let expectedWordTokens = [[50364], [2425], [11], [1002], [0], [50414], [50414], [639], [307], [257], [220, 31636], [11], [1943, 380], [309], [30], [50257]]
@@ -275,14 +292,14 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(wordTokens, expectedWordTokens, "Word tokens did not match expected output.")
     }
 
-    func testSplitToWordTokensSpanish() async {
-        let tokenizer = try? await loadTokenizer(for: .tiny)
+    func testSplitToWordTokensSpanish() async throws {
+        let tokenizer = try await loadTokenizer(for: .tiny)
 
         // ¡Hola Mundo! Esta es una prueba, ¿no?
         let tokenIds = [50363, 24364, 48529, 376, 6043, 0, 20547, 785, 2002, 48241, 11, 3841, 1771, 30, 50257]
-        let originalWords = tokenIds.map { tokenizer!.convertIdToToken($0) }
+        let originalWords = tokenIds.map { tokenizer.convertIdToToken($0) }
 
-        let (words, wordTokens) = tokenizer!.splitToWordTokens(tokenIds: tokenIds)
+        let (words, wordTokens) = tokenizer.splitToWordTokens(tokenIds: tokenIds)
 
         let expectedWords = ["<|notimestamps|>", "¡Hola", " Mundo", "!", " Esta", " es", " una", " prueba", ",", " ¿no", "?", "<|endoftext|>"]
         let expectedWordTokens = [[50363], [24364, 48529], [376, 6043], [0], [20547], [785], [2002], [48241], [11], [3841, 1771], [30], [50257]]
@@ -292,14 +309,14 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(wordTokens, expectedWordTokens, "Word tokens did not match expected output.")
     }
 
-    func testSplitToWordTokensJapanese() async {
-        let tokenizer = try? await loadTokenizer(for: .tiny)
+    func testSplitToWordTokensJapanese() async throws {
+        let tokenizer = try await loadTokenizer(for: .tiny)
 
         // こんにちは、世界！これはテストですよね？
         let tokenIds = [50364, 38088, 1231, 24486, 171, 120, 223, 25212, 22985, 40498, 4767, 30346, 171, 120, 253, 50257]
-        let originalWords = tokenIds.map { tokenizer!.convertIdToToken($0) }
+        let originalWords = tokenIds.map { tokenizer.convertIdToToken($0) }
 
-        let (words, wordTokens) = tokenizer!.splitToWordTokens(tokenIds: tokenIds)
+        let (words, wordTokens) = tokenizer.splitToWordTokens(tokenIds: tokenIds)
 
         let expectedWords = ["<|0.00|>", "こんにちは", "、", "世界", "！", "これは", "テ", "スト", "です", "よね", "？", "<|endoftext|>"]
         let expectedWordTokens = [[50364], [38088], [1231], [24486], [171, 120, 223], [25212], [22985], [40498], [4767], [30346], [171, 120, 253], [50257]]
@@ -311,7 +328,7 @@ final class UnitTests: XCTestCase {
 
     // MARK: - Options Tests
 
-    func testSampleLength() async {
+    func testSampleLength() async throws {
         let desiredDecodingLoops = 5
         let targetTokenCount = 7 // Account for the first token and the end of transcript token, which dont require decoding loops
 
@@ -323,125 +340,122 @@ final class UnitTests: XCTestCase {
         ]
 
         for option in options {
-            guard let result = try? await transcribe(with: .tiny, options: option) else {
-                XCTFail("Failed to transcribe")
-                return
-            }
+            let result = try await XCTUnwrapAsync(
+                await transcribe(with: .tiny, options: option),
+                "Failed to transcribe"
+            )
             XCTAssertEqual(result.segments.first?.tokens.count, targetTokenCount)
         }
     }
 
     /// Multilingual Tests
     /// NOTE: These are purely for consistency checks and do not reflect the ground truth translations
-    func testTranslateSpanish() async {
+    func testTranslateSpanish() async throws {
         let targetLanguage = "es"
         let options = DecodingOptions(task: .translate, language: targetLanguage, temperatureFallbackCount: 0)
 
-        guard let result = try? await transcribe(with: .tiny, options: options, audioFile: "es_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options, audioFile: "es_test_clip.wav"),
+            "Failed to transcribe"
+        )
 
         XCTAssertEqual(result.text.split(separator: " ").prefix(2).joined(separator: " "), "This is")
     }
 
-    func testTranscribeSpanish() async {
+    func testTranscribeSpanish() async throws {
         let sourceLanguage = "es"
         let options = DecodingOptions(task: .transcribe, language: sourceLanguage, temperatureFallbackCount: 0)
 
-        guard let result = try? await transcribe(with: .tiny, options: options, audioFile: "es_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options, audioFile: "es_test_clip.wav"),
+            "Failed to transcribe"
+        )
+
         XCTAssertEqual(result.text.split(separator: " ").prefix(4).joined(separator: " "), "Esta es una grabación")
     }
 
-    func testTranslateJapanese() async {
+    func testTranslateJapanese() async throws {
         let targetLanguage = "ja"
         let options = DecodingOptions(task: .translate, language: targetLanguage, temperatureFallbackCount: 0)
 
-        guard let result = try? await transcribe(with: .tiny, options: options, audioFile: "ja_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options, audioFile: "ja_test_clip.wav"),
+            "Failed to transcribe"
+        )
 
         XCTAssertEqual(result.text.split(separator: " ").first, "Tokyo")
     }
 
-    func testTranscribeJapanese() async {
+    func testTranscribeJapanese() async throws {
         let sourceLanguage = "ja"
         let options = DecodingOptions(task: .transcribe, language: sourceLanguage, temperatureFallbackCount: 0)
 
-        guard let result = try? await transcribe(with: .tiny, options: options, audioFile: "ja_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options, audioFile: "ja_test_clip.wav"),
+            "Failed to transcribe"
+        )
+
         XCTAssertEqual(result.text.prefix(3), "東京は")
     }
 
-    func testNoTimestamps() async {
+    func testNoTimestamps() async throws {
         let options = DecodingOptions(withoutTimestamps: true)
 
-        guard let result = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
 
         XCTAssertEqual(result.segments.first?.text.normalized, "<|startoftranscript|><|en|><|transcribe|><|notimestamps|> And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.<|endoftext|>".normalized)
     }
 
-    func testSkipSpecialTokens() async {
+    func testSkipSpecialTokens() async throws {
         let options = DecodingOptions(skipSpecialTokens: true, withoutTimestamps: true)
 
-        guard let result = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
 
         XCTAssertEqual(result.segments.first?.text.normalized, " And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.".normalized)
     }
 
-    func testPrefill() async {
+    func testPrefill() async throws {
         let options = DecodingOptions(usePrefillPrompt: true)
 
-        do {
-            let result = try await transcribe(with: .tiny, options: options)
-            XCTAssertNotNil(result?.text)
-        } catch {
-            XCTFail("Failed to transcribe \(error.localizedDescription)")
-        }
+        try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
     }
 
-    func testNoPrefill() async {
+    func testNoPrefill() async throws {
         let options = DecodingOptions(usePrefillPrompt: false)
 
-        guard let result = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
+
         XCTAssertNotNil(result.text)
     }
 
-    func testSilence() async {
-        let whisperKit = try? await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
-
+    func testSilence() async throws {
+        let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         let audioSamples = [Float](repeating: 0.0, count: 30 * 16000)
-
         let options = DecodingOptions(usePrefillPrompt: false, skipSpecialTokens: false)
 
-        guard let result = try? await whisperKit!.transcribe(audioArray: audioSamples, decodeOptions: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
-        XCTAssertTrue(result.segments.first!.tokens.contains(whisperKit!.tokenizer!.noSpeechToken))
+        let result = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioArray: audioSamples, decodeOptions: options),
+            "Failed to transcribe"
+        )
+        XCTAssertTrue(result.segments.first!.tokens.contains(whisperKit.tokenizer!.specialTokens.noSpeechToken))
     }
 
-    func testTemperatureIncrement() async {
-        let whisperKit = try? await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
-
+    func testTemperatureIncrement() async throws {
+        let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         // Generate random audio samples
         let audioSamples = (0..<(30 * 16000)).map { _ in Float.random(in: -0.5...0.5) }
-
         // Define options with temperature increment settings
         let initialTemperature: Float = 0
         let temperatureIncrement: Float = 0.1
@@ -454,48 +468,43 @@ final class UnitTests: XCTestCase {
         )
 
         // Perform transcription
-        guard let result = try? await whisperKit!.transcribe(audioArray: audioSamples, decodeOptions: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let result = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioArray: audioSamples, decodeOptions: options),
+            "Failed to transcribe"
+        )
 
         let expectedTemperature = initialTemperature + temperatureIncrement * Float(fallbackCount)
         XCTAssertEqual(result.segments.first!.temperature, expectedTemperature, "Temperature was not incremented correctly after fallbacks")
     }
 
-    func testTopK() async {
-        var options = DecodingOptions(temperature: 0.5, topK: 10000)
-
-        guard let result10000 = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
-
-        options = DecodingOptions(temperature: 0.5)
-
-        guard let result5 = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+    func testTopK() async throws {
+        let result10000 = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: DecodingOptions(temperature: 0.5, topK: 10000)),
+            "Failed to transcribe"
+        )
+        let result5 = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: DecodingOptions(temperature: 0.5)),
+            "Failed to transcribe"
+        )
 
         XCTAssertLessThan(Float(result5.timings!.decodingSampling), Float(result10000.timings!.decodingSampling), "topK=5 should be faster than topK=10000")
     }
 
-    func testSeekClips() async {
+    func testSeekClips() async throws {
         var options = DecodingOptions(withoutTimestamps: true, clipTimestamps: [0])
 
-        guard let resultFull = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let resultFull = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
 
         let seekTime: Float = 3.0
         options = DecodingOptions(withoutTimestamps: true, clipTimestamps: [seekTime])
 
-        guard let resultSeek = try? await transcribe(with: .tiny, options: options) else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let resultSeek = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
 
         XCTAssertNotEqual(resultFull.text, resultSeek.text)
         XCTAssertTrue(resultFull.text.normalized.contains(resultSeek.text.normalized), "Seeking should be a subset of the full clip")
@@ -546,27 +555,34 @@ final class UnitTests: XCTestCase {
     }
 
     func testSuppressBlankFilter() throws {
-        let tokensFilter1 = SuppressBlankFilter(suppressBlankTokens: [], sampleBegin: 0)
-        let logits1 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
-        let result1 = tokensFilter1.filterLogits(logits1, withTokens: [])
-        XCTAssertEqual(result1.data(for: 2), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
-
-        let tokensFilter2 = SuppressBlankFilter(suppressBlankTokens: [0], sampleBegin: 0)
+        let tokensFilter2 = SuppressBlankFilter(
+            specialTokens: .default(),
+            sampleBegin: 0
+        )
         let logits2 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result2 = tokensFilter2.filterLogits(logits2, withTokens: [])
         XCTAssertEqual(result2.data(for: 2), [-.infinity, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
 
-        let tokensFilter3 = SuppressBlankFilter(suppressBlankTokens: [0, 2, 6], sampleBegin: 0)
+        let tokensFilter3 = SuppressBlankFilter(
+            specialTokens: .default(endToken: 0, whitespaceToken: 2),
+            sampleBegin: 0
+        )
         let logits3 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result3 = tokensFilter3.filterLogits(logits3, withTokens: [])
-        XCTAssertEqual(result3.data(for: 2), [-.infinity, 0.2, -.infinity, 0.4, 0.5, 0.6, -.infinity])
+        XCTAssertEqual(result3.data(for: 2), [-.infinity, 0.2, -.infinity, 0.4, 0.5, 0.6, 0.7])
 
-        let tokensFilter4 = SuppressBlankFilter(suppressBlankTokens: [0, 2, 6], sampleBegin: 3)
+        let tokensFilter4 = SuppressBlankFilter(
+            specialTokens: .default(endToken: 0, whitespaceToken: 2),
+            sampleBegin: 3
+        )
         let logits4 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result4 = tokensFilter4.filterLogits(logits4, withTokens: [1, 2, 3])
-        XCTAssertEqual(result4.data(for: 2), [-.infinity, 0.2, -.infinity, 0.4, 0.5, 0.6, -.infinity])
+        XCTAssertEqual(result4.data(for: 2), [-.infinity, 0.2, -.infinity, 0.4, 0.5, 0.6, 0.7])
 
-        let tokensFilter5 = SuppressBlankFilter(suppressBlankTokens: [0, 2, 6], sampleBegin: 5)
+        let tokensFilter5 = SuppressBlankFilter(
+            specialTokens: .default(endToken: 0, whitespaceToken: 2),
+            sampleBegin: 5
+        )
         let logits5 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result5 = tokensFilter5.filterLogits(logits5, withTokens: [1, 2, 3])
         XCTAssertEqual(result5.data(for: 2), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
@@ -575,11 +591,13 @@ final class UnitTests: XCTestCase {
     func testTimestampRulesFilter() throws {
         // NOTE: for non-multilingual models we supress tokens immediately
         let tokensFilter1 = TimestampRulesFilter(
-            transcribeToken: 100,
-            translateToken: 101,
-            noTimestampsToken: 2,
-            timeTokenBegin: 4,
-            endToken: 3,
+            specialTokens: .default(
+                endToken: 3,
+                noTimestampsToken: 2,
+                timeTokenBegin: 4,
+                transcribeToken: 100,
+                translateToken: 101
+            ),
             sampleBegin: 2,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: false
@@ -589,11 +607,13 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, 0.2])
 
         let tokensFilter2 = TimestampRulesFilter(
-            transcribeToken: 100,
-            translateToken: 101,
-            noTimestampsToken: 2,
-            timeTokenBegin: 4,
-            endToken: 3,
+            specialTokens: .default(
+                endToken: 3,
+                noTimestampsToken: 2,
+                timeTokenBegin: 4,
+                transcribeToken: 100,
+                translateToken: 101
+            ),
             sampleBegin: 2,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: false
@@ -606,11 +626,13 @@ final class UnitTests: XCTestCase {
     func testTimestampRulesFilterMultilingual() throws {
         // NOTE: for multilingual models we supress tokens only after transcribe or translate token
         let tokensFilter1 = TimestampRulesFilter(
-            transcribeToken: 100,
-            translateToken: 101,
-            noTimestampsToken: 2,
-            timeTokenBegin: 4,
-            endToken: 3,
+            specialTokens: .default(
+                endToken: 3,
+                noTimestampsToken: 2,
+                timeTokenBegin: 4,
+                transcribeToken: 100,
+                translateToken: 101
+            ),
             sampleBegin: 2,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: true
@@ -620,11 +642,13 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2])
         
         let tokensFilter2 = TimestampRulesFilter(
-            transcribeToken: 100,
-            translateToken: 101,
-            noTimestampsToken: 2,
-            timeTokenBegin: 4,
-            endToken: 3,
+            specialTokens: .default(
+                endToken: 3,
+                noTimestampsToken: 2,
+                timeTokenBegin: 4,
+                transcribeToken: 100,
+                translateToken: 101
+            ),
             sampleBegin: 2,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: true
@@ -634,11 +658,13 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(result2.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, 0.2])
 
         let tokensFilter3 = TimestampRulesFilter(
-            transcribeToken: 100,
-            translateToken: 101,
-            noTimestampsToken: 2,
-            timeTokenBegin: 4,
-            endToken: 3,
+            specialTokens: .default(
+                endToken: 3,
+                noTimestampsToken: 2,
+                timeTokenBegin: 4,
+                transcribeToken: 100,
+                translateToken: 101
+            ),
             sampleBegin: 2,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: true
@@ -733,12 +759,12 @@ final class UnitTests: XCTestCase {
         }
     }
 
-    func testFindAlignment() async {
+    func testFindAlignment() async throws {
         let numberOfRows: NSNumber = 448
         let numberOfColumns: NSNumber = 1500
 
         // Populate the matrix with some non-linear data
-        let matrix = try! MLMultiArray(shape: [numberOfRows, numberOfColumns], dataType: .float16)
+        let matrix = try MLMultiArray(shape: [numberOfRows, numberOfColumns], dataType: .float16)
         let tokenProbs = Array(repeating: 0.0, count: numberOfRows.intValue).map { _ in Float.random(in: -1..<0) }
         for i in 0..<numberOfRows.intValue {
             for j in 0..<numberOfColumns.intValue {
@@ -746,33 +772,29 @@ final class UnitTests: XCTestCase {
             }
         }
 
-        let tokenizer = try! await loadTokenizer(for: .tiny)
+        let tokenizer = try await loadTokenizer(for: .tiny)
 
         let wordTokenIds = [400, 370, 452, 7177, 6280, 11, 1029, 406, 437, 428, 1941, 393, 360, 337, 291, 11, 1029, 437, 291, 393, 360, 337, 428, 1941, 13]
-        do {
-            let result = try SegmentSeeker().findAlignment(
-                wordTokenIds: wordTokenIds,
-                alignmentWeights: matrix,
-                tokenLogProbs: tokenProbs,
-                tokenizer: tokenizer
-            )
+        let result = try SegmentSeeker().findAlignment(
+            wordTokenIds: wordTokenIds,
+            alignmentWeights: matrix,
+            tokenLogProbs: tokenProbs,
+            tokenizer: tokenizer
+        )
 
-            XCTAssertFalse(result.isEmpty, "Result should not be empty.")
+        XCTAssertFalse(result.isEmpty, "Result should not be empty.")
 
-            var previousEndTime: Float = -1.0
-            for wordTiming in result {
-                XCTAssertFalse(wordTiming.word.isEmpty, "Word should not be empty.")
-                XCTAssertFalse(wordTiming.tokens.isEmpty, "Tokens should not be empty.")
-                XCTAssert(wordTiming.tokens.allSatisfy { $0 >= 0 }, "All token IDs should be non-negative.")
-                XCTAssertLessThanOrEqual(wordTiming.start, wordTiming.end, "Start should be less than or equal to end.")
-                XCTAssertGreaterThanOrEqual(wordTiming.start, previousEndTime, "Start time should not be earlier than the previous end time.")
-                XCTAssertGreaterThanOrEqual(wordTiming.probability, 0.0, "Probability should not be negative.")
-                XCTAssertLessThanOrEqual(wordTiming.probability, 1.0, "Probability should not be greater than 1.")
+        var previousEndTime: Float = -1.0
+        for wordTiming in result {
+            XCTAssertFalse(wordTiming.word.isEmpty, "Word should not be empty.")
+            XCTAssertFalse(wordTiming.tokens.isEmpty, "Tokens should not be empty.")
+            XCTAssert(wordTiming.tokens.allSatisfy { $0 >= 0 }, "All token IDs should be non-negative.")
+            XCTAssertLessThanOrEqual(wordTiming.start, wordTiming.end, "Start should be less than or equal to end.")
+            XCTAssertGreaterThanOrEqual(wordTiming.start, previousEndTime, "Start time should not be earlier than the previous end time.")
+            XCTAssertGreaterThanOrEqual(wordTiming.probability, 0.0, "Probability should not be negative.")
+            XCTAssertLessThanOrEqual(wordTiming.probability, 1.0, "Probability should not be greater than 1.")
 
-                previousEndTime = wordTiming.end
-            }
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+            previousEndTime = wordTiming.end
         }
     }
 
@@ -913,173 +935,5 @@ final class UnitTests: XCTestCase {
             XCTAssertEqual(mergedAlignmentTiming[i].end, expectedWordTimings[i].end, "End time at index \(i) does not match")
             XCTAssertEqual(mergedAlignmentTiming[i].probability, expectedWordTimings[i].probability, "Probability at index \(i) does not match")
         }
-    }
-}
-
-// MARK: Helpers
-
-@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-extension MLMultiArray {
-    /// Create `MLMultiArray` of shape [1, 1, arr.count] and fill up the last
-    /// dimension with with values from arr.
-    static func logits(_ arr: [FloatType]) throws -> MLMultiArray {
-        let logits = try MLMultiArray(shape: [1, 1, arr.count] as [NSNumber], dataType: .float16)
-        let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(logits.dataPointer))
-        for (index, value) in arr.enumerated() {
-            let linearOffset = logits.linearOffset(for: [0, 0, index as NSNumber])
-            ptr[linearOffset] = value
-        }
-        return logits
-    }
-
-    /// Get the data from `MLMultiArray` for given dimension
-    func data(for dimension: Int) -> [FloatType] {
-        let count = shape[dimension].intValue
-        let indexes = stride(from: 0, to: count, by: 1).map { [0, 0, $0 as NSNumber] }
-        var result = [FloatType]()
-        let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(dataPointer))
-        for index in indexes {
-            let linearOffset = linearOffset(for: index as [NSNumber])
-            result.append(ptr[linearOffset])
-        }
-        return result
-    }
-}
-
-@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-extension XCTestCase {
-    func transcribe(with variant: ModelVariant, options: DecodingOptions, audioFile: String = "jfk.wav", file: StaticString = #file, line: UInt = #line) async throws -> TranscriptionResult? {
-        var modelPath = tinyModelPath()
-        switch variant {
-            case .largev3:
-                modelPath = largev3ModelPath()
-            default:
-                modelPath = tinyModelPath()
-        }
-        let computeOptions = ModelComputeOptions(
-            melCompute: .cpuOnly,
-            audioEncoderCompute: .cpuOnly,
-            textDecoderCompute: .cpuOnly,
-            prefillCompute: .cpuOnly
-        )
-        let whisperKit = try await WhisperKit(modelFolder: modelPath, computeOptions: computeOptions, verbose: true, logLevel: .debug)
-        trackForMemoryLeaks(on: whisperKit, file: file, line: line)
-
-        let audioComponents = audioFile.components(separatedBy: ".")
-        guard let audioFileURL = Bundle.module.path(forResource: audioComponents.first, ofType: audioComponents.last) else {
-            return nil
-        }
-
-        let result = try await whisperKit.transcribe(audioPath: audioFileURL, decodeOptions: options)
-        return result
-    }
-
-    func tinyModelPath() -> String {
-        let modelDir = "whisperkit-coreml/openai_whisper-tiny"
-        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
-            print("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
-            return ""
-        }
-        return modelPath
-    }
-
-    func largev3ModelPath() -> String {
-        let modelDir = "whisperkit-coreml/openai_whisper-large-v3" // use faster to compile model for tests
-        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
-            print("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
-            return ""
-        }
-        return modelPath
-    }
-
-    func largev3TurboModelPath() -> String {
-        let modelDir = "whisperkit-coreml/openai_whisper-large-v3_turbo"
-        guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
-            print("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
-            return ""
-        }
-        return modelPath
-    }
-
-    func allModelPaths() -> [String] {
-        let fileManager = FileManager.default
-        var modelPaths: [String] = []
-        let directory = "whisperkit-coreml"
-
-        do {
-            let resourceKeys: [URLResourceKey] = [.isDirectoryKey]
-            guard let baseurl = Bundle.module.resourceURL?.appendingPathComponent(directory) else {
-                print("Base URL for directory \(directory) not found.")
-                return []
-            }
-
-            let directoryContents = try fileManager.contentsOfDirectory(at: baseurl, includingPropertiesForKeys: resourceKeys, options: .skipsHiddenFiles)
-
-            for folderURL in directoryContents {
-                let resourceValues = try folderURL.resourceValues(forKeys: Set(resourceKeys))
-                if resourceValues.isDirectory == true {
-                    // Check if the directory contains actual data files, or if it contains pointer files.
-                    // As a proxy, use the MelSpectrogramc.mlmodel/coredata.bin file.
-                    let proxyFileToCheck = folderURL.appendingPathComponent("MelSpectrogram.mlmodelc/coremldata.bin")
-                    if isGitLFSPointerFile(url: proxyFileToCheck) {
-                        continue
-                    }
-                    
-                    // Check if the directory name contains the quantization pattern
-                    // Only test large quantized models
-                    let dirName = folderURL.lastPathComponent
-                    if !(dirName.contains("q") && !dirName.contains("large")) {
-                        modelPaths.append(folderURL.absoluteString)
-                    }
-                }
-            }
-        } catch {
-            print(error.localizedDescription)
-        }
-
-        return modelPaths
-    }
-    
-    // Function to check if the beginning of the file matches a Git LFS pointer pattern
-    func isGitLFSPointerFile(url: URL) -> Bool {
-        do {
-            let fileHandle = try FileHandle(forReadingFrom: url)
-            // Read the first few bytes of the file to get enough for the Git LFS pointer signature
-            let data = fileHandle.readData(ofLength: 512) // Read first 512 bytes
-            fileHandle.closeFile()
-
-            if let string = String(data: data, encoding: .utf8),
-               string.starts(with: "version https://git-lfs.github.com/") {
-                return true
-            }
-        } catch {
-            fatalError("Failed to read file: \(error)")
-        }
-        
-        return false
-    }
-
-    func trackForMemoryLeaks(on instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
-        addTeardownBlock { [weak instance] in
-            XCTAssertNil(instance, "Detected potential memory leak", file: file, line: line)
-        }
-    }
-}
-
-extension String {
-    var normalized: String {
-        // Trim whitespace and newlines
-        let trimmedString = self.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Convert to lowercase
-        let lowercaseString = trimmedString.lowercased()
-
-        // Remove punctuation
-        let noPunctuationString = lowercaseString.components(separatedBy: .punctuationCharacters).joined()
-
-        // Replace multiple spaces with a single space
-        let singleSpacedString = noPunctuationString.replacingOccurrences(of: " +", with: " ", options: .regularExpression)
-
-        return singleSpacedString
     }
 }


### PR DESCRIPTION
Based on a discussion with @ZachNagengast in https://github.com/argmaxinc/WhisperKit/pull/45 this PR introduces:

- changes to tokenizer:
  - new `SpecialTokens` struct
  - new protocol `WhisperTokenizer` which inherits from `Tokenizer` protocol and has `specialTokens` property
  - new struct `WhisperTokenizerWrapper` which implements `WhisperTokenizer` protocol and forwards tokenizer related methods
- `TextDecoding` has new `isModelMultilingual` property
- `SuppressBlankFilter` and `TimestampRulesFilter` depend on `SpecialTokens`
- tests cleanup
  - new assertions helper methods
  - new file `TestUtils`