### PR TITLE
Add `microphoneUnavailable` error

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1066,6 +1066,13 @@ struct ContentView: View {
                    let device = devices.first(where: {$0.name == selectedAudioInput}) {
                     deviceId = device.id
                 }
+                // There is no built-in microphone for mac mini / studio
+                // Or use AVCaptureDevice.DiscoverySession to do more checks
+                if deviceId == nil {
+                    let error = WhisperError.microphoneUnavailable()
+                    print(error)
+                    throw error
+                }
                 #endif
 
                 try? audioProcessor.startRecordingLive(inputDeviceID: deviceId) { _ in

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1070,7 +1070,7 @@ struct ContentView: View {
                 // There is no built-in microphone
                 if deviceId == nil {
                     let error = WhisperError.microphoneUnavailable()
-                    print(error)
+                    Logging.error(error)
                     throw error
                 }
                 #endif

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1066,8 +1066,8 @@ struct ContentView: View {
                    let device = devices.first(where: {$0.name == selectedAudioInput}) {
                     deviceId = device.id
                 }
-                // There is no built-in microphone for mac mini / studio
-                // Or use AVCaptureDevice.DiscoverySession to do more checks
+
+                // There is no built-in microphone
                 if deviceId == nil {
                     let error = WhisperError.microphoneUnavailable()
                     print(error)

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1069,9 +1069,7 @@ struct ContentView: View {
 
                 // There is no built-in microphone
                 if deviceId == nil {
-                    let error = WhisperError.microphoneUnavailable()
-                    Logging.error(error)
-                    throw error
+                   throw WhisperError.microphoneUnavailable()
                 }
                 #endif
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -370,15 +370,16 @@ public struct DecodingResult {
     }
 }
 
-enum WhisperError: Error, LocalizedError {
+public enum WhisperError: Error, LocalizedError {
     case tokenizerUnavailable(String = "Tokenizer is unavailable")
     case modelsUnavailable(String = "Models are unavailable")
     case prefillFailed(String = "Prefill failed")
     case audioProcessingFailed(String = "Audio processing failed")
     case decodingLogitsFailed(String = "Unable to decode logits from the model output")
     case segmentingFailed(String = "Creating segments failed")
+    case microphoneUnavailable(String = "No available microphone to record or stream")
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
             case let .tokenizerUnavailable(message):
                 Logging.error(message)
@@ -396,6 +397,9 @@ enum WhisperError: Error, LocalizedError {
                 Logging.error(message)
                 return message
             case let .segmentingFailed(message):
+                Logging.error(message)
+                return message
+            case let .microphoneUnavailable(message):
                 Logging.error(message)
                 return message
         }


### PR DESCRIPTION
Hi guys, I'm testing `WhisperKit` on my mac mini / studio and there is no builtin microphone.

This change will prevent crash if you click "Record" or "Stream" button if you don't connect Earphones or Microphones.