### PR TITLE
Async batch predictions

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1107,10 +1107,7 @@ struct ContentView: View {
     // MARK: - Transcribe Logic
 
     func transcribeCurrentFile(path: String) async throws {
-        guard let audioFileBuffer = AudioProcessor.loadAudio(fromPath: path) else {
-            return
-        }
-
+        let audioFileBuffer = try AudioProcessor.loadAudio(fromPath: path)
         let audioFileSamples = AudioProcessor.convertBufferToArray(buffer: audioFileBuffer)
         let transcription = try await transcribeAudioSamples(audioFileSamples)
 

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -731,7 +731,7 @@ struct ContentView: View {
             VStack {
                 Text("Max Tokens Per Loop")
                 HStack {
-                    Slider(value: $sampleLength, in: 0...Double(min(whisperKit?.textDecoder.kvCacheMaxSequenceLength ?? WhisperKit.maxTokenContext, WhisperKit.maxTokenContext)), step: 10)
+                    Slider(value: $sampleLength, in: 0...Double(min(whisperKit?.textDecoder.kvCacheMaxSequenceLength ?? Constants.maxTokenContext, Constants.maxTokenContext)), step: 10)
                     Text(sampleLength.formatted(.number))
                         .frame(width: 30)
                     InfoButton("Maximum number of tokens to generate per loop.\nCan be lowered based on the type of speech in order to further prevent repetition loops from going too long.")
@@ -937,7 +937,7 @@ struct ContentView: View {
                         localModels.append(model)
                     }
                     
-                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = Constants.languages.map { $0.key }.sorted()
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -1137,7 +1137,7 @@ struct ContentView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 
@@ -1353,7 +1353,7 @@ struct ContentView: View {
             return nil
         }
 
-        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
 
         let options = DecodingOptions(

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -535,7 +535,7 @@ struct WhisperAXWatchView: View {
         }
 
         let transcription = try await whisperKit.transcribe(audioArray: samples, decodeOptions: options, callback: decodingCallback)
-        return transcription
+        return transcription.first
     }
 
     // MARK: Streaming Logic

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -407,7 +407,7 @@ struct WhisperAXWatchView: View {
                 try await whisperKit.loadModels()
 
                 await MainActor.run {
-                    availableLanguages = whisperKit.tokenizer?.languages.map { $0.key }.sorted() ?? ["english"]
+                    availableLanguages = Constants.languages.map { $0.key }.sorted()
                     loadingProgressValue = 1.0
                     modelState = whisperKit.modelState
                 }
@@ -489,7 +489,7 @@ struct WhisperAXWatchView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = whisperKit.tokenizer?.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage] ?? "en"
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 
@@ -534,7 +534,11 @@ struct WhisperAXWatchView: View {
             return nil
         }
 
-        let transcription = try await whisperKit.transcribe(audioArray: samples, decodeOptions: options, callback: decodingCallback)
+        let transcription: [TranscriptionResult] = try await whisperKit.transcribe(
+            audioArray: samples,
+            decodeOptions: options,
+            callback: decodingCallback
+        )
         return transcription.first
     }
 

--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -50,9 +50,8 @@ public class AudioEncoder: AudioEncoding, WhisperMLModel {
         }
         try Task.checkCancellation()
 
-        let signpostId = signposter.makeSignpostID()
-        let interval = signposter.beginInterval("EncodeAudio", id: signpostId)
-        defer { signposter.endInterval("EncodeAudio", interval) }
+        let interval = Logging.beginSignpost("EncodeAudio", signposter: signposter)
+        defer { Logging.endSignpost("EncodeAudio", interval: interval, signposter: signposter) }
 
         let modelInputs = AudioEncoderInput(melspectrogram_features: features)
         let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())

--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -5,7 +5,7 @@ import CoreML
 import OSLog
 
 private let logger = Logger(
-    subsystem: "com.argmax.whisperkit.WhisperAX",
+    subsystem: Constants.Logging.subsystem,
     category: "AudioEncoding"
 )
 private let signposter = OSSignposter(logger: logger)

--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -2,13 +2,6 @@
 //  Copyright © 2024 Argmax, Inc. All rights reserved.
 
 import CoreML
-import OSLog
-
-private let logger = Logger(
-    subsystem: Constants.Logging.subsystem,
-    category: "AudioEncoding"
-)
-private let signposter = OSSignposter(logger: logger)
 
 /// AudioEncoding protocol defines the requirements for an audio encoding implementation.
 public protocol AudioEncoding {
@@ -50,8 +43,8 @@ public class AudioEncoder: AudioEncoding, WhisperMLModel {
         }
         try Task.checkCancellation()
 
-        let interval = Logging.beginSignpost("EncodeAudio", signposter: signposter)
-        defer { Logging.endSignpost("EncodeAudio", interval: interval, signposter: signposter) }
+        let interval = Logging.beginSignpost("EncodeAudio", signposter: Logging.AudioEncoding.signposter)
+        defer { Logging.endSignpost("EncodeAudio", interval: interval, signposter: Logging.AudioEncoding.signposter) }
 
         let modelInputs = AudioEncoderInput(melspectrogram_features: features)
         let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())

--- a/Sources/WhisperKit/Core/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/AudioProcessor.swift
@@ -191,8 +191,8 @@ public class AudioProcessor: NSObject, AudioProcessing {
             }
             outputBuffer = buffer
         }
-        Logging.info("Audio source details - Sample Rate: \(sampleRate) Hz, Channel Count: \(channelCount), Frame Length: \(frameLength), Duration: \(Double(frameLength) / sampleRate)s")
-        Logging.info("Audio buffer details - Sample Rate: \(outputBuffer.format.sampleRate) Hz, Channel Count: \(outputBuffer.format.channelCount), Frame Length: \(outputBuffer.frameLength), Duration: \(Double(outputBuffer.frameLength) / outputBuffer.format.sampleRate)s")
+        Logging.debug("Audio source details - Sample Rate: \(sampleRate) Hz, Channel Count: \(channelCount), Frame Length: \(frameLength), Duration: \(Double(frameLength) / sampleRate)s")
+        Logging.debug("Audio buffer details - Sample Rate: \(outputBuffer.format.sampleRate) Hz, Channel Count: \(outputBuffer.format.channelCount), Frame Length: \(outputBuffer.frameLength), Duration: \(Double(outputBuffer.frameLength) / outputBuffer.format.sampleRate)s")
         return outputBuffer
     }
 

--- a/Sources/WhisperKit/Core/AudioStreamTranscriber.swift
+++ b/Sources/WhisperKit/Core/AudioStreamTranscriber.swift
@@ -22,7 +22,7 @@ public extension AudioStreamTranscriber {
 public typealias AudioStreamTranscriberCallback = (AudioStreamTranscriber.State, AudioStreamTranscriber.State) -> Void
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public typealias AudioStreamTranscribe = ([Float], DecodingOptions?, TranscriptionCallback) async throws -> TranscriptionResult?
+public typealias AudioStreamTranscribe = ([Float], DecodingOptions?, TranscriptionCallback) async throws -> [TranscriptionResult]
 
 /// Responsible for streaming audio from the microphone, processing it, and transcribing it in real-time.
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
@@ -166,7 +166,7 @@ public actor AudioStreamTranscriber {
 
         state.currentText = ""
         state.unconfirmedText = []
-        guard let segments = transcription?.segments else {
+        guard let segments = transcription.first?.segments else {
             return
         }
 
@@ -197,7 +197,7 @@ public actor AudioStreamTranscriber {
         }
     }
 
-    private func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
+    private func transcribeAudioSamples(_ samples: [Float]) async throws -> [TranscriptionResult] {
         var options = decodingOptions
         options.clipTimestamps = [state.lastConfirmedSegmentEndSeconds]
         let checkWindow = compressionCheckWindow

--- a/Sources/WhisperKit/Core/AudioStreamTranscriber.swift
+++ b/Sources/WhisperKit/Core/AudioStreamTranscriber.swift
@@ -41,7 +41,6 @@ public actor AudioStreamTranscriber {
     private let decodingOptions: DecodingOptions
 
     public init(
-        maxTokenContext: Int,
         audioEncoder: any AudioEncoding,
         featureExtractor: any FeatureExtracting,
         segmentSeeker: any SegmentSeeking,
@@ -56,7 +55,6 @@ public actor AudioStreamTranscriber {
         stateChangeCallback: AudioStreamTranscriberCallback?
     ) {
         self.transcribeTask = TranscribeTask(
-            maxTokenContext: maxTokenContext,
             currentTimings: TranscriptionTimings(),
             progress: Progress(),
             audioEncoder: audioEncoder,

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -39,9 +39,8 @@ open class FeatureExtractor: FeatureExtracting, WhisperMLModel {
         }
         try Task.checkCancellation()
 
-        let signpostId = signposter.makeSignpostID()
-        let interval = signposter.beginInterval("ExtractAudioFeatures", id: signpostId)
-        defer { signposter.endInterval("ExtractAudioFeatures", interval) }
+        let interval = Logging.beginSignpost("ExtractAudioFeatures", signposter: signposter)
+        defer { Logging.endSignpost("ExtractAudioFeatures", interval: interval, signposter: signposter) }
 
         let modelInputs = MelSpectrogramInput(audio: inputAudio)
         let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 
 private let logger = Logger(
-    subsystem: "com.argmax.whisperkit.WhisperAX",
+    subsystem: Constants.Logging.subsystem,
     category: "FeatureExtractor"
 )
 private let signposter = OSSignposter(logger: logger)

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -6,13 +6,6 @@ import AVFoundation
 import CoreGraphics
 import CoreML
 import Foundation
-import OSLog
-
-private let logger = Logger(
-    subsystem: Constants.Logging.subsystem,
-    category: "FeatureExtractor"
-)
-private let signposter = OSSignposter(logger: logger)
 
 public protocol FeatureExtracting {
     var melCount: Int? { get }
@@ -39,8 +32,8 @@ open class FeatureExtractor: FeatureExtracting, WhisperMLModel {
         }
         try Task.checkCancellation()
 
-        let interval = Logging.beginSignpost("ExtractAudioFeatures", signposter: signposter)
-        defer { Logging.endSignpost("ExtractAudioFeatures", interval: interval, signposter: signposter) }
+        let interval = Logging.beginSignpost("ExtractAudioFeatures", signposter: Logging.FeatureExtractor.signposter)
+        defer { Logging.endSignpost("ExtractAudioFeatures", interval: interval, signposter: Logging.FeatureExtractor.signposter) }
 
         let modelInputs = MelSpectrogramInput(audio: inputAudio)
         let outputFeatures = try await model.asyncPrediction(from: modelInputs, options: MLPredictionOptions())

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -282,7 +282,7 @@ public struct DecodingOptions {
                 temperature: Float = 0.0,
                 temperatureIncrementOnFallback: Float = 0.2,
                 temperatureFallbackCount: Int = 5,
-                sampleLength: Int = WhisperKit.maxTokenContext,
+                sampleLength: Int = Constants.maxTokenContext,
                 topK: Int = 5,
                 usePrefillPrompt: Bool = true,
                 usePrefillCache: Bool = true,
@@ -455,7 +455,6 @@ public enum WhisperError: Error, LocalizedError, Equatable {
 
 public struct TranscriptionResult: Codable {
     public var text: String
-    public var totalTokens: Int
     public var segments: [TranscriptionSegment]
     public var language: String
     public var timings: TranscriptionTimings
@@ -476,6 +475,7 @@ public struct TranscriptionResult: Codable {
         let timeToFirstToken = timings.firstTokenTime - timings.pipelineStart
         let tokensPerSecond = timings.tokensPerSecond
         let rtf = timings.realTimeFactor
+        let totalTokens = segments.reduce(0) { $0 + $1.tokens.count }
 
         let fullPipelineDuration = timings.fullPipeline * 1000 // Convert to milliseconds
 
@@ -1238,6 +1238,11 @@ extension WhisperTokenizerWrapper {
 // MARK: Constants
 
 public enum Constants {
+    enum Logging {
+        static let subsystem = "com.argmax.whisperkit"
+    }
+
+    public static let maxTokenContext = Int(448 / 2)
     public static let languages: [String: String] =
         [
             "english": "en",
@@ -1353,22 +1358,4 @@ public enum Constants {
             "castilian": "es",
             "mandarin": "zh",
         ]
-}
-
-// MARK: - Constants
-
-enum Constants {
-    enum Logging {
-        static let subsystem = "com.argmax.whisperkit.Whisper"
-    }
-}
-
-// MARK: - Extensions
-
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
-    }
 }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -250,6 +250,7 @@ public struct DecodingOptions {
     public var logProbThreshold: Float?
     public var firstTokenLogProbThreshold: Float?
     public var noSpeechThreshold: Float?
+    public var concurrentWorkerCount: Int
 
     public init(verbose: Bool = false,
                 task: DecodingTask = .transcribe,
@@ -273,7 +274,8 @@ public struct DecodingOptions {
                 compressionRatioThreshold: Float? = 2.4,
                 logProbThreshold: Float? = -1.0,
                 firstTokenLogProbThreshold: Float? = -1.5,
-                noSpeechThreshold: Float? = 0.6)
+                noSpeechThreshold: Float? = 0.6,
+                concurrentWorkerCount: Int = 0)
     {
         self.verbose = verbose
         self.task = task
@@ -298,6 +300,7 @@ public struct DecodingOptions {
         self.logProbThreshold = logProbThreshold
         self.firstTokenLogProbThreshold = firstTokenLogProbThreshold
         self.noSpeechThreshold = noSpeechThreshold
+        self.concurrentWorkerCount = concurrentWorkerCount
     }
 }
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -373,13 +373,14 @@ public struct DecodingResult {
     }
 }
 
-enum WhisperError: Error, LocalizedError {
+enum WhisperError: Error, LocalizedError, Equatable {
     case tokenizerUnavailable(String = "Tokenizer is unavailable")
     case modelsUnavailable(String = "Models are unavailable")
     case prefillFailed(String = "Prefill failed")
     case audioProcessingFailed(String = "Audio processing failed")
     case decodingLogitsFailed(String = "Unable to decode logits from the model output")
     case segmentingFailed(String = "Creating segments failed")
+    case loadAudioFailed(String = "Load audio failed")
 
     var errorDescription: String? {
         switch self {
@@ -399,6 +400,9 @@ enum WhisperError: Error, LocalizedError {
                 Logging.error(message)
                 return message
             case let .segmentingFailed(message):
+                Logging.error(message)
+                return message
+            case let .loadAudioFailed(message):
                 Logging.error(message)
                 return message
         }
@@ -1231,4 +1235,22 @@ extension WhisperTokenizerWrapper {
     static var defaultNoSpeechToken: Int { 50362 }
     static var defaultNoTimestampsToken: Int { 50363 }
     static var defaultTimeTokenBegin: Int { 50364 }
+}
+
+// MARK: - Constants
+
+enum Constants {
+    enum Logging {
+        static let subsystem = "com.argmax.whisperkit.Whisper"
+    }
+}
+
+// MARK: - Extensions
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
 }

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -1,0 +1,349 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import Foundation
+import OSLog
+import CoreML
+
+private let logger = Logger(
+    subsystem: Constants.Logging.subsystem,
+    category: "TranscribeTask"
+)
+private let signposter = OSSignposter(logger: logger)
+
+/// Responsible for transcribing audio chunk to text using the provided models and configurations.
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+final class TranscribeTask {
+    private let maxTokenContext: Int
+    private var timings: TranscriptionTimings
+    private let progress: Progress
+    private let audioEncoder: any AudioEncoding
+    private let featureExtractor: any FeatureExtracting
+    private let segmentSeeker: any SegmentSeeking
+    private let textDecoder: any TextDecoding
+    private let tokenizer: any WhisperTokenizer
+
+    init(
+        maxTokenContext: Int,
+        currentTimings: TranscriptionTimings,
+        progress: Progress?,
+        audioEncoder: any AudioEncoding,
+        featureExtractor: any FeatureExtracting,
+        segmentSeeker: any SegmentSeeking,
+        textDecoder: any TextDecoding,
+        tokenizer: any WhisperTokenizer
+    ) {
+        self.maxTokenContext = maxTokenContext
+        self.timings = currentTimings
+        self.progress = progress ?? Progress()
+        self.audioEncoder = audioEncoder
+        self.featureExtractor = featureExtractor
+        self.segmentSeeker = segmentSeeker
+        self.textDecoder = textDecoder
+        self.tokenizer = tokenizer
+    }
+
+    func run(
+        audioArray: [Float],
+        decodeOptions: DecodingOptions? = nil,
+        callback: TranscriptionCallback = nil
+    ) async throws -> TranscriptionResult {
+        let interval = Logging.beginSignpost("TranscribeAudio", signposter: signposter)
+        defer { Logging.endSignpost("TranscribeAudio", interval: interval, signposter: signposter) }
+
+        timings.pipelineStart = CFAbsoluteTimeGetCurrent()
+
+        var options = decodeOptions ?? DecodingOptions()
+        options.verbose = Logging.shared.logLevel != .none
+
+        var detectedLanguage: String?
+
+        let contentFrames = audioArray.count
+        timings.inputAudioSeconds = Double(Int(contentFrames) / WhisperKit.sampleRate) - Double(decodeOptions?.clipTimestamps.first ?? 0)
+
+        // MARK: Init decoder inputs
+
+        // These accumulate across windows
+        var allSegments: [TranscriptionSegment] = []
+        var allTokens: [Int] = []
+        var transcription = ""
+
+        let startDecoderInit = CFAbsoluteTimeGetCurrent()
+        var decoderInputs = try textDecoder.prepareDecoderInputs(withPrompt: [tokenizer.specialTokens.startOfTranscriptToken])
+        let decoderInitTime = CFAbsoluteTimeGetCurrent() - startDecoderInit
+        timings.decodingInit = decoderInitTime
+        Logging.debug("Decoder init time: \(decoderInitTime)")
+
+        // MARK: - Prefill KV Cache
+
+        let prefillStartTime = CFAbsoluteTimeGetCurrent()
+        var prefilledCacheSize = 0
+        if options.usePrefillPrompt {
+            let prefilledInputs = try await textDecoder.prefillDecoderInputs(decoderInputs, withOptions: options)
+            decoderInputs = prefilledInputs
+            prefilledCacheSize = decoderInputs.cacheLength[0].intValue
+        }
+        let prefillTime = CFAbsoluteTimeGetCurrent() - prefillStartTime
+        timings.prefill = prefillTime
+
+        // Setup masks based on prefill values
+        prefilledCacheSize += 1 // Add 1 for initial masked cache update
+        decoderInputs.kvCacheUpdateMask[prefilledCacheSize - 1] = 1.0
+        for i in 0..<prefilledCacheSize {
+            decoderInputs.decoderKeyPaddingMask[i] = 0.0
+        }
+
+        Logging.debug("Prefill time: \(prefillTime)")
+        Logging.debug("Prefill prompt: \(decoderInputs.initialPrompt.map { tokenizer.convertIdToToken($0) ?? "" })")
+
+        // MARK: - Main decoder loop
+
+        var fallbackCount: Double = 0
+
+        // Process seek clips
+        var seekPoints: [Int] = options.clipTimestamps.map { Int(round($0 * Float(WhisperKit.sampleRate))) }
+        if seekPoints.count == 0 {
+            seekPoints.append(0)
+        }
+        if seekPoints.count % 2 == 1 {
+            seekPoints.append(contentFrames)
+        }
+
+        var seekClips: [(start: Int, end: Int)] = []
+        for i in stride(from: 0, to: seekPoints.count, by: 2) {
+            let start = seekPoints[i]
+            let end = i + 1 < seekPoints.count ? seekPoints[i + 1] : contentFrames
+            seekClips.append((start, end))
+        }
+
+        let startDecodeLoopTime = CFAbsoluteTimeGetCurrent()
+
+        let totalSeekDuration = seekClips.reduce(0) { $0 + ($1.end - $1.start) }
+        progress.totalUnitCount = Int64(totalSeekDuration)
+        defer { progress.completedUnitCount = progress.totalUnitCount }
+        for (seekClipStart, seekClipEnd) in seekClips {
+            // Loop through the current clip until we reach the end
+            // Typically this will be the full audio file, unless seek points are explicitly provided
+            var seek: Int = seekClipStart
+
+            let previousSeekProgress = progress.completedUnitCount
+
+            let windowPadding = 16000 // prevent hallucinations at the end of the clip by stopping up to 1.0s early
+            while seek < seekClipEnd - windowPadding {
+                // calculate new encoder segment features
+                Logging.debug("Decoding Seek: \(seek)")
+                let timeOffset = Float(seek) / Float(WhisperKit.sampleRate)
+                let segmentSize = min(WhisperKit.windowSamples, contentFrames - seek, seekClipEnd - seek)
+                let timeOffsetEnd = Float(seek + segmentSize) / Float(WhisperKit.sampleRate)
+
+                let audioProcessingStart = Date()
+                guard let audioSamples = AudioProcessor.padOrTrimAudio(fromArray: audioArray, startAt: seek, toLength: WhisperKit.windowSamples) else {
+                    throw WhisperError.transcriptionFailed("Audio samples are nil")
+                }
+                let processTime = Date().timeIntervalSince(audioProcessingStart)
+                timings.audioProcessing += processTime
+                timings.totalAudioProcessingRuns += 1
+
+                try Task.checkCancellation()
+                let melStart = Date()
+                guard let melOutput = try await featureExtractor.logMelSpectrogram(fromAudio: audioSamples) else {
+                    throw WhisperError.transcriptionFailed("Mel output is nil")
+                }
+                let melTime = Date().timeIntervalSince(melStart)
+                timings.logmels += melTime
+                timings.totalLogmelRuns += 1
+
+                try Task.checkCancellation()
+                let encoderStart = Date()
+                guard let encoderOutput = try await audioEncoder.encodeFeatures(melOutput) else {
+                    throw WhisperError.transcriptionFailed("Encoder output is nil")
+                }
+                let encoderTime = Date().timeIntervalSince(encoderStart)
+                timings.encoding += encoderTime
+                timings.totalEncodingRuns += 1
+
+                // All features are computed, now we can decode
+                Logging.info("Decoding \(timeOffset)s - \(timeOffsetEnd)s")
+
+                try Task.checkCancellation()
+                // Send to decoder to predict text tokens with fallback
+                let decodingResult = try await decodeWithFallback(encoderSegment: encoderOutput, decodingOptions: options, callback: callback)
+
+                // MARK: Windowing
+
+                // At this point we have a completed window aka segment
+                let windowingStart = Date()
+
+                let previousSeek = seek
+                var (newSeek, currentSegments) = segmentSeeker.findSeekPointAndSegments(
+                    decodingResult: decodingResult,
+                    options: options,
+                    allSegmentsCount: allSegments.count,
+                    currentSeek: seek,
+                    segmentSize: segmentSize,
+                    sampleRate: WhisperKit.sampleRate,
+                    timeToken: tokenizer.specialTokens.timeTokenBegin,
+                    specialToken: tokenizer.specialTokens.specialTokenBegin,
+                    tokenizer: tokenizer
+                )
+
+                // Update seek point without moving backward
+                seek = max(seek, newSeek)
+
+                // Optionally add word timestamps
+                if options.wordTimestamps,
+                   let alignmentWeights = decodingResult.cache?.alignmentWeights
+                {
+                    let wordTimestampsStart = Date()
+                    currentSegments = try segmentSeeker.addWordTimestamps(
+                        segments: currentSegments ?? [],
+                        alignmentWeights: alignmentWeights,
+                        tokenizer: tokenizer,
+                        seek: previousSeek,
+                        segmentSize: segmentSize,
+                        prependPunctuations: "\"'“¿([{-",
+                        appendPunctuations: "\"'.。,，!！?？:：”)]}、",
+                        lastSpeechTimestamp: currentSegments?.last?.end ?? 0,
+                        options: options,
+                        timings: timings
+                    )
+
+                    timings.decodingWordTimestamps += Date().timeIntervalSince(wordTimestampsStart)
+                    timings.totalTimestampAlignmentRuns += 1
+
+                    // Update seek point with new (more accurate) segments
+                    if let lastSpeechTimestamp = currentSegments?.last?.end {
+                        seek = max(seek, Int(lastSpeechTimestamp * Float(WhisperKit.sampleRate)))
+                    }
+
+                    if options.verbose {
+                        Logging.debug("Word timestamps:")
+                        for segment in currentSegments ?? [] {
+                            for word in segment.words ?? [] {
+                                Logging.debug("[\(word.start.formatted(.number.precision(.significantDigits(3)))) -> \(word.end.formatted(.number.precision(.significantDigits(3))))] prob: \(word.probability), word: \(word.word)")
+                            }
+                        }
+                    }
+                }
+
+                guard let currentSegments = currentSegments else {
+                    // No current segment found, skip to next window
+                    continue
+                }
+
+                if options.verbose {
+                    let lines = formatSegments(currentSegments)
+                    for line in lines {
+                        Logging.debug(line)
+                    }
+                }
+
+                // add them to the `allSegments` list
+                allSegments.append(contentsOf: currentSegments)
+                let allCurrentTokens = currentSegments.flatMap { $0.tokens }
+                allTokens.append(contentsOf: allCurrentTokens)
+
+                timings.decodingWindowing += Date().timeIntervalSince(windowingStart)
+                timings.totalDecodingWindows += 1
+
+                // Reset cache and move on to the next window
+                decoderInputs.reset(prefilledCacheSize: prefilledCacheSize, maxTokenContext: maxTokenContext)
+
+                let clipProgress = min(seek, seekClipEnd) - seekClipStart
+                progress.completedUnitCount = previousSeekProgress + Int64(clipProgress)
+            }
+        }
+
+        func decodeWithFallback(
+            encoderSegment encoderOutput: MLMultiArray,
+            decodingOptions options: DecodingOptions,
+            callback: TranscriptionCallback = nil
+        ) async throws -> DecodingResult {
+            let interval = Logging.beginSignpost("Decode", signposter: signposter)
+            defer { Logging.endSignpost("Decode", interval: interval, signposter: signposter) }
+
+            // Fallback `options.temperatureFallbackCount` times with increasing temperatures, starting at `options.temperature`
+            let temperatures = (0...options.temperatureFallbackCount).map { FloatType(options.temperature) + FloatType($0) * FloatType(options.temperatureIncrementOnFallback) }
+
+            Logging.debug("Decoding with tempeartures \(temperatures)")
+
+            var decodingResult: DecodingResult?
+
+            for (i, temp) in temperatures.enumerated() {
+                Logging.info("Decoding Temperature: \(temp)")
+                let decodeWithFallbackStart = Date()
+
+                let tokenSampler = GreedyTokenSampler(temperature: temp, eotToken: tokenizer.specialTokens.endToken, decodingOptions: options)
+
+                var currentDecodingOptions = options
+                // For a multilingual model, if language is not passed and usePrefill is false, detect language and set in options
+                if textDecoder.isModelMultilingual, options.language == nil, !options.usePrefillPrompt {
+                    let languageDecodingResult = try? await textDecoder.detectLanguage(
+                        from: encoderOutput,
+                        using: decoderInputs,
+                        sampler: tokenSampler,
+                        options: options,
+                        temperature: temp
+                    )
+                    detectedLanguage = languageDecodingResult?.language
+                    currentDecodingOptions.language = languageDecodingResult?.language
+                }
+
+                decodingResult = try await textDecoder.decodeText(
+                    from: encoderOutput,
+                    using: decoderInputs,
+                    sampler: tokenSampler,
+                    options: currentDecodingOptions,
+                    callback: callback
+                )
+
+                // Update timings from the decoder main loop
+                if let decodingTimings = decodingResult?.timings {
+                    if timings.firstTokenTime == 0 {
+                        timings.firstTokenTime = decodingTimings.firstTokenTime
+                    }
+                    timings.decodingPredictions += decodingTimings.decodingPredictions
+                    timings.totalDecodingLoops += decodingTimings.totalDecodingLoops
+                    timings.decodingNonPrediction += decodingTimings.decodingNonPrediction
+                    timings.decodingFiltering += decodingTimings.decodingFiltering
+                    timings.decodingSampling += decodingTimings.decodingSampling
+                    timings.decodingKvCaching += decodingTimings.decodingKvCaching
+                    timings.totalKVUpdateRuns += decodingTimings.totalKVUpdateRuns
+                }
+
+                // MARK: Fallback checks
+
+                if let fallback = decodingResult?.fallback, fallback.needsFallback {
+                    // Reset decoder inputs for fallback
+                    fallbackCount = Double(i)
+                    timings.decodingFallback += Date().timeIntervalSince(decodeWithFallbackStart)
+                    timings.totalDecodingFallbacks = fallbackCount
+                    decoderInputs.reset(prefilledCacheSize: prefilledCacheSize, maxTokenContext: maxTokenContext)
+                    Logging.info("Fallback #\(fallbackCount + 1) (\(fallback.fallbackReason))")
+                } else {
+                    break
+                }
+            }
+
+            guard let decodingResult else {
+                throw WhisperError.decodingFailed()
+            }
+            return decodingResult
+        }
+
+        // MARK: Result
+
+        timings.decodingLoop = CFAbsoluteTimeGetCurrent() - startDecodeLoopTime
+        timings.fullPipeline = CFAbsoluteTimeGetCurrent() - timings.pipelineStart
+
+        let wordTokens = allTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+        transcription = tokenizer.decode(tokens: wordTokens).trimmingCharacters(in: .whitespaces)
+        return TranscriptionResult(
+            text: transcription,
+            totalTokens: allTokens.count,
+            segments: allSegments,
+            language: detectedLanguage ?? "en",
+            timings: timings
+        )
+    }
+}

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -6,6 +6,7 @@ import CoreML
 import Foundation
 import Hub
 import Tokenizers
+import os.signpost
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -96,7 +97,6 @@ public extension WhisperKit {
     }
 }
 
-
 extension Float {
     func rounded(_ decimalPlaces: Int) -> Float {
         let divisor = pow(10.0, Float(decimalPlaces))
@@ -119,14 +119,6 @@ extension String {
         let singleSpacedString = noPunctuationString.replacingOccurrences(of: " +", with: " ", options: .regularExpression)
 
         return singleSpacedString
-    }
-}
-
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
     }
 }
 
@@ -567,9 +559,20 @@ public class Logging {
     }
 }
 
+extension Logging {
+    static func beginSignpost(
+        _ intervalName: StaticString,
+        signposter: OSSignposter
+    ) -> OSSignpostIntervalState {
+        let signpostId = signposter.makeSignpostID()
+        return signposter.beginInterval(intervalName, id: signpostId)
+    }
 
-enum Constants {
-    enum Logging {
-        static let subsystem = "com.argmax.whisperkit.Whisper"
+    static func endSignpost(
+        _ intervalName: StaticString,
+        interval: OSSignpostIntervalState,
+        signposter: OSSignposter
+    ) {
+        signposter.endInterval(intervalName, interval)
     }
 }

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -393,52 +393,50 @@ public func mergeTranscriptionResults(_ results: [TranscriptionResult?], confirm
     let validResults = results.compactMap { $0 }
     let language = validResults.first?.language ?? "en"
 
-    var mergedSegments: [TranscriptionSegment] = []
+    let mergedSegments = validResults.flatMap { $0.segments }
     let mergedText = confirmedWords.map { $0.word }.joined()
-
-    for result in validResults {
-        mergedSegments.append(contentsOf: result.segments)
-    }
+    let totalTokens = validResults.map { $0.totalTokens }.reduce(0, +)
 
     var mergedTimings = TranscriptionTimings(
-        modelLoading: validResults.map { $0.timings?.modelLoading ?? 0 }.max() ?? 0,
-        audioLoading: validResults.map { $0.timings?.audioLoading ?? 0 }.reduce(0, +),
-        audioProcessing: validResults.map { $0.timings?.audioProcessing ?? 0 }.reduce(0, +),
-        logmels: validResults.map { $0.timings?.logmels ?? 0 }.reduce(0, +),
-        encoding: validResults.map { $0.timings?.encoding ?? 0 }.reduce(0, +),
-        prefill: validResults.map { $0.timings?.prefill ?? 0 }.reduce(0, +),
-        decodingInit: validResults.map { $0.timings?.decodingInit ?? 0 }.reduce(0, +),
-        decodingLoop: validResults.map { $0.timings?.decodingLoop ?? 0 }.reduce(0, +),
-        decodingPredictions: validResults.map { $0.timings?.decodingPredictions ?? 0 }.reduce(0, +),
-        decodingFiltering: validResults.map { $0.timings?.decodingFiltering ?? 0 }.reduce(0, +),
-        decodingSampling: validResults.map { $0.timings?.decodingSampling ?? 0 }.reduce(0, +),
-        decodingFallback: validResults.map { $0.timings?.decodingFallback ?? 0 }.reduce(0, +),
-        decodingWindowing: validResults.map { $0.timings?.decodingWindowing ?? 0 }.reduce(0, +),
-        decodingKvCaching: validResults.map { $0.timings?.decodingKvCaching ?? 0 }.reduce(0, +),
-        decodingTimestampAlignment: validResults.map { $0.timings?.decodingWordTimestamps ?? 0 }.reduce(0, +),
-        decodingNonPrediction: validResults.map { $0.timings?.decodingNonPrediction ?? 0 }.reduce(0, +),
-        totalAudioProcessingRuns: validResults.map { $0.timings?.totalAudioProcessingRuns ?? 0 }.reduce(0, +),
-        totalLogmelRuns: validResults.map { $0.timings?.totalLogmelRuns ?? 0 }.reduce(0, +),
-        totalEncodingRuns: validResults.map { $0.timings?.totalEncodingRuns ?? 0 }.reduce(0, +),
-        totalDecodingLoops: validResults.map { $0.timings?.totalDecodingLoops ?? 0 }.reduce(0, +),
-        totalKVUpdateRuns: validResults.map { $0.timings?.totalKVUpdateRuns ?? 0 }.reduce(0, +),
-        totalTimestampAlignmentRuns: validResults.map { $0.timings?.totalTimestampAlignmentRuns ?? 0 }.reduce(0, +),
-        totalDecodingFallbacks: validResults.map { $0.timings?.totalDecodingFallbacks ?? 0 }.reduce(0, +),
-        totalDecodingWindows: validResults.map { $0.timings?.totalDecodingWindows ?? 0 }.reduce(0, +),
-        fullPipeline: validResults.map { $0.timings?.fullPipeline ?? 0 }.reduce(0, +)
+        modelLoading: validResults.map { $0.timings.modelLoading }.max() ?? 0,
+        audioLoading: validResults.map { $0.timings.audioLoading }.reduce(0, +),
+        audioProcessing: validResults.map { $0.timings.audioProcessing }.reduce(0, +),
+        logmels: validResults.map { $0.timings.logmels }.reduce(0, +),
+        encoding: validResults.map { $0.timings.encoding }.reduce(0, +),
+        prefill: validResults.map { $0.timings.prefill }.reduce(0, +),
+        decodingInit: validResults.map { $0.timings.decodingInit }.reduce(0, +),
+        decodingLoop: validResults.map { $0.timings.decodingLoop }.reduce(0, +),
+        decodingPredictions: validResults.map { $0.timings.decodingPredictions }.reduce(0, +),
+        decodingFiltering: validResults.map { $0.timings.decodingFiltering }.reduce(0, +),
+        decodingSampling: validResults.map { $0.timings.decodingSampling }.reduce(0, +),
+        decodingFallback: validResults.map { $0.timings.decodingFallback }.reduce(0, +),
+        decodingWindowing: validResults.map { $0.timings.decodingWindowing }.reduce(0, +),
+        decodingKvCaching: validResults.map { $0.timings.decodingKvCaching }.reduce(0, +),
+        decodingTimestampAlignment: validResults.map { $0.timings.decodingWordTimestamps }.reduce(0, +),
+        decodingNonPrediction: validResults.map { $0.timings.decodingNonPrediction }.reduce(0, +),
+        totalAudioProcessingRuns: validResults.map { $0.timings.totalAudioProcessingRuns }.reduce(0, +),
+        totalLogmelRuns: validResults.map { $0.timings.totalLogmelRuns }.reduce(0, +),
+        totalEncodingRuns: validResults.map { $0.timings.totalEncodingRuns }.reduce(0, +),
+        totalDecodingLoops: validResults.map { $0.timings.totalDecodingLoops }.reduce(0, +),
+        totalKVUpdateRuns: validResults.map { $0.timings.totalKVUpdateRuns }.reduce(0, +),
+        totalTimestampAlignmentRuns: validResults.map { $0.timings.totalTimestampAlignmentRuns }.reduce(0, +),
+        totalDecodingFallbacks: validResults.map { $0.timings.totalDecodingFallbacks }.reduce(0, +),
+        totalDecodingWindows: validResults.map { $0.timings.totalDecodingWindows }.reduce(0, +),
+        fullPipeline: validResults.map { $0.timings.fullPipeline }.reduce(0, +)
     )
 
-    mergedTimings.inputAudioSeconds = validResults.map { $0.timings?.inputAudioSeconds ?? 0 }.reduce(0, +)
+    mergedTimings.inputAudioSeconds = validResults.map { $0.timings.inputAudioSeconds }.reduce(0, +)
 
     // Average first token times
-    if let pipelineStart = validResults.first?.timings?.pipelineStart {
-        let averageFirstTokenTime = validResults.map { (($0.timings?.firstTokenTime ?? 0) - ($0.timings?.pipelineStart ?? 0)) }.reduce(0, +) / Double(validResults.count)
+    if let pipelineStart = validResults.first?.timings.pipelineStart {
+        let averageFirstTokenTime = validResults.map { (($0.timings.firstTokenTime) - ($0.timings.pipelineStart)) }.reduce(0, +) / Double(validResults.count)
         mergedTimings.pipelineStart = pipelineStart
         mergedTimings.firstTokenTime = pipelineStart + averageFirstTokenTime
     }
 
     return TranscriptionResult(
         text: mergedText,
+        totalTokens: totalTokens,
         segments: mergedSegments,
         language: language,
         timings: mergedTimings

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -566,3 +566,10 @@ public class Logging {
         }
     }
 }
+
+
+enum Constants {
+    enum Logging {
+        static let subsystem = "com.argmax.whisperkit.Whisper"
+    }
+}

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -122,6 +122,14 @@ extension String {
     }
 }
 
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}
+
 // MARK: - Helpers
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -15,6 +15,14 @@ import AppKit
 
 // MARK: - Extensions
 
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}
+
 extension MLMultiArray {
     /// Calculate the linear offset by summing the products of each dimension’s index with the dimension’s stride.
     /// More info [here](https://developer.apple.com/documentation/coreml/mlmultiarray/2879231-subscript)
@@ -395,7 +403,6 @@ public func mergeTranscriptionResults(_ results: [TranscriptionResult?], confirm
 
     let mergedSegments = validResults.flatMap { $0.segments }
     let mergedText = confirmedWords.map { $0.word }.joined()
-    let totalTokens = validResults.map { $0.totalTokens }.reduce(0, +)
 
     var mergedTimings = TranscriptionTimings(
         modelLoading: validResults.map { $0.timings.modelLoading }.max() ?? 0,
@@ -436,7 +443,6 @@ public func mergeTranscriptionResults(_ results: [TranscriptionResult?], confirm
 
     return TranscriptionResult(
         text: mergedText,
-        totalTokens: totalTokens,
         segments: mergedSegments,
         language: language,
         timings: mergedTimings
@@ -554,6 +560,36 @@ public class Logging {
         if shared.logLevel.shouldLog(level: .error) {
             shared.log(items, separator: separator, terminator: terminator)
         }
+    }
+}
+
+extension Logging {
+    enum AudioEncoding {
+        static let logger = Logger(
+            subsystem: Constants.Logging.subsystem,
+            category: "AudioEncoding"
+        )
+        static let signposter = OSSignposter(logger: logger)
+    }
+}
+
+extension Logging {
+    enum FeatureExtractor {
+        static let logger = Logger(
+            subsystem: Constants.Logging.subsystem,
+            category: "FeatureExtractor"
+        )
+        static let signposter = OSSignposter(logger: logger)
+    }
+}
+
+extension Logging {
+    enum TranscribeTask {
+        static let logger = Logger(
+            subsystem: Constants.Logging.subsystem,
+            category: "TranscribeTask"
+        )
+        static let signposter = OSSignposter(logger: logger)
     }
 }
 

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -4,8 +4,8 @@
 import ArgumentParser
 
 struct CLIArguments: ParsableArguments {
-    @Option(help: "Path to audio file")
-    var audioPath: String = "Tests/WhisperKitTests/Resources/jfk.wav"
+    @Option(help: "Paths to audio files")
+    var audioPath = [String]()
 
     @Option(help: "Path of model files")
     var modelPath: String?
@@ -96,4 +96,7 @@ struct CLIArguments: ParsableArguments {
 
     @Flag(help: "Simulate streaming transcription using the input audio file")
     var streamSimulated: Bool = false
+
+    @Option(help: "Maximum concurrent inference, might be helpful when processing more than 1 audio file at the same time. 0 means unlimited")
+    var concurrentWorkerCount: Int = 0
 }

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -68,7 +68,7 @@ struct Transcribe: AsyncParsableCommand {
             options.prefixTokens = tokenizer.encode(text: " " + prefixText.trimmingCharacters(in: .whitespaces)).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         }
 
-        let transcribeResult = await whisperKit.transcribe(
+        let transcribeResult: [Result<[TranscriptionResult], Swift.Error>] = await whisperKit.transcribe(
             audioPaths: resolvedAudioPaths,
             decodeOptions: options
         )
@@ -101,7 +101,6 @@ struct Transcribe: AsyncParsableCommand {
         let decodingOptions = decodingOptions(task: .transcribe)
 
         let audioStreamTranscriber = AudioStreamTranscriber(
-            maxTokenContext: WhisperKit.maxTokenContext,
             audioEncoder: whisperKit.audioEncoder,
             featureExtractor: whisperKit.featureExtractor,
             segmentSeeker: whisperKit.segmentSeeker,

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -68,7 +68,7 @@ struct Transcribe: AsyncParsableCommand {
         for (audioPath, result) in zip(resolvedAudioPaths, transcribeResult) {
             switch result {
             case .success(let transcribeResult):
-                processTranscriptionResult(audioPath: audioPath, transcribeResult: transcribeResult)
+                processTranscriptionResult(audioPath: audioPath, transcribeResult: transcribeResult.first)
             case .failure(let error):
                 print("Error when transcribing \(audioPath): \(error)")
             }
@@ -160,7 +160,7 @@ struct Transcribe: AsyncParsableCommand {
             let lastAgreedTokens = lastAgreedWords.flatMap { $0.tokens }
             streamOptions.prefixTokens = lastAgreedTokens
             do {
-                let result: TranscriptionResult? = try await whisperKit.transcribe(audioArray: simulatedStreamingAudio, decodeOptions: streamOptions)
+                let result: TranscriptionResult? = try await whisperKit.transcribe(audioArray: simulatedStreamingAudio, decodeOptions: streamOptions).first
                 var skipAppend = false
                 if let result = result, let _ = result.segments.first?.words {
                     hypothesisWords = result.allWords.filter { $0.start >= lastAgreedSeconds }

--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -82,6 +82,9 @@ struct Transcribe: AsyncParsableCommand {
         }
 
         let whisperKit = try await setupWhisperKit()
+        guard let tokenizer = whisperKit.tokenizer else {
+            throw WhisperError.tokenizerUnavailable()
+        }
 
         if cliArguments.verbose {
             print("Models initialized")
@@ -90,8 +93,13 @@ struct Transcribe: AsyncParsableCommand {
         let decodingOptions = decodingOptions(task: .transcribe)
 
         let audioStreamTranscriber = AudioStreamTranscriber(
+            maxTokenContext: WhisperKit.maxTokenContext,
+            audioEncoder: whisperKit.audioEncoder,
+            featureExtractor: whisperKit.featureExtractor,
+            segmentSeeker: whisperKit.segmentSeeker,
+            textDecoder: whisperKit.textDecoder,
+            tokenizer: tokenizer,
             audioProcessor: whisperKit.audioProcessor,
-            transcribe: whisperKit.transcribe,
             decodingOptions: decodingOptions
         ) { oldState, newState in
             guard oldState.currentText != newState.currentText ||

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -159,18 +159,48 @@ final class FunctionalTests: XCTestCase {
         )
 
         XCTAssertEqual(transcriptionResults.count, 3)
-        XCTAssertTrue(transcriptionResults.allSatisfy { $0.value.isSuccess })
+        XCTAssertTrue(transcriptionResults.allSatisfy { $0.isSuccess })
         XCTAssertEqual(
-            try transcriptionResults[audioPaths[0]]?.normalizedText(prefix: 5),
+            try transcriptionResults[0].normalizedText(prefix: 5),
             "and so my fellow americans"
         )
         XCTAssertEqual(
-            try transcriptionResults[audioPaths[1]]?.normalizedText(prefix: 2),
+            try transcriptionResults[1].normalizedText(prefix: 2),
             "this is"
         )
         XCTAssertEqual(
-            try transcriptionResults[audioPaths[2]]?.normalizedText(prefix: 1),
+            try transcriptionResults[2].normalizedText(prefix: 1),
             "tokyo"
+        )
+    }
+
+    func testBatchTranscribeAudioPathsWithErrors() async throws {
+        let audioPaths = [
+            "/path/to/file1.wav",
+            try XCTUnwrap(
+                Bundle.module.path(forResource: "jfk", ofType: "wav"),
+                "Audio file not found"
+            ),
+            "/path/to/file2.wav"
+        ]
+        let whisperKit = try await WhisperKit(modelFolder: try tinyModelPath())
+        let transcriptionResults = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioPaths: audioPaths),
+            "Transcription failed"
+        )
+
+        XCTAssertEqual(transcriptionResults.count, 3)
+        XCTAssertEqual(
+            transcriptionResults[0].whisperError(),
+            .loadAudioFailed("Resource path does not exist /path/to/file1.wav")
+        )
+        XCTAssertEqual(
+            try transcriptionResults[1].normalizedText(prefix: 5),
+            "and so my fellow americans"
+        )
+        XCTAssertEqual(
+            transcriptionResults[2].whisperError(),
+            .loadAudioFailed("Resource path does not exist /path/to/file2.wav")
         )
     }
 
@@ -189,8 +219,8 @@ final class FunctionalTests: XCTestCase {
                 "Audio file not found"
             )
         ]
-        let audioArrays = audioPaths
-            .compactMap { AudioProcessor.loadAudio(fromPath: $0) }
+        let audioArrays = try audioPaths
+            .map { try AudioProcessor.loadAudio(fromPath: $0) }
             .map { AudioProcessor.convertBufferToArray(buffer: $0) }
 
         let whisperKit = try await WhisperKit(modelFolder: try tinyModelPath())

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -35,9 +35,11 @@ final class FunctionalTests: XCTestCase {
                 "Transcription failed"
             )
 
-            print("[Integration] \(transcriptionResult.text)")
+            let transcriptionResultText = transcriptionResult.text
+
+            print("[Integration] \(transcriptionResultText)")
             XCTAssertEqual(
-                transcriptionResult.text.normalized,
+                transcriptionResultText.normalized,
                 " And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.".normalized,
                 "Transcription result does not match expected result for model \(modelName)"
             )
@@ -66,7 +68,8 @@ final class FunctionalTests: XCTestCase {
                     await whisperKit.transcribe(audioPath: audioFilePath),
                     "Transcription failed"
                 )
-                XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+                let transcriptionResultText = transcriptionResult.map(\.text).joined(separator: " ")
+                XCTAssertGreaterThan(transcriptionResultText.count, 0)
                 dispatchSemaphore.signal()
             }
             dispatchSemaphore.wait()
@@ -253,26 +256,17 @@ final class FunctionalTests: XCTestCase {
 
         var pipe = try await WhisperKit(model: "large-v3", verbose: true, logLevel: .debug)
 
-        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
-            XCTFail("Transcription failed")
-            return
-        }
-        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+        let transcriptionResult1 = try await pipe.transcribe(audioPath: audioFilePath)
+        XCTAssertFalse(transcriptionResult1.text.isEmpty)
 
         pipe = try await WhisperKit(model: "distil*large-v3", verbose: true, logLevel: .debug)
 
-        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
-            XCTFail("Transcription failed")
-            return
-        }
-        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+        let transcriptionResult2 = try await pipe.transcribe(audioPath: audioFilePath)
+        XCTAssertFalse(transcriptionResult2.text.isEmpty)
 
         pipe = try await WhisperKit(model: "distil-whisper_distil-large-v3", verbose: true, logLevel: .debug)
 
-        guard let transcriptionResult = try await pipe.transcribe(audioPath: audioFilePath) else {
-            XCTFail("Transcription failed")
-            return
-        }
-        XCTAssertGreaterThan(transcriptionResult.text.count, 0)
+        let transcriptionResult3 = try await pipe.transcribe(audioPath: audioFilePath)
+        XCTAssertFalse(transcriptionResult3.text.isEmpty)
     }
 }

--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -30,11 +30,7 @@ final class FunctionalTests: XCTestCase {
                 logLevel: .debug
             )
 
-            let transcriptionResult = try await XCTUnwrapAsync(
-                await whisperKit.transcribe(audioPath: audioFilePath),
-                "Transcription failed"
-            )
-
+            let transcriptionResult: [TranscriptionResult] = try await whisperKit.transcribe(audioPath: audioFilePath)
             let transcriptionResultText = transcriptionResult.text
 
             print("[Integration] \(transcriptionResultText)")
@@ -64,10 +60,7 @@ final class FunctionalTests: XCTestCase {
         measure(metrics: metrics, options: measureOptions) {
             let dispatchSemaphore = DispatchSemaphore(value: 0)
             Task {
-                let transcriptionResult = try await XCTUnwrapAsync(
-                    await whisperKit.transcribe(audioPath: audioFilePath),
-                    "Transcription failed"
-                )
+                let transcriptionResult: [TranscriptionResult] = try await whisperKit.transcribe(audioPath: audioFilePath)
                 let transcriptionResultText = transcriptionResult.map(\.text).joined(separator: " ")
                 XCTAssertGreaterThan(transcriptionResultText.count, 0)
                 dispatchSemaphore.signal()
@@ -94,10 +87,7 @@ final class FunctionalTests: XCTestCase {
         measure(metrics: metrics, options: measureOptions) {
             let dispatchSemaphore = DispatchSemaphore(value: 0)
             Task {
-                let transcriptionResult = try await XCTUnwrapAsync(
-                    await whisperKit.transcribe(audioPath: audioFilePath),
-                    "Transcription failed"
-                )
+                let transcriptionResult: [TranscriptionResult] = try await whisperKit.transcribe(audioPath: audioFilePath)
                 XCTAssertGreaterThan(transcriptionResult.text.count, 0)
                 dispatchSemaphore.signal()
             }
@@ -115,10 +105,7 @@ final class FunctionalTests: XCTestCase {
 
         Task {
             let whisperKit = try await XCTUnwrapAsync(await WhisperKit(model: "large-v3"))
-            let transcriptionResult = try await XCTUnwrapAsync(
-                await whisperKit.transcribe(audioPath: audioFilePath),
-                "Transcription failed"
-            )
+            let transcriptionResult: [TranscriptionResult] = try await whisperKit.transcribe(audioPath: audioFilePath)
             XCTAssertGreaterThan(transcriptionResult.text.count, 0)
             dispatchSemaphore.signal()
         }
@@ -132,10 +119,7 @@ final class FunctionalTests: XCTestCase {
             "Audio file not found"
         )
         let whisperKit = try await WhisperKit(model: "large-v3")
-        let transcriptionResult = try await XCTUnwrapAsync(
-            await whisperKit.transcribe(audioPath: audioFilePath),
-            "Transcription failed"
-        )
+        let transcriptionResult: [TranscriptionResult] = try await whisperKit.transcribe(audioPath: audioFilePath)
 
         XCTAssertGreaterThan(transcriptionResult.text.count, 0)
     }
@@ -156,10 +140,7 @@ final class FunctionalTests: XCTestCase {
             )
         ]
         let whisperKit = try await WhisperKit(modelFolder: try tinyModelPath())
-        let transcriptionResults = try await XCTUnwrapAsync(
-            await whisperKit.transcribe(audioPaths: audioPaths),
-            "Transcription failed"
-        )
+        let transcriptionResults: [Result<[TranscriptionResult], Swift.Error>] = await whisperKit.transcribe(audioPaths: audioPaths)
 
         XCTAssertEqual(transcriptionResults.count, 3)
         XCTAssertTrue(transcriptionResults.allSatisfy { $0.isSuccess })
@@ -187,10 +168,7 @@ final class FunctionalTests: XCTestCase {
             "/path/to/file2.wav"
         ]
         let whisperKit = try await WhisperKit(modelFolder: try tinyModelPath())
-        let transcriptionResults = try await XCTUnwrapAsync(
-            await whisperKit.transcribe(audioPaths: audioPaths),
-            "Transcription failed"
-        )
+        let transcriptionResults: [Result<[TranscriptionResult], Swift.Error>] = await whisperKit.transcribe(audioPaths: audioPaths)
 
         XCTAssertEqual(transcriptionResults.count, 3)
         XCTAssertEqual(
@@ -227,10 +205,7 @@ final class FunctionalTests: XCTestCase {
             .map { AudioProcessor.convertBufferToArray(buffer: $0) }
 
         let whisperKit = try await WhisperKit(modelFolder: try tinyModelPath())
-        let transcriptionResults = try await XCTUnwrapAsync(
-            await whisperKit.transcribe(audioArrays: audioArrays),
-            "Transcription failed"
-        )
+        let transcriptionResults: [Result<[TranscriptionResult], Swift.Error>] = await whisperKit.transcribe(audioArrays: audioArrays)
 
         XCTAssertEqual(transcriptionResults.count, 3)
         XCTAssertTrue(transcriptionResults.allSatisfy { $0.isSuccess })
@@ -249,24 +224,21 @@ final class FunctionalTests: XCTestCase {
     }
 
     func testModelSearchPathLarge() async throws {
-        guard let audioFilePath = Bundle.module.path(forResource: "jfk", ofType: "wav") else {
-            XCTFail("Audio file not found")
-            return
-        }
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "jfk", ofType: "wav"),
+            "Audio file not found"
+        )
 
-        var pipe = try await WhisperKit(model: "large-v3", verbose: true, logLevel: .debug)
-
-        let transcriptionResult1 = try await pipe.transcribe(audioPath: audioFilePath)
+        let pipe1 = try await WhisperKit(model: "large-v3", verbose: true, logLevel: .debug)
+        let transcriptionResult1: [TranscriptionResult] = try await pipe1.transcribe(audioPath: audioFilePath)
         XCTAssertFalse(transcriptionResult1.text.isEmpty)
 
-        pipe = try await WhisperKit(model: "distil*large-v3", verbose: true, logLevel: .debug)
-
-        let transcriptionResult2 = try await pipe.transcribe(audioPath: audioFilePath)
+        let pipe2 = try await WhisperKit(model: "distil*large-v3", verbose: true, logLevel: .debug)
+        let transcriptionResult2: [TranscriptionResult] = try await pipe2.transcribe(audioPath: audioFilePath)
         XCTAssertFalse(transcriptionResult2.text.isEmpty)
 
-        pipe = try await WhisperKit(model: "distil-whisper_distil-large-v3", verbose: true, logLevel: .debug)
-
-        let transcriptionResult3 = try await pipe.transcribe(audioPath: audioFilePath)
+        let pipe3 = try await WhisperKit(model: "distil-whisper_distil-large-v3", verbose: true, logLevel: .debug)
+        let transcriptionResult3: [TranscriptionResult] = try await pipe3.transcribe(audioPath: audioFilePath)
         XCTAssertFalse(transcriptionResult3.text.isEmpty)
     }
 }

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -244,6 +244,15 @@ extension Result {
             return false
         }
     }
+
+    func whisperError() -> WhisperError? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            return error as? WhisperError
+        }
+    }
 }
 
 extension Result where Success == TranscriptionResult {

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -234,3 +234,20 @@ extension SpecialTokens {
         )
     }
 }
+
+extension Result {
+    var isSuccess: Bool {
+        switch self {
+        case .success:
+            return true
+        case .failure:
+            return false
+        }
+    }
+}
+
+extension Result where Success == TranscriptionResult {
+    func normalizedText(prefix: Int) throws -> String {
+        try get().text.normalized.split(separator: " ").prefix(prefix).joined(separator: " ")
+    }
+}

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -107,7 +107,7 @@ extension XCTestCase {
         audioFile: String = "jfk.wav",
         file: StaticString = #file,
         line: UInt = #line
-    ) async throws -> TranscriptionResult? {
+    ) async throws -> [TranscriptionResult] {
         let modelPath: String
         switch variant {
             case .largev3:
@@ -255,8 +255,20 @@ extension Result {
     }
 }
 
-extension Result where Success == TranscriptionResult {
+extension Result where Success == [TranscriptionResult] {
     func normalizedText(prefix: Int) throws -> String {
         try get().text.normalized.split(separator: " ").prefix(prefix).joined(separator: " ")
+    }
+}
+
+extension Collection where Element == TranscriptionResult {
+    var text: String {
+        map(\.text).joined(separator: " ")
+    }
+}
+
+extension Collection where Element == TranscriptionResult {
+    var segments: [TranscriptionSegment] {
+        flatMap(\.segments)
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -34,10 +34,10 @@ final class UnitTests: XCTestCase {
             Bundle.module.path(forResource: "jfk", ofType: "wav"),
             "Audio file not found"
         )
-        let audioBuffer = AudioProcessor.loadAudio(fromPath: audioFilePath)
+        let audioBuffer = try AudioProcessor.loadAudio(fromPath: audioFilePath)
         XCTAssertNotNil(audioBuffer, "Failed to load audio file at path: \(audioFilePath)")
-        XCTAssertEqual(audioBuffer!.format.sampleRate, 16000)
-        XCTAssertEqual(audioBuffer!.format.channelCount, 1)
+        XCTAssertEqual(audioBuffer.format.sampleRate, 16000)
+        XCTAssertEqual(audioBuffer.format.channelCount, 1)
     }
 
     func testAudioPad() {
@@ -368,11 +368,7 @@ final class UnitTests: XCTestCase {
             Bundle.module.path(forResource: "jfk", ofType: "wav"),
             "Audio file not found"
         )
-        let audioBuffer = try XCTUnwrap(
-            AudioProcessor.loadAudio(fromPath: audioFilePath),
-            "Failed to load audio buffer"
-        )
-
+        let audioBuffer = try AudioProcessor.loadAudio(fromPath: audioFilePath)
         let audioSamples = AudioProcessor.convertBufferToArray(buffer: audioBuffer)
         let silence = [Float](repeating: 0.0, count: 30 * 16000)
         let multiWindowSamples = audioSamples + silence + audioSamples
@@ -610,7 +606,7 @@ final class UnitTests: XCTestCase {
             "Failed to transcribe"
         )
 
-        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
+        let tokenizer = try XCTUnwrap(whisperKit.tokenizer)
 
         XCTAssertTrue(result.segments.first!.tokens.contains(tokenizer.specialTokens.noSpeechToken))
     }
@@ -683,7 +679,7 @@ final class UnitTests: XCTestCase {
     func testPromptTokens() async throws {
         let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         let promptText = " prompt to encourage output without any punctuation and without capitalizing americans as if it was already normalized"
-        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
+        let tokenizer = try XCTUnwrap(whisperKit.tokenizer)
         let promptTokens = tokenizer.encode(text: promptText).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         let options = DecodingOptions(skipSpecialTokens: true, promptTokens: promptTokens)
 
@@ -699,7 +695,7 @@ final class UnitTests: XCTestCase {
         let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         // Prefix to encourage output without any punctuation and without capitalizing americans as if it was already normalized
         let prefixText = " and so my fellow americans"
-        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
+        let tokenizer = try XCTUnwrap(whisperKit.tokenizer)
         let prefixTokens = tokenizer.encode(text: prefixText).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         let options = DecodingOptions(skipSpecialTokens: true, prefixTokens: prefixTokens)
 
@@ -1220,10 +1216,7 @@ final class UnitTests: XCTestCase {
             XCTFail("Audio file not found")
             return
         }
-        guard let audioBuffer = AudioProcessor.loadAudio(fromPath: audioFileURL) else {
-            XCTFail("Failed to load audio buffer")
-            return
-        }
+        let audioBuffer = try AudioProcessor.loadAudio(fromPath: audioFileURL)
         let audioArray = AudioProcessor.convertBufferToArray(buffer: audioBuffer)
 
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -609,8 +609,10 @@ final class UnitTests: XCTestCase {
             await whisperKit.transcribe(audioArray: audioSamples, decodeOptions: options),
             "Failed to transcribe"
         )
-        
-        XCTAssertTrue(result.segments.first!.tokens.contains(whisperKit.tokenizer!.specialTokens.noSpeechToken))
+
+        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
+
+        XCTAssertTrue(result.segments.first!.tokens.contains(tokenizer.specialTokens.noSpeechToken))
     }
 
     func testTemperatureIncrement() async throws {
@@ -681,7 +683,7 @@ final class UnitTests: XCTestCase {
     func testPromptTokens() async throws {
         let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         let promptText = " prompt to encourage output without any punctuation and without capitalizing americans as if it was already normalized"
-        let tokenizer = whisperKit.tokenizer!
+        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
         let promptTokens = tokenizer.encode(text: promptText).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         let options = DecodingOptions(skipSpecialTokens: true, promptTokens: promptTokens)
 
@@ -697,7 +699,7 @@ final class UnitTests: XCTestCase {
         let whisperKit = try await WhisperKit(modelFolder: tinyModelPath(), verbose: true, logLevel: .debug)
         // Prefix to encourage output without any punctuation and without capitalizing americans as if it was already normalized
         let prefixText = " and so my fellow americans"
-        let tokenizer = whisperKit.tokenizer!
+        let tokenizer = try await XCTUnwrapAsync(await whisperKit.tokenizer)
         let prefixTokens = tokenizer.encode(text: prefixText).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
         let options = DecodingOptions(skipSpecialTokens: true, prefixTokens: prefixTokens)
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -732,6 +732,17 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(logits4.data(for: 2), [0.1, 0.2, -.infinity, -.infinity, -.infinity, 0.6, 0.7])
     }
 
+    func testChunkedArray() {
+        XCTAssertEqual([Int]().chunked(into: 1), [])
+        XCTAssertEqual([1, 2, 3, 4].chunked(into: 1), [[1], [2], [3], [4]])
+
+        XCTAssertEqual([Int]().chunked(into: 10), [])
+        XCTAssertEqual([1, 2, 3, 4].chunked(into: 10), [[1, 2, 3, 4]])
+
+        XCTAssertEqual([Int]().chunked(into: 3), [])
+        XCTAssertEqual([1, 2, 3, 4].chunked(into: 3), [[1, 2, 3], [4]])
+    }
+
     // MARK: - LogitsFilter Tests
 
     func testSuppressTokensFilter() throws {


### PR DESCRIPTION
Should partially resolve https://github.com/argmaxinc/WhisperKit/issues/97

- added audio file batch processing
- added `concurrentWorkerCount` responsible for controlling no of concurrent tasks
- added signposts for better tracing
- removed `Transcriber` protocol, made `WhipserKit` an open class
- added `TranscribeTask` class responsible for transcribing audio chunk to text and moved all the logic there
- added tests

This is how signposts look like in Instruments (for processing 5 audio files):

<img width="1020" alt="Screenshot 2024-04-04 at 11 30 49" src="https://github.com/argmaxinc/WhisperKit/assets/487331/56b4ddc0-b328-4472-b71c-d4678a7ab1d0">


Some benchmarks on my MacBook Air M1 (running in the release mode using tiny model `time swift run -c release whisperkit-cli transcribe [...]`):
- running on 1 file, 40:26 length -- 99.30s user, 11.07s system, 1:24.12 total
- running on 5 files, 40:26 length each -- 744.40s user, 111.61s system, 2:58.57 total
- running on 1 file, 0:11 length -- 0.73s user, 0.11s system, 1.535 total
- running on 5 files, 0:11 length each -- 2.55s user, 0.40s system, 1.780 total

using `Alice.mp3` file provided by @ZachNagengast:
- running on 1 file, 12:16 length -- 32.69s user, 3.71s system, 27.981 total
- running on 5 files, 12:16 length each -- 263.17s user, 39.25s system, 1:00.95 total

## API changes

### Deprecations

#### `WhisperKit`

1.

Deprecated

```swift
public func transcribe(
    audioPath: String,
    decodeOptions: DecodingOptions? = nil,
    callback: TranscriptionCallback = nil
) async throws -> TranscriptionResult?
```

use instead

```swift
public func transcribe(
    audioPath: String,
    decodeOptions: DecodingOptions? = nil,
    callback: TranscriptionCallback = nil
) async throws -> [TranscriptionResult]
```

2.

Deprecated

```swift
public func transcribe(
    audioArray: [Float],
    decodeOptions: DecodingOptions? = nil,
    callback: TranscriptionCallback = nil
) async throws -> TranscriptionResult?
```

use instead

```swift
public func transcribe(
    audioArray: [Float],
    decodeOptions: DecodingOptions? = nil,
    callback: TranscriptionCallback = nil
) async throws -> [TranscriptionResult]
```

#### `TextDecoding`

1.

Deprecated

```swift
func decodeText(
    from encoderOutput: MLMultiArray,
    using decoderInputs: DecodingInputs,
    sampler tokenSampler: TokenSampling,
    options decoderOptions: DecodingOptions,
    callback: ((TranscriptionProgress) -> Bool?)?
) async throws -> [DecodingResult]
```

use instead

```swift
func decodeText(
    from encoderOutput: MLMultiArray,
    using decoderInputs: DecodingInputs,
    sampler tokenSampler: TokenSampling,
    options decoderOptions: DecodingOptions,
    callback: ((TranscriptionProgress) -> Bool?)?
) async throws -> DecodingResult
```

2.

Deprecated

```swift
func detectLanguage(
    from encoderOutput: MLMultiArray,
    using decoderInputs: DecodingInputs,
    sampler tokenSampler: TokenSampling,
    options: DecodingOptions,
    temperature: FloatType
) async throws -> [DecodingResult]
```

use instead

```swift
func detectLanguage(
    from encoderOutput: MLMultiArray,
    using decoderInputs: DecodingInputs,
    sampler tokenSampler: TokenSampling,
    options: DecodingOptions,
    temperature: FloatType
) async throws -> DecodingResult
```

### Breaking changes

- removed `Transcriber` protocol

#### `AudioProcessing`

```swift
static func loadAudio(fromPath audioFilePath: String) -> AVAudioPCMBuffer?
```

becomes

```swift
static func loadAudio(fromPath audioFilePath: String) throws -> AVAudioPCMBuffer
```

#### `AudioStreamTranscriber`

```swift
public init(
    audioProcessor: any AudioProcessing, 
    transcriber: any Transcriber, 
    decodingOptions: DecodingOptions, 
    requiredSegmentsForConfirmation: Int = 2, 
    silenceThreshold: Float = 0.3, 
    compressionCheckWindow: Int = 20, 
    useVAD: Bool = true, 
    stateChangeCallback: AudioStreamTranscriberCallback?
)
```

becomes

```swift
public init(
    audioEncoder: any AudioEncoding,
    featureExtractor: any FeatureExtracting,
    segmentSeeker: any SegmentSeeking,
    textDecoder: any TextDecoding,
    tokenizer: any WhisperTokenizer,
    audioProcessor: any AudioProcessing,
    decodingOptions: DecodingOptions,
    requiredSegmentsForConfirmation: Int = 2,
    silenceThreshold: Float = 0.3,
    compressionCheckWindow: Int = 20,
    useVAD: Bool = true,
    stateChangeCallback: AudioStreamTranscriberCallback?
)
```

#### `TextDecoding`

```swift
func prepareDecoderInputs(withPrompt initialPrompt: [Int]) -> DecodingInputs?
```

becomes

```swift
func prepareDecoderInputs(withPrompt initialPrompt: [Int]) throws -> DecodingInputs
```
