### PR TITLE
Support distil whisper models

### DIFF
--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "564442fba36b0b694d730a62d0593e5f54043b55",
-        "version" : "0.1.2"
+        "revision" : "4f915610451d29a05948802a140880ff37494dad",
+        "version" : "0.1.6"
       }
     }
   ],

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -57,7 +57,7 @@ struct ContentView: View {
     @State private var currentFallbacks: Int = 0
     @State private var lastBufferSize: Int = 0
     @State private var lastConfirmedSegmentEndSeconds: Float = 0
-    @State private var requiredSegmentsForConfirmation: Int = 2
+    @State private var requiredSegmentsForConfirmation: Int = 4
     @State private var bufferEnergy: [Float] = []
     @State private var confirmedSegments: [TranscriptionSegment] = []
     @State private var unconfirmedSegments: [TranscriptionSegment] = []
@@ -269,7 +269,8 @@ struct ContentView: View {
 
                     #if os(macOS)
                     Button(action: {
-                        if let folder = whisperKit?.modelFolder {
+                        let folderURL = whisperKit?.modelFolder ?? (localModels.contains(selectedModel) ? URL(fileURLWithPath: localModelPath) : nil)
+                        if let folder = folderURL {
                             NSWorkspace.shared.open(folder)
                         }
                     }, label: {
@@ -708,7 +709,7 @@ struct ContentView: View {
                 localModelPath = modelPath
                 do {
                     let downloadedModels = try FileManager.default.contentsOfDirectory(atPath: modelPath)
-                    for model in downloadedModels where !localModels.contains(model) && model.starts(with: "openai") {
+                    for model in downloadedModels where !localModels.contains(model) {
                         localModels.append(model)
                     }
                 } catch {
@@ -763,7 +764,7 @@ struct ContentView: View {
             if localModels.contains(model) && !redownload {
                 // Get local model folder URL from localModels
                 // TODO: Make this configurable in the UI
-                folder = URL(fileURLWithPath: localModelPath).appendingPathComponent("openai_whisper-\(model)")
+                folder = URL(fileURLWithPath: localModelPath).appendingPathComponent(model)
             } else {
                 // Download the model
                 folder = try await WhisperKit.download(variant: model, from: repoName, progressCallback: { progress in
@@ -833,7 +834,7 @@ struct ContentView: View {
     
     func deleteModel() {
         if localModels.contains(selectedModel) {
-            let modelFolder = URL(fileURLWithPath: localModelPath).appendingPathComponent("openai_whisper-\(selectedModel)")
+            let modelFolder = URL(fileURLWithPath: localModelPath).appendingPathComponent(selectedModel)
             
             do {
                 try FileManager.default.removeItem(at: modelFolder)

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -357,7 +357,7 @@ struct WhisperAXWatchView: View {
                 // Get local model folder URL from localModels
                 // TODO: Make this configurable in the UI
                 // TODO: Handle incomplete downloads
-                folder = URL(fileURLWithPath: localModelPath).appendingPathComponent("openai_whisper-\(model)")
+                folder = URL(fileURLWithPath: localModelPath).appendingPathComponent(model)
             } else {
                 // Download the model
                 folder = try await WhisperKit.download(variant: model, from: repoName, progressCallback: { progress in

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "3bd02269b7797ade67c15679a575cd5c6f203ce6",
-        "version" : "0.1.5"
+        "revision" : "4f915610451d29a05948802a140880ff37494dad",
+        "version" : "0.1.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.5"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.6"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Check out the demo app on [TestFlight](https://testflight.apple.com/join/LPVOyJZ
 ## Table of Contents
 
 - [Installation](#installation)
+  - [Swift Package Manager](#swift-package-manager)
   - [Prerequisites](#prerequisites)
   - [Steps](#steps)
+  - [Homebrew](#homebrew)
 - [Getting Started](#getting-started)
   - [Quick Example](#quick-example)
   - [Model Selection](#model-selection)
@@ -88,7 +90,7 @@ Task {
 WhisperKit automatically downloads the recommended model for the device if not specified. You can also select a specific model by passing in the model name:
 
 ```swift
-let pipe = try? await WhisperKit(model: "large-v3")
+let pipe = try? await WhisperKit(model: "openai_whisper-large-v3")
 ```
 
 For a list of available models, see our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml).
@@ -98,7 +100,7 @@ For a list of available models, see our [HuggingFace repo](https://huggingface.c
 WhisperKit also comes with the supporting repo [`whisperkittools`](https://github.com/argmaxinc/whisperkittools) which lets you create and deploy your own fine tuned versions of Whisper in CoreML format to HuggingFace. Once generated, they can be loaded by simply changing the repo name to the one used to upload the model:
 
 ```swift
-let pipe = try? await WhisperKit(model: "large-v3", modelRepo: "username/your-model-repo")
+let pipe = try? await WhisperKit(model: "openai_whisper-large-v3", modelRepo: "username/your-model-repo")
 ```
 
 ### Swift CLI

--- a/README.md
+++ b/README.md
@@ -90,8 +90,16 @@ Task {
 WhisperKit automatically downloads the recommended model for the device if not specified. You can also select a specific model by passing in the model name:
 
 ```swift
-let pipe = try? await WhisperKit(model: "openai_whisper-large-v3")
+let pipe = try? await WhisperKit(model: "large-v3")
 ```
+
+This method also supports glob search, so you can use wildcards to select a model:
+
+```swift
+let pipe = try? await WhisperKit(model: "distil*large-v3")
+```
+
+Note that the model search must return a single model from the source repo, otherwise an error will be thrown.
 
 For a list of available models, see our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml).
 
@@ -100,7 +108,7 @@ For a list of available models, see our [HuggingFace repo](https://huggingface.c
 WhisperKit also comes with the supporting repo [`whisperkittools`](https://github.com/argmaxinc/whisperkittools) which lets you create and deploy your own fine tuned versions of Whisper in CoreML format to HuggingFace. Once generated, they can be loaded by simply changing the repo name to the one used to upload the model:
 
 ```swift
-let pipe = try? await WhisperKit(model: "openai_whisper-large-v3", modelRepo: "username/your-model-repo")
+let pipe = try? await WhisperKit(model: "large-v3", modelRepo: "username/your-model-repo")
 ```
 
 ### Swift CLI

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -13,7 +13,7 @@ public protocol FeatureExtracting {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class FeatureExtractor: FeatureExtracting, WhisperMLModel {
+open class FeatureExtractor: FeatureExtracting, WhisperMLModel {
     public var model: MLModel?
 
     public init() {}

--- a/Sources/WhisperKit/Core/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/LogitsFilter.swift
@@ -11,7 +11,7 @@ public protocol LogitsFiltering {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class SuppressTokensFilter: LogitsFiltering {
+open class SuppressTokensFilter: LogitsFiltering {
     let suppressTokens: [Int]
     private let suppressTokenIndexes: [[NSNumber]]
 
@@ -27,7 +27,7 @@ public class SuppressTokensFilter: LogitsFiltering {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class SuppressBlankFilter: LogitsFiltering {
+open class SuppressBlankFilter: LogitsFiltering {
     let suppressBlankTokens: [Int]
     let sampleBegin: Int
     private let suppressTokenIndexes: [[NSNumber]]
@@ -49,7 +49,7 @@ public class SuppressBlankFilter: LogitsFiltering {
 
 /// Implementation based on https://github.com/openai/whisper/blob/master/whisper/decoding.py#L441
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class TimestampRulesFilter: LogitsFiltering {
+open class TimestampRulesFilter: LogitsFiltering {
     let transcribeToken: Int
     let translateToken: Int
     let noTimestampsToken: Int

--- a/Sources/WhisperKit/Core/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/LogitsFilter.swift
@@ -115,15 +115,15 @@ open class TimestampRulesFilter: LogitsFiltering {
             }
         }
 
-       if tokens.count == sampleBegin {
-           // suppress generating non-timestamp tokens at the beginning
-           logits.fillLastDimension(indexes: 0..<timeTokenBegin, with: -FloatType.infinity)
-           if let maxInitialTimestampIndex {
-               // apply the `maxInitialTimestamp` option
-               let lastAllowed = timeTokenBegin + maxInitialTimestampIndex + 1
-               logits.fillLastDimension(indexes: lastAllowed..<logits.count, with: -FloatType.infinity)
-           }
-       }
+        if tokens.count == sampleBegin {
+            // suppress generating non-timestamp tokens at the beginning
+            logits.fillLastDimension(indexes: 0..<timeTokenBegin, with: -FloatType.infinity)
+            if let maxInitialTimestampIndex {
+                // apply the `maxInitialTimestamp` option
+                let lastAllowed = timeTokenBegin + maxInitialTimestampIndex + 1
+                logits.fillLastDimension(indexes: lastAllowed..<logits.count, with: -FloatType.infinity)
+            }
+        }
 
         // if sum of probability over timestamps is above any other token, sample timestamp
         if sumOfProbabilityOverTimestampsIsAboveAnyOtherToken(logits: logits, timeTokenBegin: timeTokenBegin) {
@@ -175,14 +175,14 @@ open class TimestampRulesFilter: LogitsFiltering {
                 output: logprobs,
                 batchSize: 1
             )
-            
+
             let timeTokenCount = logits.count - timeTokenBeginOffset
             let noTimeTokenCount = timeTokenBeginOffset
             let logSumExpInputPointer = UnsafeMutableRawBufferPointer(
                 start: logprobs.data!.advanced(by: timeTokenBeginOffset * MemoryLayout<FloatType>.stride),
                 count: timeTokenCount * MemoryLayout<FloatType>.stride
             )
-            
+
             guard let logSumExpInputDescriptor = BNNSNDArrayDescriptor(
                 data: logSumExpInputPointer,
                 scalarType: FloatType.self,
@@ -191,25 +191,25 @@ open class TimestampRulesFilter: LogitsFiltering {
                 Logging.error("Cannot create `logSumExpInputDescriptor`")
                 return false
             }
-            
+
             let timestampLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
                 scalarType: FloatType.self,
                 shape: .vector(1, stride: 1)
             )
             defer { timestampLogProb.deallocate() }
-            
+
             try BNNS.applyReduction(
                 .logSumExp,
                 input: logSumExpInputDescriptor,
                 output: timestampLogProb,
                 weights: nil
             )
-            
+
             let maxTextTokenLogProbInputPointer = UnsafeMutableRawBufferPointer(
                 start: logprobs.data,
                 count: noTimeTokenCount * MemoryLayout<FloatType>.stride
             )
-            
+
             guard let maxTextTokenLogProbInputDescriptor = BNNSNDArrayDescriptor(
                 data: maxTextTokenLogProbInputPointer,
                 scalarType: FloatType.self,
@@ -218,22 +218,23 @@ open class TimestampRulesFilter: LogitsFiltering {
                 Logging.error("Cannot create `maxTextTokenLogProbInputDescriptor`")
                 return false
             }
-            
+
             let maxTextTokenLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
                 scalarType: FloatType.self,
                 shape: .vector(1, stride: 1)
             )
             defer { maxTextTokenLogProb.deallocate() }
-            
+
             try BNNS.applyReduction(
                 .max,
                 input: maxTextTokenLogProbInputDescriptor,
                 output: maxTextTokenLogProb,
                 weights: nil
             )
-            
+
             guard let timestampLogProbValue = timestampLogProb.makeArray(of: FloatType.self)?.first,
-                  let maxTextTokenLogProbValue = maxTextTokenLogProb.makeArray(of: FloatType.self)?.first else {
+                  let maxTextTokenLogProbValue = maxTextTokenLogProb.makeArray(of: FloatType.self)?.first
+            else {
                 Logging.error("Cannot create logProb arrays")
                 return false
             }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -147,11 +147,11 @@ public struct ModelComputeOptions {
             self.prefillCompute = .cpuOnly
             return
         }
-        
+
         self.melCompute = melCompute
         self.prefillCompute = prefillCompute
         self.textDecoderCompute = textDecoderCompute
-        
+
         if #available(macOS 14.0, iOS 17.0, watchOS 10, visionOS 1, *) {
             self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndNeuralEngine
         } else {

--- a/Sources/WhisperKit/Core/ResultWriter.swift
+++ b/Sources/WhisperKit/Core/ResultWriter.swift
@@ -37,7 +37,7 @@ public extension ResultWriting {
     }
 }
 
-public class WriteJSON: ResultWriting {
+open class WriteJSON: ResultWriting {
     public let outputDir: String
 
     public init(outputDir: String) {
@@ -66,7 +66,7 @@ public class WriteJSON: ResultWriting {
     }
 }
 
-public class WriteSRT: ResultWriting {
+open class WriteSRT: ResultWriting {
     public let outputDir: String
 
     public init(outputDir: String) {
@@ -101,7 +101,7 @@ public class WriteSRT: ResultWriting {
     }
 }
 
-public class WriteVTT: ResultWriting {
+open class WriteVTT: ResultWriting {
     public let outputDir: String
 
     public init(outputDir: String) {

--- a/Sources/WhisperKit/Core/SegmentSeeker.swift
+++ b/Sources/WhisperKit/Core/SegmentSeeker.swift
@@ -35,7 +35,7 @@ public protocol SegmentSeeking {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class SegmentSeeker: SegmentSeeking {
+open class SegmentSeeker: SegmentSeeking {
     public init() {}
 
     // MARK: - Seek & Segments

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -235,7 +235,7 @@ public class TextDecoderContextPrefill: WhisperMLModel {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class TextDecoder: TextDecoding, WhisperMLModel {
+open class TextDecoder: TextDecoding, WhisperMLModel {
     public var model: MLModel?
     public var tokenizer: Tokenizer?
     public var prefillData: WhisperMLModel?

--- a/Sources/WhisperKit/Core/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/TokenSampler.swift
@@ -17,7 +17,7 @@ public struct SamplingResult {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public class GreedyTokenSampler: TokenSampling {
+open class GreedyTokenSampler: TokenSampling {
     public var temperature: FloatType
     public var eotToken: Int
     public var decodingOptions: DecodingOptions
@@ -169,7 +169,7 @@ public class GreedyTokenSampler: TokenSampling {
     }
 }
 
-public class BeamSearchTokenSampler: TokenSampling {
+open class BeamSearchTokenSampler: TokenSampling {
     public var beamSize: Int
     public var eotToken: Int
     public var patience: Float

--- a/Sources/WhisperKit/Core/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/TokenSampler.swift
@@ -201,7 +201,7 @@ public class BeamSearchTokenSampler: TokenSampling {
         fatalError("Not implemented: \(#function)")
     }
 
-    public func finalize(tokens: [Int], logProbs: [Float]) -> SamplingResult{
+    public func finalize(tokens: [Int], logProbs: [Float]) -> SamplingResult {
         // TODO: Implement
         fatalError("Not implemented: \(#function)")
     }

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -4,8 +4,8 @@
 import AVFoundation
 import CoreML
 import Foundation
-import Tokenizers
 import Hub
+import Tokenizers
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -198,9 +198,9 @@ func detectVariant(logitsDim: Int, encoderDim: Int) -> ModelVariant {
 public func modelSupport(for deviceName: String) -> (default: String, disabled: [String]) {
     switch deviceName {
         case let model where model.hasPrefix("iPhone11"), // A12
-            let model where model.hasPrefix("iPhone12"), // A13
-            let model where model.hasPrefix("Watch7"): // Series 9 and Ultra 2
-            return ("openai_whisper-base", ["openai_whisper-small", 
+             let model where model.hasPrefix("iPhone12"), // A13
+             let model where model.hasPrefix("Watch7"): // Series 9 and Ultra 2
+            return ("openai_whisper-base", ["openai_whisper-small",
                                             "openai_whisper-small.en",
                                             "openai_whisper-large-v2",
                                             "openai_whisper-large-v2_949MB",
@@ -208,7 +208,7 @@ public func modelSupport(for deviceName: String) -> (default: String, disabled: 
                                             "openai_whisper-large-v2_turbo_955MB",
                                             "openai_whisper-large-v3",
                                             "openai_whisper-large-v3_947MB",
-                                            "openai_whisper-large-v3_turbo", 
+                                            "openai_whisper-large-v3_turbo",
                                             "openai_whisper-large-v3_turbo_954MB",
                                             "distil-whisper_distil-large-v3",
                                             "distil-whisper_distil-large-v3_594MB",
@@ -226,13 +226,12 @@ public func modelSupport(for deviceName: String) -> (default: String, disabled: 
                                             "distil-whisper_distil-large-v3_turbo"])
 
         case let model where model.hasPrefix("iPhone14"), // A15
-            let model where model.hasPrefix("iPhone15"), // A16
-            let model where model.hasPrefix("iPhone16"): // A17
+             let model where model.hasPrefix("iPhone15"), // A16
+             let model where model.hasPrefix("iPhone16"): // A17
             return ("openai_whisper-base", ["openai_whisper-large-v2",
                                             "openai_whisper-large-v2_turbo",
                                             "openai_whisper-large-v3",
                                             "openai_whisper-large-v3_turbo"])
-
 
         // Fall through to macOS checks
         default:

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -198,17 +198,41 @@ func detectVariant(logitsDim: Int, encoderDim: Int) -> ModelVariant {
 public func modelSupport(for deviceName: String) -> (default: String, disabled: [String]) {
     switch deviceName {
         case let model where model.hasPrefix("iPhone11"), // A12
-             let model where model.hasPrefix("iPhone12"), // A13
-             let model where model.hasPrefix("Watch7"): // Series 9 and Ultra 2
-            return ("base", ["small", "small.en", "large-v3_turbo", "large-v3", "large-v3_turbo_1018MB", "large-v2", "large-v2_turbo", "large-v2_turbo_1022MB", "large-v2_1050MB"])
+            let model where model.hasPrefix("iPhone12"), // A13
+            let model where model.hasPrefix("Watch7"): // Series 9 and Ultra 2
+            return ("openai_whisper-base", ["openai_whisper-small", 
+                                            "openai_whisper-small.en",
+                                            "openai_whisper-large-v2",
+                                            "openai_whisper-large-v2_949MB",
+                                            "openai_whisper-large-v2_turbo",
+                                            "openai_whisper-large-v2_turbo_955MB",
+                                            "openai_whisper-large-v3",
+                                            "openai_whisper-large-v3_947MB",
+                                            "openai_whisper-large-v3_turbo", 
+                                            "openai_whisper-large-v3_turbo_954MB",
+                                            "distil-whisper_distil-large-v3",
+                                            "distil-whisper_distil-large-v3_594MB",
+                                            "distil-whisper_distil-large-v3_turbo_600MB",
+                                            "distil-whisper_distil-large-v3_turbo"])
 
         case let model where model.hasPrefix("iPhone13"): // A14
-            return ("base", ["large-v3_turbo", "large-v3", "large-v3_turbo_1018MB", "large-v2", "large-v2_turbo", "large-v2_turbo_1022MB"])
+            return ("openai_whisper-base", ["openai_whisper-large-v2",
+                                            "openai_whisper-large-v2_turbo",
+                                            "openai_whisper-large-v2_turbo_955MB",
+                                            "openai_whisper-large-v3",
+                                            "openai_whisper-large-v3_turbo",
+                                            "openai_whisper-large-v3_turbo_954MB",
+                                            "distil-whisper_distil-large-v3_turbo_600MB",
+                                            "distil-whisper_distil-large-v3_turbo"])
 
         case let model where model.hasPrefix("iPhone14"), // A15
-             let model where model.hasPrefix("iPhone15"), // A16
-             let model where model.hasPrefix("iPhone16"): // A17
-            return ("base", ["large-v3_turbo", "large-v3", "large-v2_turbo", "large-v2"])
+            let model where model.hasPrefix("iPhone15"), // A16
+            let model where model.hasPrefix("iPhone16"): // A17
+            return ("openai_whisper-base", ["openai_whisper-large-v2",
+                                            "openai_whisper-large-v2_turbo",
+                                            "openai_whisper-large-v3",
+                                            "openai_whisper-large-v3_turbo"])
+
 
         // Fall through to macOS checks
         default:
@@ -219,16 +243,21 @@ public func modelSupport(for deviceName: String) -> (default: String, disabled: 
     if deviceName.hasPrefix("arm64") {
         if Process.processor.contains("Apple M1") {
             // Disable turbo variants for M1
-            return ("base", ["large-v3_turbo", "large-v3_turbo_1018MB", "large-v2_turbo", "large-v2_turbo_1022MB"])
+            return ("openai_whisper-base", ["openai_whisper-large-v2_turbo",
+                                            "openai_whisper-large-v2_turbo_955MB",
+                                            "openai_whisper-large-v3_turbo",
+                                            "openai_whisper-large-v3_turbo_954MB",
+                                            "distil-whisper_distil-large-v3_turbo_600MB",
+                                            "distil-whisper_distil-large-v3_turbo"])
         } else {
             // Enable all variants for M2 or M3, none disabled
-            return ("base", [])
+            return ("openai_whisper-base", [])
         }
     }
     #endif
 
     // Unhandled device, default to base variant
-    return ("base", [""])
+    return ("openai_whisper-base", [""])
 }
 
 #if os(macOS)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -128,11 +128,9 @@ public class WhisperKit: Transcriber {
         return deviceName
     }
 
-    public static func fetchAvailableModels(from repo: String = "argmaxinc/whisperkit-coreml") async throws -> [String] {
+    public static func fetchAvailableModels(from repo: String = "argmaxinc/whisperkit-coreml", matching: [String] = ["openai_*", "distil-whisper_*"] ) async throws -> [String] {
         let hubApi = HubApi()
-        // TODO: get config from the source repo
-        _ = try? await hubApi.httpGet(for: URL(string: "https://huggingface.co/argmaxinc/whisperkit-coreml/blob/main/config.json")!)
-        let modelFiles = try await hubApi.getFilenames(from: repo, matching: ["openai_whisper*"])
+        let modelFiles = try await hubApi.getFilenames(from: repo, matching: matching)
 
         return formatModelFiles(modelFiles)
     }
@@ -149,10 +147,7 @@ public class WhisperKit: Transcriber {
         })
 
         let availableModels = filteredVariants.map { variant -> String in
-            let parts = variant.split(separator: "_")
-            let modelInfo = parts[1].split(separator: "-").dropFirst().joined(separator: "-")
-            let additionalInfo = parts.count > 2 ? "_\(parts[2...].joined(separator: "_"))" : ""
-            return (modelInfo + additionalInfo).trimmingFromEnd(character: "/", upto: 1)
+            return variant.trimmingFromEnd(character: "/", upto: 1)
         }
 
         // Sorting order based on enum
@@ -193,7 +188,7 @@ public class WhisperKit: Transcriber {
                 }
             }
 
-            let modelFolderName = modelFolder.appending(path: "openai_whisper-\(variant)")
+            let modelFolderName = modelFolder.appending(path: variant)
             return modelFolderName
         } catch {
             Logging.debug(error)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -180,15 +180,40 @@ public class WhisperKit: Transcriber {
     ) async throws -> URL {
         let hubApi = HubApi(downloadBase: downloadBase, useBackgroundSession: useBackgroundSession)
         let repo = Hub.Repo(id: repo, type: .models)
+        let modelSearchPath = "*\(variant.description)/*"
         do {
-            let modelFolder = try await hubApi.snapshot(from: repo, matching: ["*\(variant.description)/*"]) { progress in
+            Logging.debug("Searching for models matching \"\(modelSearchPath) in \(repo)")
+            let modelFiles = try await hubApi.getFilenames(from: repo, matching: [modelSearchPath])
+            var uniquePaths = Set(modelFiles.map { $0.components(separatedBy: "/").first! })
+
+            var variantPath: String? = nil
+
+            if uniquePaths.count == 1 {
+                variantPath = uniquePaths.first
+            } else {
+                // If the model name search returns more than one unique model folder, then prepend the default "openai" prefix from whisperkittools to disambiguate
+                let adjustedModelSearchPath = "*openai*\(variant.description)/*"
+                let adjustedModelFiles = try await hubApi.getFilenames(from: repo, matching: [adjustedModelSearchPath])
+                uniquePaths = Set(adjustedModelFiles.map { $0.components(separatedBy: "/").first! })
+
+                if uniquePaths.count == 1 {
+                    variantPath = uniquePaths.first
+                }
+            }
+
+            guard let variantPath else {
+                // If there is still ambiguity, throw an error
+                throw WhisperError.modelsUnavailable("Multiple models found matching \(modelSearchPath)")
+            }
+
+            Logging.debug("Downloading model \(variantPath)...")
+            let modelFolder = try await hubApi.snapshot(from: repo, matching: [modelSearchPath]) { progress in
                 Logging.debug(progress)
                 if let callback = progressCallback {
                     callback(progress)
                 }
             }
-
-            let modelFolderName = modelFolder.appending(path: variant)
+            let modelFolderName = modelFolder.appending(path: variantPath)
             return modelFolderName
         } catch {
             Logging.debug(error)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -48,7 +48,7 @@ public class WhisperKit: Transcriber {
 
     /// State
     public let progress = Progress()
-    
+
     /// Configuration
     public var modelFolder: URL?
     public var tokenizerFolder: URL?
@@ -128,7 +128,7 @@ public class WhisperKit: Transcriber {
         return deviceName
     }
 
-    public static func fetchAvailableModels(from repo: String = "argmaxinc/whisperkit-coreml", matching: [String] = ["openai_*", "distil-whisper_*"] ) async throws -> [String] {
+    public static func fetchAvailableModels(from repo: String = "argmaxinc/whisperkit-coreml", matching: [String] = ["openai_*", "distil-whisper_*"]) async throws -> [String] {
         let hubApi = HubApi()
         let modelFiles = try await hubApi.getFilenames(from: repo, matching: matching)
 
@@ -147,7 +147,7 @@ public class WhisperKit: Transcriber {
         })
 
         let availableModels = filteredVariants.map { variant -> String in
-            return variant.trimmingFromEnd(character: "/", upto: 1)
+            variant.trimmingFromEnd(character: "/", upto: 1)
         }
 
         // Sorting order based on enum
@@ -485,7 +485,7 @@ public class WhisperKit: Transcriber {
 
         let startDecodeLoopTime = CFAbsoluteTimeGetCurrent()
 
-        let totalSeekDuration = seekClips.reduce(0, { return $0 + ($1.end - $1.start) })
+        let totalSeekDuration = seekClips.reduce(0) { $0 + ($1.end - $1.start) }
         progress.totalUnitCount = Int64(totalSeekDuration)
         defer { progress.completedUnitCount = progress.totalUnitCount }
         for (seekClipStart, seekClipEnd) in seekClips {

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -182,7 +182,7 @@ public class WhisperKit: Transcriber {
         let repo = Hub.Repo(id: repo, type: .models)
         let modelSearchPath = "*\(variant.description)/*"
         do {
-            Logging.debug("Searching for models matching \"\(modelSearchPath) in \(repo)")
+            Logging.debug("Searching for models matching \"\(modelSearchPath)\" in \(repo)")
             let modelFiles = try await hubApi.getFilenames(from: repo, matching: [modelSearchPath])
             var uniquePaths = Set(modelFiles.map { $0.components(separatedBy: "/").first! })
 
@@ -192,7 +192,9 @@ public class WhisperKit: Transcriber {
                 variantPath = uniquePaths.first
             } else {
                 // If the model name search returns more than one unique model folder, then prepend the default "openai" prefix from whisperkittools to disambiguate
+                Logging.debug("Multiple models found matching \"\(modelSearchPath)\"")
                 let adjustedModelSearchPath = "*openai*\(variant.description)/*"
+                Logging.debug("Searching for models matching \"\(adjustedModelSearchPath)\" in \(repo)")
                 let adjustedModelFiles = try await hubApi.getFilenames(from: repo, matching: [adjustedModelSearchPath])
                 uniquePaths = Set(adjustedModelFiles.map { $0.components(separatedBy: "/").first! })
 
@@ -203,7 +205,7 @@ public class WhisperKit: Transcriber {
 
             guard let variantPath else {
                 // If there is still ambiguity, throw an error
-                throw WhisperError.modelsUnavailable("Multiple models found matching \(modelSearchPath)")
+                throw WhisperError.modelsUnavailable("Multiple models found matching \"\(modelSearchPath)\"")
             }
 
             Logging.debug("Downloading model \(variantPath)...")

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -9,7 +9,7 @@ struct CLIArguments: ParsableArguments {
 
     @Option(help: "Path of model files")
     var modelPath: String?
-    
+
     @Option(help: "Model to download if no modelPath is provided")
     var model: String?
 
@@ -18,25 +18,25 @@ struct CLIArguments: ParsableArguments {
 
     @Option(help: "Path to save the downloaded model")
     var downloadModelPath: String?
-    
+
     @Option(help: "Path to save the downloaded tokenizer files")
     var downloadTokenizerPath: String?
 
     @Option(help: "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var audioEncoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
-    
+
     @Option(help: "Compute units for text decoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var textDecoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine
 
     @Flag(help: "Verbose mode")
     var verbose: Bool = false
-    
+
     @Option(help: "Task to perform (transcribe or translate)")
     var task: String = "transcribe"
-    
+
     @Option(help: "Language spoken in the audio")
     var language: String?
-    
+
     @Option(help: "Temperature to use for sampling")
     var temperature: Float = 0
 

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -12,7 +12,10 @@ struct CLIArguments: ParsableArguments {
     
     @Option(help: "Model to download if no modelPath is provided")
     var model: String?
-    
+
+    @Option(help: "Text to add in front of the model name to specify between different types of the same variant (values: \"openai_whisper-\", \"distil-whisper_distil-\")")
+    var modelPrefix: String = "openai_whisper-"
+
     @Option(help: "Path to save the downloaded model")
     var downloadModelPath: String?
     

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -13,8 +13,8 @@ struct CLIArguments: ParsableArguments {
     @Option(help: "Model to download if no modelPath is provided")
     var model: String?
 
-    @Option(help: "Text to add in front of the model name to specify between different types of the same variant (values: \"openai_whisper-\", \"distil-whisper_distil-\")")
-    var modelPrefix: String = "openai_whisper-"
+    @Option(help: "Text to add in front of the model name to specify between different types of the same variant (values: \"openai\", \"distil\")")
+    var modelPrefix: String = "openai"
 
     @Option(help: "Path to save the downloaded model")
     var downloadModelPath: String?

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -71,7 +71,7 @@ struct Transcribe: AsyncParsableCommand {
 
         let modelName: String? =
             if let modelVariant = cliArguments.model {
-                cliArguments.modelPrefix + modelVariant
+                cliArguments.modelPrefix + "*" + modelVariant
             } else {
                 nil
             }

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -28,28 +28,28 @@ struct Transcribe: AsyncParsableCommand {
         guard FileManager.default.fileExists(atPath: resolvedAudioPath) else {
             throw CocoaError.error(.fileNoSuchFile)
         }
-        
+
         let task: DecodingTask
         if cliArguments.task.lowercased() == "translate" {
             task = .translate
         } else {
             task = .transcribe
         }
-        
+
         if cliArguments.verbose {
             print("Task: \(task.description.capitalized) audio at \(cliArguments.audioPath)")
         }
 
         var audioEncoderComputeUnits = cliArguments.audioEncoderComputeUnits.asMLComputeUnits
         let textDecoderComputeUnits = cliArguments.textDecoderComputeUnits.asMLComputeUnits
-        
+
         // Use gpu for audio encoder on macOS below 14
         if audioEncoderComputeUnits == .cpuAndNeuralEngine {
             if #unavailable(macOS 14.0) {
                 audioEncoderComputeUnits = .cpuAndGPU
             }
         }
-        
+
         let computeOptions = ModelComputeOptions(
             audioEncoderCompute: audioEncoderComputeUnits,
             textDecoderCompute: textDecoderComputeUnits
@@ -69,12 +69,19 @@ struct Transcribe: AsyncParsableCommand {
                 nil
             }
 
+        let modelName: String? =
+            if let modelVariant = cliArguments.model {
+                cliArguments.modelPrefix + modelVariant
+            } else {
+                nil
+            }
+
         if cliArguments.verbose {
             print("Initializing models...")
         }
 
         let whisperKit = try await WhisperKit(
-            model: cliArguments.model,
+            model: modelName,
             downloadBase: downloadModelFolder,
             modelFolder: cliArguments.modelPath,
             tokenizerFolder: downloadTokenizerFolder,
@@ -173,8 +180,15 @@ struct Transcribe: AsyncParsableCommand {
             print("Initializing models...")
         }
 
+        let modelName: String? =
+            if let modelVariant = cliArguments.model {
+                cliArguments.modelPrefix + modelVariant
+            } else {
+                nil
+            }
+
         let whisperKit = try await WhisperKit(
-            model: cliArguments.model,
+            model: modelName,
             downloadBase: downloadModelFolder,
             modelFolder: cliArguments.modelPath,
             tokenizerFolder: downloadTokenizerFolder,

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -138,4 +138,27 @@ final class FunctionalTests: XCTestCase {
 
         XCTAssertGreaterThan(transcription!.count, 0)
     }
+
+    func testModelSearchPathLarge() async throws {
+        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
+            XCTFail("Audio file not found")
+            return
+        }
+
+        var pipe = try await WhisperKit(model: "large-v3", verbose: true, logLevel: .debug)
+
+        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
+            XCTFail("Transcription failed")
+            return
+        }
+        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+
+        pipe = try await WhisperKit(model: "distil*large-v3", verbose: true, logLevel: .debug)
+
+        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
+            XCTFail("Transcription failed")
+            return
+        }
+        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+    }
 }

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -160,5 +160,13 @@ final class FunctionalTests: XCTestCase {
             return
         }
         XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+
+        pipe = try await WhisperKit(model: "distil-whisper_distil-large-v3", verbose: true, logLevel: .debug)
+
+        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
+            XCTFail("Transcription failed")
+            return
+        }
+        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -955,8 +955,7 @@ final class UnitTests: XCTestCase {
         for (index, wordTiming) in wordTimings.enumerated() {
             let expectedWordTiming = expectedWordTimings[index]
 
-            XCTAssertEqual(wordTiming.word, expectedWordTiming.word, "Word should match at index \(index)")
-            XCTAssertEqual(wordTiming.tokens, expectedWordTiming.tokens, "Tokens should match at index \(index)")
+            XCTAssertEqual(wordTiming.word.normalized, expectedWordTiming.word.normalized, "Word should match at index \(index) (expected: \(expectedWordTiming.word), actual: \(wordTiming.word))")
 
             XCTAssertEqual(wordTiming.start, expectedWordTiming.start, accuracy: 0.5, "Start time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.start), actual: \(wordTiming.start))")
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -958,11 +958,9 @@ final class UnitTests: XCTestCase {
             XCTAssertEqual(wordTiming.word, expectedWordTiming.word, "Word should match at index \(index)")
             XCTAssertEqual(wordTiming.tokens, expectedWordTiming.tokens, "Tokens should match at index \(index)")
 
-            let startTimeDifference = abs(wordTiming.start - expectedWordTiming.start)
-            XCTAssertLessThanOrEqual(startTimeDifference, 0.1, "Start time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.start), actual: \(wordTiming.start))")
+            XCTAssertEqual(wordTiming.start, expectedWordTiming.start, accuracy: 0.5, "Start time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.start), actual: \(wordTiming.start))")
 
-            let endTimeDifference = abs(wordTiming.end - expectedWordTiming.end)
-            XCTAssertLessThanOrEqual(endTimeDifference, 0.1, "End time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.end), actual: \(wordTiming.end))")
+            XCTAssertEqual(wordTiming.end, expectedWordTiming.end, accuracy: 0.5, "End time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.end), actual: \(wordTiming.end))")
         }
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -914,6 +914,57 @@ final class UnitTests: XCTestCase {
             XCTAssertEqual(mergedAlignmentTiming[i].probability, expectedWordTimings[i].probability, "Probability at index \(i) does not match")
         }
     }
+
+    func testWordTimestampCorrectness() async {
+        let options = DecodingOptions(wordTimestamps: true)
+
+        guard let result = try? await transcribe(with: .tiny, options: options) else {
+            XCTFail("Failed to transcribe")
+            return
+        }
+
+        let wordTimings = result.segments.compactMap { $0.words }.flatMap { $0 }
+
+        let expectedWordTimings = [
+            WordTiming(word: " And", tokens: [400], start: 0.32, end: 0.68, probability: 0.85),
+            WordTiming(word: " so", tokens: [370], start: 0.68, end: 1.1, probability: 1.0),
+            WordTiming(word: " my", tokens: [452], start: 1.1, end: 1.36, probability: 0.51),
+            WordTiming(word: " fellow", tokens: [7177], start: 1.36, end: 1.74, probability: 0.52),
+            WordTiming(word: " Americans", tokens: [6280], start: 1.74, end: 2.26, probability: 0.82),
+            WordTiming(word: " ask", tokens: [1029], start: 2.26, end: 3.82, probability: 0.4),
+            WordTiming(word: " not", tokens: [406], start: 3.82, end: 4.56, probability: 1.0),
+            WordTiming(word: " what", tokens: [437], start: 4.56, end: 5.68, probability: 0.91),
+            WordTiming(word: " your", tokens: [428], start: 5.68, end: 5.92, probability: 0.22),
+            WordTiming(word: " country", tokens: [1941], start: 5.92, end: 6.38, probability: 0.64),
+            WordTiming(word: " can", tokens: [393], start: 6.38, end: 6.76, probability: 0.52),
+            WordTiming(word: " do", tokens: [360], start: 6.76, end: 6.98, probability: 0.85),
+            WordTiming(word: " for", tokens: [337], start: 6.98, end: 7.22, probability: 0.97),
+            WordTiming(word: " you,", tokens: [291, 11], start: 7.22, end: 8.36, probability: 0.97),
+            WordTiming(word: " ask", tokens: [1029], start: 8.36, end: 8.66, probability: 0.93),
+            WordTiming(word: " what", tokens: [437], start: 8.66, end: 8.86, probability: 0.98),
+            WordTiming(word: " you", tokens: [291], start: 8.86, end: 9.22, probability: 0.06),
+            WordTiming(word: " can", tokens: [393], start: 9.22, end: 9.44, probability: 0.58),
+            WordTiming(word: " do", tokens: [360], start: 9.44, end: 9.64, probability: 0.87),
+            WordTiming(word: " for", tokens: [337], start: 9.64, end: 9.86, probability: 0.95),
+            WordTiming(word: " your", tokens: [428], start: 9.86, end: 10.06, probability: 0.96),
+            WordTiming(word: " country.", tokens: [1941, 13], start: 10.06, end: 10.5, probability: 0.91)
+        ]
+
+        XCTAssertEqual(wordTimings.count, expectedWordTimings.count, "Number of word timings should match")
+
+        for (index, wordTiming) in wordTimings.enumerated() {
+            let expectedWordTiming = expectedWordTimings[index]
+
+            XCTAssertEqual(wordTiming.word, expectedWordTiming.word, "Word should match at index \(index)")
+            XCTAssertEqual(wordTiming.tokens, expectedWordTiming.tokens, "Tokens should match at index \(index)")
+
+            let startTimeDifference = abs(wordTiming.start - expectedWordTiming.start)
+            XCTAssertLessThanOrEqual(startTimeDifference, 0.1, "Start time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.start), actual: \(wordTiming.start))")
+
+            let endTimeDifference = abs(wordTiming.end - expectedWordTiming.end)
+            XCTAssertLessThanOrEqual(endTimeDifference, 0.1, "End time difference for word '\(wordTiming.word)' should be within +/- 0.1 seconds (expected: \(expectedWordTiming.end), actual: \(wordTiming.end))")
+        }
+    }
 }
 
 // MARK: Helpers


### PR DESCRIPTION
Distil whisper models are a great addition to the standard openai models especially for smaller devices, and with [distil large v3](https://huggingface.co/distil-whisper/distil-large-v3
) out now, its a great time to add support for them.

Important note: This required some significant changes to how we search for models, specifically that we now require the full model name like "openai_whisper-large-v3" rather than just "large-v3" in order to use the convenience methods for downloading a model without doing it manually using the modelFolder param.

### Swift

`let pipe = try? await WhisperKit(model: "distil-whisper_distil-large-v3")`

or

`let pipe = try? await WhisperKit(model: "distil*large-v3")`


### CLI

`swift run whisperkit-cli transcribe --model "large-v3" --model-prefix "distil" --audio-path ~/your-audio.mp3`

