### PR TITLE
First token logProb thresholding

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -302,8 +302,9 @@ public struct DecodingFallback {
     }
 }
 
-extension DecodingFallback {
-    public init?(
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+public extension DecodingFallback {
+    init?(
         options: DecodingOptions,
         isFirstTokenLogProbTooLow: Bool,
         noSpeechProb: Float,
@@ -328,6 +329,7 @@ extension DecodingFallback {
     }
 }
 
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public struct DecodingResult {
     public var language: String
     public var languageProbs: [String: Float]

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -309,6 +309,18 @@ extension DecodingFallback {
         compressionRatio: Float,
         avgLogProb: Float
     ) {
+        print("""
+        [DecodingFallback]
+            isFirstTokenLogProbTooLow: \(isFirstTokenLogProbTooLow),
+            noSpeechProb: \(noSpeechProb),
+            compressionRatio: \(compressionRatio),
+            avgLogProb: \(avgLogProb)
+            options:
+                noSpeechThreshold: \(String(describing: options.noSpeechThreshold))
+                compressionRatioThreshold: \(String(describing: options.compressionRatioThreshold))
+                logProbThreshold: \(String(describing: options.logProbThreshold))
+        [---]
+        """)
         // NOTE: order matters here
         if isFirstTokenLogProbTooLow {
             self.init(needsFallback: true, fallbackReason: "firstTokenLogProbThreshold")

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -291,6 +291,7 @@ public struct DecodingOptions {
     }
 }
 
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public struct DecodingFallback {
     public var needsFallback: Bool
     public var fallbackReason: String

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -309,18 +309,6 @@ extension DecodingFallback {
         compressionRatio: Float,
         avgLogProb: Float
     ) {
-        print("""
-        [DecodingFallback]
-            isFirstTokenLogProbTooLow: \(isFirstTokenLogProbTooLow),
-            noSpeechProb: \(noSpeechProb),
-            compressionRatio: \(compressionRatio),
-            avgLogProb: \(avgLogProb)
-            options:
-                noSpeechThreshold: \(String(describing: options.noSpeechThreshold))
-                compressionRatioThreshold: \(String(describing: options.compressionRatioThreshold))
-                logProbThreshold: \(String(describing: options.logProbThreshold))
-        [---]
-        """)
         // NOTE: order matters here
         if isFirstTokenLogProbTooLow {
             self.init(needsFallback: true, fallbackReason: "firstTokenLogProbThreshold")

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -218,6 +218,7 @@ public struct DecodingCache {
 ///   - supressTokens: List of token IDs to suppress during decoding.
 ///   - compressionRatioThreshold: If the compression ratio of the transcription text is above this value, it is too repetitive and treated as failed.
 ///   - logProbThreshold: If the average log probability over sampled tokens is below this value, treat as failed.
+///   - firstTokenLogProbThreshold: If the log probability over the first sampled token is below this value, treat as failed.
 ///   - noSpeechThreshold: If the no speech probability is higher than this value AND the average log
 ///                        probability over sampled tokens is below `logProbThreshold`, consider the segment as silent.
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
@@ -263,7 +264,7 @@ public struct DecodingOptions {
                 supressTokens: [Int]? = nil,
                 compressionRatioThreshold: Float? = 2.4,
                 logProbThreshold: Float? = -1.0,
-                firstTokenLogProbThreshold: Float? = nil,
+                firstTokenLogProbThreshold: Float? = -0.7,
                 noSpeechThreshold: Float? = 0.6)
     {
         self.verbose = verbose

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -333,7 +333,7 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
         var nextToken: Int = decoderInputs.initialPrompt.last!
         var logProbs: [Float] = Array(repeating: 0, count: prefilledIndex + 1)
 
-        guard let tokenizer = tokenizer else {
+        guard let tokenizer else {
             // Tokenizer required for decoding
             throw WhisperError.tokenizerUnavailable()
         }
@@ -378,17 +378,16 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
 
         let loopCount = min(options.sampleLength, WhisperKit.maxTokenContext)
         Logging.debug("Running main loop for a maximum of \(loopCount) iterations, starting at index \(prefilledIndex)")
-        var isPrefill: Bool
         var hasAlignment = false
+        var isFirstTokenLogProbTooLow = false
         for tokenIndex in prefilledIndex..<loopCount {
             let loopStart = Date()
 
+            let isPrefill = tokenIndex < intialPromptIndex // Prefill stops at the last token of the initial prompt
+            let isFirstToken = tokenIndex == intialPromptIndex + 1
             // Check if current index is part of the initial prompt
-            isPrefill = false
             if tokenIndex <= intialPromptIndex {
-                isPrefill = tokenIndex < intialPromptIndex // Prefill stops at the last token of the initial prompt
-                let prefillToken = currentTokens[tokenIndex]
-                nextToken = prefillToken
+                nextToken = currentTokens[tokenIndex]
                 Logging.debug("Forcing token \(nextToken) at index \(tokenIndex) from initial prompt")
             }
 
@@ -443,13 +442,21 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             let sampleResult = tokenSampler.update(tokens: currentTokens, logits: logits, logProbs: logProbs)
 
             nextToken = sampleResult.tokens.last!
+            let nextTokenLogProb = sampleResult.logProbs.last!
             logProbs = sampleResult.logProbs
 
             let samplingTime = Date().timeIntervalSince(samplingStartTime)
             timings.decodingSampling += samplingTime
 
-            if sampleResult.completed || currentTokens.count >= WhisperKit.maxTokenContext {
-                // Completed segment, stop the loop
+            let isSegmentCompleted = sampleResult.completed || currentTokens.count >= WhisperKit.maxTokenContext
+            isFirstTokenLogProbTooLow =
+                if isFirstToken, let firstTokenLogProbThreshold = options.firstTokenLogProbThreshold, nextTokenLogProb < firstTokenLogProbThreshold {
+                    true
+                } else {
+                    false
+                }
+            
+            if isSegmentCompleted || isFirstTokenLogProbTooLow {
                 break
             } else {
                 // MARK: KV Caching
@@ -547,8 +554,17 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             // Convert Float16 temperature to Float with 3 decimal places
             temperature = round(Float(sampler.temperature) * 1000) / 1000
         }
+        let noSpeechProb: Float = 0 // TODO: implement no speech prob
 
         let transcript = tokenizer.decode(tokens: segmentTokens)
+        
+        let decodingFallback = DecodingFallback(
+            options: options,
+            isFirstTokenLogProbTooLow: isFirstTokenLogProbTooLow,
+            noSpeechProb: noSpeechProb,
+            compressionRatio: compressionRatio,
+            avgLogProb: avgLogProbs
+        )
 
         let decodingResult = DecodingResult(
             language: options.language ?? "en",
@@ -557,13 +573,13 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             tokenLogProbs: tokenProbs,
             text: transcript,
             avgLogProb: avgLogProbs,
-            noSpeechProb: 0, // TODO: implement no speech prob
+            noSpeechProb: noSpeechProb,
             temperature: temperature,
             compressionRatio: compressionRatio,
             cache: cache,
-            timings: timings
+            timings: timings,
+            fallback: decodingFallback
         )
-
         return [decodingResult]
     }
 

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -384,7 +384,7 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             let loopStart = Date()
 
             let isPrefill = tokenIndex < intialPromptIndex // Prefill stops at the last token of the initial prompt
-            let isFirstToken = tokenIndex == intialPromptIndex + 1
+            let isFirstToken = tokenIndex == intialPromptIndex
             // Check if current index is part of the initial prompt
             if tokenIndex <= intialPromptIndex {
                 nextToken = currentTokens[tokenIndex]
@@ -448,15 +448,19 @@ public class TextDecoder: TextDecoding, WhisperMLModel {
             let samplingTime = Date().timeIntervalSince(samplingStartTime)
             timings.decodingSampling += samplingTime
 
-            let isSegmentCompleted = sampleResult.completed || currentTokens.count >= WhisperKit.maxTokenContext
             isFirstTokenLogProbTooLow =
                 if isFirstToken, let firstTokenLogProbThreshold = options.firstTokenLogProbThreshold, nextTokenLogProb < firstTokenLogProbThreshold {
                     true
                 } else {
                     false
                 }
-            
-            if isSegmentCompleted || isFirstTokenLogProbTooLow {
+            let isSegmentCompleted = 
+                sampleResult.completed ||
+                currentTokens.count >= WhisperKit.maxTokenContext ||
+                isFirstTokenLogProbTooLow
+
+            if isSegmentCompleted {
+                // Completed segment, stop the loop
                 break
             } else {
                 // MARK: KV Caching

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -671,39 +671,15 @@ public class WhisperKit: Transcriber {
 
                 // MARK: Fallback checks
 
-                var needsFallback = false
-                var fallbackReason = ""
-                if let result = decodingResult {
-                    if let threshold = options.compressionRatioThreshold,
-                       result.compressionRatio > threshold
-                    {
-                        needsFallback = true // too repetitive
-                        fallbackReason = "compressionRatioThreshold"
-                    }
-
-                    if let threshold = options.logProbThreshold,
-                       result.avgLogProb < threshold
-                    {
-                        needsFallback = true // average log probablity too low (model is not confident enough)
-                        fallbackReason = "logProbThreshold"
-                    }
-
-                    if let threshold = options.noSpeechThreshold,
-                       result.noSpeechProb > threshold
-                    {
-                        needsFallback = false // silence
-                    }
-                }
-
-                if !needsFallback {
-                    break
-                } else {
+                if let fallback = decodingResult?.fallback, fallback.needsFallback {
                     // Reset decoder inputs for fallback
                     fallbackCount = Double(i)
                     timings.decodingFallback += Date().timeIntervalSince(decodeWithFallbackStart)
                     timings.totalDecodingFallbacks = fallbackCount
                     resetDecoderInputs()
-                    Logging.info("Fallback #\(fallbackCount + 1) (\(fallbackReason))")
+                    Logging.info("Fallback #\(fallbackCount + 1) (\(fallback.fallbackReason))")
+                } else {
+                    break
                 }
             }
 

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -70,6 +70,9 @@ struct CLIArguments: ParsableArguments {
     @Option(help: "Average log probability threshold for decoding failure")
     var logprobThreshold: Float?
 
+    @Option(help: "Log probability threshold for first token decoding failure")
+    var firstTokenLogProbThreshold: Float?
+
     @Option(help: "Probability threshold to consider a segment as silence")
     var noSpeechThreshold: Float?
 

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -104,6 +104,7 @@ struct Transcribe: AsyncParsableCommand {
             supressTokens: cliArguments.supressTokens,
             compressionRatioThreshold: cliArguments.compressionRatioThreshold,
             logProbThreshold: cliArguments.logprobThreshold,
+            firstTokenLogProbThreshold: cliArguments.firstTokenLogProbThreshold,
             noSpeechThreshold: cliArguments.noSpeechThreshold
         )
 
@@ -205,6 +206,7 @@ struct Transcribe: AsyncParsableCommand {
             supressTokens: cliArguments.supressTokens,
             compressionRatioThreshold: cliArguments.compressionRatioThreshold ?? 2.4,
             logProbThreshold: cliArguments.logprobThreshold ?? -1.0,
+            firstTokenLogProbThreshold: cliArguments.firstTokenLogProbThreshold ?? -0.7,
             noSpeechThreshold: cliArguments.noSpeechThreshold ?? 0.6
         )
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -178,7 +178,7 @@ final class UnitTests: XCTestCase {
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -Float16.infinity)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -FloatType.infinity)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
@@ -198,7 +198,7 @@ final class UnitTests: XCTestCase {
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -Float16.infinity)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -FloatType.infinity)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -173,7 +173,7 @@ final class UnitTests: XCTestCase {
         let decodingOptions = DecodingOptions(
             withoutTimestamps: true,
             compressionRatioThreshold: nil,
-            logProbThreshold: 100.0,
+            logProbThreshold: 1000.0,
             firstTokenLogProbThreshold: nil,
             noSpeechThreshold: nil
         )
@@ -190,7 +190,7 @@ final class UnitTests: XCTestCase {
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
 
-        let fallback = try XCTUnwrap(decoderOutput.first?.fallback)
+        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback is `nil` \(String(describing: decoderOutput.first))")
         XCTAssertEqual(fallback.fallbackReason, "logProbThreshold")
         XCTAssertTrue(fallback.needsFallback)
     }
@@ -200,7 +200,7 @@ final class UnitTests: XCTestCase {
             withoutTimestamps: true,
             compressionRatioThreshold: nil,
             logProbThreshold: nil,
-            firstTokenLogProbThreshold: 100.0,
+            firstTokenLogProbThreshold: 1000.0,
             noSpeechThreshold: nil
         )
         var textDecoder = TextDecoder()
@@ -216,7 +216,7 @@ final class UnitTests: XCTestCase {
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
 
-        let fallback = try XCTUnwrap(decoderOutput.first?.fallback)
+        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback is `nil` \(String(describing: decoderOutput.first))")
         XCTAssertEqual(fallback.fallbackReason, "firstTokenLogProbThreshold")
         XCTAssertTrue(fallback.needsFallback)
     }
@@ -361,7 +361,7 @@ final class UnitTests: XCTestCase {
         let silence = [Float](repeating: 0.0, count: 30 * 16000)
         let multiWindowSamples = audioSamples + silence + audioSamples
 
-        let options = DecodingOptions(usePrefillPrompt: true, withoutTimestamps: false)
+        let options = DecodingOptions(usePrefillPrompt: true, withoutTimestamps: false, firstTokenLogProbThreshold: nil)
 
         let result = try? await whisperKit!.transcribe(audioArray: multiWindowSamples, decodeOptions: options)
         XCTAssertEqual(result?.segments.count, 3, "Expected 3 segments")

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -194,14 +194,14 @@ final class UnitTests: XCTestCase {
             noSpeechThreshold: nil
         )
         var textDecoder = TextDecoder()
-        let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
         try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
-        let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
+        let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.specialTokens.endToken, decodingOptions: decodingOptions)
 
         let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: FloatType(0))
-        let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
+        let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.specialTokens.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
@@ -220,14 +220,14 @@ final class UnitTests: XCTestCase {
             noSpeechThreshold: nil
         )
         var textDecoder = TextDecoder()
-        let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
         try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
-        let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
+        let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.specialTokens.endToken, decodingOptions: decodingOptions)
 
         let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: FloatType(0))
-        let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
+        let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.specialTokens.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -184,13 +184,13 @@ final class UnitTests: XCTestCase {
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: FloatType(0))
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
 
-        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback is `nil` \(String(describing: decoderOutput.first))")
+        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback should not be `nil`")
         XCTAssertEqual(fallback.fallbackReason, "logProbThreshold")
         XCTAssertTrue(fallback.needsFallback)
     }
@@ -210,13 +210,13 @@ final class UnitTests: XCTestCase {
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: FloatType(0))
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
         let decoderOutput = try await textDecoder.decodeText(from: encoderInput, using: inputs, sampler: tokenSampler, options: decodingOptions)
 
-        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback is `nil` \(String(describing: decoderOutput.first))")
+        let fallback = try XCTUnwrap(decoderOutput.first?.fallback, "Fallback should not be `nil`")
         XCTAssertEqual(fallback.fallbackReason, "firstTokenLogProbThreshold")
         XCTAssertTrue(fallback.needsFallback)
     }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -171,14 +171,14 @@ final class UnitTests: XCTestCase {
     
     func testDecoderLogProbThresholdDecodingFallback() async throws {
         var textDecoder = TextDecoder()
-        let decodingOptions = DecodingOptions(logProbThreshold: -1.0)
+        let decodingOptions = DecodingOptions(logProbThreshold: -1.0, firstTokenLogProbThreshold: nil)
         let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
         try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -Float16.infinity)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
@@ -191,14 +191,14 @@ final class UnitTests: XCTestCase {
 
     func testDecoderFirstTokenLogProbThresholdDecodingFallback() async throws {
         var textDecoder = TextDecoder()
-        let decodingOptions = DecodingOptions(firstTokenLogProbThreshold: -1.0)
+        let decodingOptions = DecodingOptions(logProbThreshold: nil, firstTokenLogProbThreshold: -1.0)
         let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
         try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
 
-        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let encoderInput = initMLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16, initialValue: -Float16.infinity)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -170,31 +170,20 @@ final class UnitTests: XCTestCase {
     }
     
     func testDecoderLogProbThresholdDecodingFallback() async throws {
-        let computeUnits = ModelComputeOptions()
         let decodingOptions = DecodingOptions(
             compressionRatioThreshold: nil,
-            logProbThreshold: -1.0,
-            firstTokenLogProbThreshold: nil
+            logProbThreshold: 100.0,
+            firstTokenLogProbThreshold: nil,
+            noSpeechThreshold: nil
         )
-        let modelPath = URL(filePath: tinyModelPath())
-
-        var audioEncoder = AudioEncoder()
-        try await audioEncoder.loadModel(
-            at: modelPath.appending(path: "AudioEncoder.mlmodelc"),
-            computeUnits: computeUnits.audioEncoderCompute
-        )
-
         var textDecoder = TextDecoder()
-        try await textDecoder.loadModel(
-            at: modelPath.appending(path: "TextDecoder.mlmodelc"),
-            computeUnits: computeUnits.textDecoderCompute
-        )
+        let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
-        let audioFeatures = initMLMultiArray(shape: [1, 80, 1, 3000], dataType: .float16, initialValue: -FloatType.infinity)
-        let audioEncoderInput = try await audioEncoder.encodeFeatures(audioFeatures)
-        let encoderInput = try XCTUnwrap(audioEncoderInput)
+
+        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")
@@ -206,31 +195,20 @@ final class UnitTests: XCTestCase {
     }
 
     func testDecoderFirstTokenLogProbThresholdDecodingFallback() async throws {
-        let computeUnits = ModelComputeOptions()
         let decodingOptions = DecodingOptions(
             compressionRatioThreshold: nil,
             logProbThreshold: nil,
-            firstTokenLogProbThreshold: -1.0
+            firstTokenLogProbThreshold: 100.0,
+            noSpeechThreshold: nil
         )
-        let modelPath = URL(filePath: tinyModelPath())
-
-        var audioEncoder = AudioEncoder()
-        try await audioEncoder.loadModel(
-            at: modelPath.appending(path: "AudioEncoder.mlmodelc"),
-            computeUnits: computeUnits.audioEncoderCompute
-        )
-
         var textDecoder = TextDecoder()
-        try await textDecoder.loadModel(
-            at: modelPath.appending(path: "TextDecoder.mlmodelc"),
-            computeUnits: computeUnits.textDecoderCompute
-        )
+        let modelPath = URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
         textDecoder.tokenizer = try await loadTokenizer(for: .tiny)
 
         let tokenSampler = GreedyTokenSampler(temperature: 0, eotToken: textDecoder.tokenizer!.endToken, decodingOptions: decodingOptions)
-        let audioFeatures = initMLMultiArray(shape: [1, 80, 1, 3000], dataType: .float16, initialValue: -FloatType.infinity)
-        let audioEncoderInput = try await audioEncoder.encodeFeatures(audioFeatures)
-        let encoderInput = try XCTUnwrap(audioEncoderInput)
+
+        let encoderInput = try MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
         let decoderInputs = textDecoder.prepareDecoderInputs(withPrompt: [textDecoder.tokenizer!.startOfTranscriptToken])
 
         let inputs = try XCTUnwrap(decoderInputs, "Failed to prepare decoder inputs")

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -171,6 +171,7 @@ final class UnitTests: XCTestCase {
     
     func testDecoderLogProbThresholdDecodingFallback() async throws {
         let decodingOptions = DecodingOptions(
+            withoutTimestamps: true,
             compressionRatioThreshold: nil,
             logProbThreshold: 100.0,
             firstTokenLogProbThreshold: nil,
@@ -196,6 +197,7 @@ final class UnitTests: XCTestCase {
 
     func testDecoderFirstTokenLogProbThresholdDecodingFallback() async throws {
         let decodingOptions = DecodingOptions(
+            withoutTimestamps: true,
             compressionRatioThreshold: nil,
             logProbThreshold: nil,
             firstTokenLogProbThreshold: 100.0,


### PR DESCRIPTION
Should resolve https://github.com/argmaxinc/WhisperKit/issues/37

- added new parameter `firstTokenLogProbThreshold` to `DecodingOptions` and `CLIArguments`
- added condition in `TextDecoder` `decodeText` method to check if the first token log prob is less than the threshold and if so, break the decoding loop and return the `DecodingResult` together with `DecodingFallback` property
- added tests

I did some testing and looks like the best value for `first-token-log-prob-threshold` is -0.7. I tested it using the [following audio](https://mega.nz/file/tFVBxK7A#L1OVn-B1DDxxs9uKKYyqninm60Tn6eeAzqUaLGU0tsc) taken from https://github.com/openai/whisper/discussions/1873 

To replicate the results, you can run the following commands:

```
swift run whisperkit-cli transcribe --model-path openai_whisper-large-v3 --audio-path 3min-kitchen-audio.mp3 --temperature-fallback-count 0 --first-token-log-prob-threshold=-1.0 --verbose
```

and

```
swift run whisperkit-cli transcribe --model-path openai_whisper-large-v3 --audio-path 3min-kitchen-audio.mp3 --temperature-fallback-count 0 --first-token-log-prob-threshold=-0.7 --verbose
```

The `temperature-fallback-count` param set to 0 is important here, if not provieded, the decoder will try to sample again with a higher temperature if the first token is not a valid one.

Running the 1st one will give you the following (or similar) output:

```
[WhisperKit] [0.00 --> 30.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [30.00 --> 34.00] <|startoftranscript|><|jw|><|translate|><|0.00|> Add the chicken and stir-fry for 2 minutes<|4.00|>
[WhisperKit] [34.00 --> 38.00] <|4.00|> Add the chicken and stir-fry for 2 minutes<|8.00|>
[WhisperKit] [38.00 --> 42.00] <|8.00|> Add the chicken and stir-fry for 2 minutes<|12.00|>
[WhisperKit] [42.00 --> 46.00] <|12.00|> Add the chicken and stir-fry for 2 minutes<|16.00|>
[WhisperKit] [46.00 --> 50.00] <|16.00|> Add the chicken and stir-fry for 2 minutes<|20.00|>
[WhisperKit] [50.00 --> 54.00] <|20.00|> Add the chicken and stir-fry for 2 minutes<|24.00|>
[WhisperKit] [54.00 --> 58.00] <|24.00|> Add the chicken and stir-fry for 2 minutes<|28.00|>
[WhisperKit] [58.00 --> 88.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [88.00 --> 118.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [118.00 --> 148.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [148.00 --> 178.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [178.00 --> 180.00] <|startoftranscript|><|endoftext|>
```

Running the 2nd one will give you the following (or similar) output:

```
[WhisperKit] [0.00 --> 30.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [30.00 --> 60.00] <|startoftranscript|><|endoftext|>
[WhisperKit] [60.00 --> 90.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [90.00 --> 120.00] <|startoftranscript|><|endoftext|>
[WhisperKit] [120.00 --> 150.00] <|startoftranscript|><|nospeech|><|endoftext|>
[WhisperKit] [150.00 --> 180.00] <|startoftranscript|><|nospeech|><|endoftext|>
```