### PR TITLE
Improve token timestamps and language detection

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -211,6 +211,7 @@ public struct DecodingCache {
 ///   - topK: Number of candidates when sampling with non-zero temperature.
 ///   - usePrefillPrompt: If true, the prefill tokens will be forced according to task and language settings.
 ///   - usePrefillCache: If true, the kv cache will be prefilled based on the prefill data mlmodel.
+///   - detectLanguage: Use this in conjuntion with `usePrefillPrompt: true` to detect the language of the input audio.
 ///   - skipSpecialTokens: Whether to skip special tokens in the output.
 ///   - withoutTimestamps: Whether to include timestamps in the transcription result.
 ///   - wordTimestamps: Whether to include word-level timestamps in the transcription result.
@@ -237,6 +238,7 @@ public struct DecodingOptions {
     public var topK: Int
     public var usePrefillPrompt: Bool
     public var usePrefillCache: Bool
+    public var detectLanguage: Bool
     public var skipSpecialTokens: Bool
     public var withoutTimestamps: Bool
     public var wordTimestamps: Bool
@@ -261,6 +263,7 @@ public struct DecodingOptions {
                 topK: Int = 5,
                 usePrefillPrompt: Bool = true,
                 usePrefillCache: Bool = true,
+                detectLanguage: Bool? = nil,
                 skipSpecialTokens: Bool = false,
                 withoutTimestamps: Bool = false,
                 wordTimestamps: Bool = false,
@@ -285,6 +288,7 @@ public struct DecodingOptions {
         self.topK = topK
         self.usePrefillPrompt = usePrefillPrompt
         self.usePrefillCache = usePrefillCache
+        self.detectLanguage = detectLanguage ?? !usePrefillPrompt // If prefill is false, detect language by default
         self.skipSpecialTokens = skipSpecialTokens
         self.withoutTimestamps = withoutTimestamps
         self.wordTimestamps = wordTimestamps
@@ -403,6 +407,7 @@ enum WhisperError: Error, LocalizedError {
 }
 
 /// Structs
+
 public struct TranscriptionResult: Codable {
     public var text: String
     public var segments: [TranscriptionSegment]
@@ -1166,6 +1171,10 @@ public extension WhisperTokenizer {
             "castilian": "es",
             "mandarin": "zh",
         ]
+    }
+
+    var allLanguageTokens: [Int] {
+        Array(Set(self.languages.compactMap { self.convertTokenToId("<|\($0.value)|>") }).filter { $0 > self.specialTokens.specialTokenBegin })
     }
 }
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -152,7 +152,7 @@ public struct ModelComputeOptions {
         self.prefillCompute = prefillCompute
         self.textDecoderCompute = textDecoderCompute
 
-        if #available(macOS 14.0, iOS 17.0, watchOS 10, *) {
+        if #available(macOS 14.0, iOS 17.0, *) {
             self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndNeuralEngine
         } else {
             self.audioEncoderCompute = audioEncoderCompute ?? .cpuAndGPU

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1027,7 +1027,6 @@ struct WhisperTokenizerWrapper: WhisperTokenizer {
     private func isPunctuation(_ text: String, tokenRange: Range<String.Index>, tag: NLTag?) -> Bool {
         let punctuationCharacters = CharacterSet.punctuationCharacters
         let token = String(text[tokenRange])
-        print(token)
         if let tag = tag, tag == .punctuation {
             return true
         } else if token.unicodeScalars.allSatisfy({ punctuationCharacters.contains($0) }) {

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -710,7 +710,6 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
         let transcript = tokenizer.decode(tokens: filteredTokens)
 
-        print(tokenProbs)
         let decodingFallback = DecodingFallback(
             options: options,
             isFirstTokenLogProbTooLow: isFirstTokenLogProbTooLow,

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -347,15 +347,15 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // 1. LanguageLogitsFilter for only language tokens
         // 2. GreedyTokenSampler for most likely language
         var timings = TranscriptionTimings()
-        let prefilledIndex = decoderInputs.cacheLength[0].intValue
-        let currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
-        var logProbs: [Float] = Array(repeating: 0, count: prefilledIndex + 1)
 
         guard let tokenizer = tokenizer else {
             // Tokenizer required for decoding
             throw WhisperError.tokenizerUnavailable()
         }
+
+        let prefilledIndex = 0
+        let currentTokens: [Int] = [tokenizer.specialTokens.startOfTranscriptToken]
+        var logProbs: [Float] = Array(repeating: 0, count: prefilledIndex + 1)
         
         guard let logitsSize = logitsSize else {
             throw WhisperError.modelsUnavailable("Failed to read logits size from model")
@@ -363,8 +363,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
         // Logits filters
         var logitsFilters: [any LogitsFiltering] = []
-        let allLanguageTokens:[Int] = tokenizer.languages.compactMap {tokenizer.convertTokenToId("<|\($0)|>")}
-        
+        let allLanguageTokens: [Int] = tokenizer.allLanguageTokens
+
         // language filter
         logitsFilters.append(
             LanguageLogitsFilter(
@@ -372,14 +372,11 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 logitsDim: logitsSize,
                 sampleBegin: prefilledIndex)
         )
-        Logging.debug("prefilled Index is \(prefilledIndex)")
 
         let tokenIndex = 0
         let prefillToken = currentTokens[tokenIndex]
-        nextToken = prefillToken
-        Logging.debug("Forcing token \(nextToken) at index \(tokenIndex) from initial prompt")
-        
-        
+        var nextToken = prefillToken
+
         // Set the current token as model input
         decoderInputs.inputIds[0] = NSNumber(value: nextToken)
         decoderInputs.cacheLength[0] = NSNumber(value: tokenIndex)
@@ -389,6 +386,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // Predict next token
         let inferenceTime = Date()
         
+        Logging.debug("Detecting language...")
         let predictedLogits = try await self.predictLogits(
             inputIds: decoderInputs.inputIds,
             cacheLength: decoderInputs.cacheLength,
@@ -398,7 +396,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             encoderOutputEmbeds: encoderOutput,
             decoderKeyPaddingMask: decoderInputs.decoderKeyPaddingMask
         )
-        Logging.debug("Predicted logits")
+
         guard let decoderOutput = predictedLogits else {
             Logging.error("Unable to decode logits")
             throw WhisperError.decodingLogitsFailed()
@@ -431,6 +429,9 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         var decodingResult = DecodingResult.emptyResults
         decodingResult.timings = timings
         decodingResult.language = String(detectedLanguage)
+
+        Logging.debug("Detected language: \(detectedLanguage)")
+
         return [decodingResult]
         
     }
@@ -500,9 +501,9 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             let isFirstToken = tokenIndex == prefilledIndex
           
             // Check if current index is part of the initial prompt
-            if tokenIndex <= intialPromptIndex {
+            if tokenIndex < intialPromptIndex {
                 nextToken = currentTokens[tokenIndex]
-                Logging.debug("Forcing token \(nextToken) at index \(tokenIndex) from initial prompt")
+                Logging.debug("Forcing prompt tokenIndex: \(tokenIndex), token: \(nextToken), text: \(tokenizer.decode(tokens: [nextToken]))")
             }
 
             // Set the current token as model input
@@ -625,7 +626,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 let compressionRatio = compressionRatio(of: currentTokens)
 
                 let result = TranscriptionProgress(timings: timings, text: currentTranscript, tokens: currentTokens, avgLogprob: averageLogProb, compressionRatio: compressionRatio)
-                Logging.debug("tokenIndex: \(tokenIndex), token: \(nextToken), word: \(tokenizer.decode(tokens: [nextToken]))")
+                Logging.debug("Predicted next tokenIndex: \(tokenIndex + 1), token: \(nextToken), text: \(tokenizer.decode(tokens: [nextToken]))")
 
                 // Call the callback if it is provided
                 if let shouldContinue = callback?(result) {
@@ -682,8 +683,34 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
         let noSpeechProb: Float = 0 // TODO: implement no speech prob
 
+        // If language is still nil here, check language can be inferred from tokens
+        var language = options.language ?? "en"
+        var languageProbs = [String: Float]()
+        if options.language == nil {
+            let allLanguageTokens: [Int] = tokenizer.allLanguageTokens
+
+            // Find the first token that is a recognized language token
+            if let predictedLanguageIndex = filteredTokens.firstIndex(where: { allLanguageTokens.contains($0) }),
+               predictedLanguageIndex < tokenProbs.count {
+                let predictedLanguageToken = filteredTokens[predictedLanguageIndex]
+                // Decode the predicted language token to get the language
+                language = tokenizer.decode(tokens: [predictedLanguageToken]).trimmingCharacters(in: CharacterSet(charactersIn: "<|>"))
+
+                // Fetch the corresponding probability for the predicted language
+                let probsDict = tokenProbs[predictedLanguageIndex]
+                languageProbs[language] = probsDict[predictedLanguageToken] ?? 0.0
+            } else {
+                // Set default values if no language token is found
+                languageProbs[language] = 0.0
+            }
+        } else {
+            // If language is provided, set the logprob to 0.0
+            languageProbs[language] = 0.0
+        }
+
         let transcript = tokenizer.decode(tokens: filteredTokens)
 
+        print(tokenProbs)
         let decodingFallback = DecodingFallback(
             options: options,
             isFirstTokenLogProbTooLow: isFirstTokenLogProbTooLow,
@@ -693,8 +720,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         )
 
         let decodingResult = DecodingResult(
-            language: options.language ?? "en",
-            languageProbs: [options.language ?? "en": 1.0],
+            language: language,
+            languageProbs: languageProbs,
             tokens: filteredTokens,
             tokenLogProbs: tokenProbs,
             text: transcript,

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -5,6 +5,7 @@ import AVFoundation
 import CoreML
 import Tokenizers
 import Hub
+import NaturalLanguage
 @testable import WhisperKit
 import XCTest
 
@@ -489,30 +490,59 @@ final class UnitTests: XCTestCase {
 
         XCTAssertEqual(result.text.split(separator: " ").prefix(4).joined(separator: " "), "Esta es una grabación")
     }
-    
-    func testDetectSpanish() async{
+
+    func testDetectSpanish() async throws {
         let targetLanguage = "es"
-        let prefillLanguage = "en"
-        let optionsNoPrefill = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false)
 
-        guard let resultNoPrefill = try? await transcribe(with: .tiny, options: optionsNoPrefill, audioFile: "es_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        let whisperKit = try await WhisperKit(
+            modelFolder: tinyModelPath(),
+            verbose: true,
+            logLevel: .debug
+        )
 
-        XCTAssertEqual(resultNoPrefill.language, targetLanguage)
-        
-        let optionsPrefill = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true)
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "es_test_clip", ofType: "wav"),
+            "Audio file not found"
+        )
 
-        guard let resultPrefill = try? await transcribe(with: .tiny, options: optionsPrefill, audioFile: "es_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+        // To detect language only, set `sampleLength` to 1 and no prefill prompt
+        let optionsDetectOnly = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, sampleLength: 1, detectLanguage: true)
 
-        XCTAssertEqual(resultPrefill.language, prefillLanguage)
+        let resultNoPrefill = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioPath: audioFilePath, decodeOptions: optionsDetectOnly),
+            "Failed to transcribe"
+        )
+
+         XCTAssertEqual(resultNoPrefill.language, targetLanguage)
     }
 
-    func testTranslateJapanese() async throws {
+    func testDetectSpanishOptions() async throws {
+        let optionsPairs: [(options: DecodingOptions, language: String)] = [
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true), "es"), // recommended usage for transcribing unknown language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true, promptTokens: [0]), "es"), // ensure prompt doesnt interfere
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: false), "en"), // en is the default prompt language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: nil), "en"), // en is the default prompt language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: true), "es"), // Unecessary combination, but can be useful if used with low `sampleLength` values to purely detect language and not decode (see above)
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: false), "es"), // no prefill, model will detect language naturally
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: nil), "es"), // no prefill, model will detect language naturally
+        ]
+
+        for (i, option) in optionsPairs.enumerated() {
+            let result = try await XCTUnwrapAsync(
+                await transcribe(with: .tiny, options: option.options, audioFile: "es_test_clip.wav"),
+                "Failed to transcribe"
+            )
+
+            let recognizer = NLLanguageRecognizer()
+            recognizer.processString(result.text)
+            let languageCode = recognizer.dominantLanguage!.rawValue
+
+            XCTAssertEqual(languageCode, option.language, "Text language \"\(languageCode)\" at index \(i) did not match expected language \"\(option.language)\"")
+            XCTAssertEqual(result.language, option.language, "Result language \"\(result.language)\" at index \(i) did not match expected language \"\(option.language)\"")
+        }
+    }
+
+    func testTranslateJapaneseOptions() async throws {
         let targetLanguage = "ja"
         let options = DecodingOptions(task: .translate, language: targetLanguage, temperatureFallbackCount: 0)
 
@@ -535,27 +565,56 @@ final class UnitTests: XCTestCase {
 
         XCTAssertEqual(result.text.prefix(3), "東京は")
     }
-    
-    func testDetectJapanese() async{
-        let targetLanguage = "ja"
-        let prefillLanguage = "en"
-        let optionsNoPrefill = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false)
 
-        guard let resultNoPrefill = try? await transcribe(with: .tiny, options: optionsNoPrefill, audioFile: "ja_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
-        }
+    func testDetectJapanese() async throws {
+        let targetLanguage = "ja"
+
+        let whisperKit = try await WhisperKit(
+            modelFolder: tinyModelPath(),
+            verbose: true,
+            logLevel: .debug
+        )
+
+        let audioFilePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "ja_test_clip", ofType: "wav"),
+            "Audio file not found"
+        )
+
+        // To detect language only, set `sampleLength` to 1 and no prefill prompt
+        let optionsDetectOnly = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, sampleLength: 1, detectLanguage: true)
+
+        let resultNoPrefill = try await XCTUnwrapAsync(
+            await whisperKit.transcribe(audioPath: audioFilePath, decodeOptions: optionsDetectOnly),
+            "Failed to transcribe"
+        )
 
         XCTAssertEqual(resultNoPrefill.language, targetLanguage)
-        
-        let optionsPrefill = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true)
+    }
 
-        guard let resultPrefill = try? await transcribe(with: .tiny, options: optionsPrefill, audioFile: "ja_test_clip.wav") else {
-            XCTFail("Failed to transcribe")
-            return
+    func testDetectJapaneseOptions() async throws {
+        let optionsPairs: [(options: DecodingOptions, language: String)] = [
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true), "ja"), // recommended usage for transcribing unknown language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true, promptTokens: [0]), "ja"), // ensure prompt doesnt interfere
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: false), "en"), // en is the default prompt language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: nil), "en"), // en is the default prompt language
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: true), "ja"), // Unecessary combination, but can be useful if used with low `sampleLength` values to purely detect language and not decode (see above)
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: false), "ja"), // no prefill, model will detect language naturally
+            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: nil), "ja"), // no prefill, model will detect language naturally
+        ]
+
+        for (i, option) in optionsPairs.enumerated() {
+            let result = try await XCTUnwrapAsync(
+                await transcribe(with: .tiny, options: option.options, audioFile: "ja_test_clip.wav"),
+                "Failed to transcribe"
+            )
+
+            let recognizer = NLLanguageRecognizer()
+            recognizer.processString(result.text)
+            let languageCode = recognizer.dominantLanguage!.rawValue
+
+            XCTAssertEqual(languageCode, option.language, "Text language \"\(languageCode)\" at index \(i) did not match expected language \"\(option.language)\"")
+            XCTAssertEqual(result.language, option.language, "Result language \"\(result.language)\" at index \(i) did not match expected language \"\(option.language)\"")
         }
-
-        XCTAssertEqual(resultPrefill.language, prefillLanguage)
     }
 
     func testNoTimestamps() async throws {
@@ -1030,16 +1089,16 @@ final class UnitTests: XCTestCase {
 
         let expectedWordTimings = [
             WordTiming(word: "<|0.00|>", tokens: [50364], start: 0, end: 1, probability: 1),
-            WordTiming(word: " Hello,", tokens: [2425, 11], start: 1, end: 3, probability: 1),
-            WordTiming(word: " world!", tokens: [1002, 0], start: 3, end: 5, probability: 1),
+            WordTiming(word: " Hello,", tokens: [2425, 11], start: 1, end: 2, probability: 1),
+            WordTiming(word: " world!", tokens: [1002, 0], start: 3, end: 4, probability: 1),
             WordTiming(word: "<|1.00|>", tokens: [50414], start: 5, end: 6, probability: 1),
             WordTiming(word: "<|1.00|>", tokens: [50414], start: 6, end: 7, probability: 1),
             WordTiming(word: " This", tokens: [639], start: 7, end: 8, probability: 1),
             WordTiming(word: " is", tokens: [307], start: 8, end: 9, probability: 1),
             WordTiming(word: " a", tokens: [257], start: 9, end: 10, probability: 1),
-            WordTiming(word: " test,", tokens: [220, 31636, 11], start: 10, end: 12, probability: 1),
+            WordTiming(word: " test,", tokens: [220, 31636, 11], start: 10, end: 11, probability: 1),
             WordTiming(word: " isn't", tokens: [1943, 380], start: 12, end: 13, probability: 1),
-            WordTiming(word: " it?", tokens: [309, 30], start: 13, end: 15, probability: 1),
+            WordTiming(word: " it?", tokens: [309, 30], start: 13, end: 14, probability: 1),
             WordTiming(word: "<|endoftext|>", tokens: [50257], start: 15, end: 16, probability: 1),
         ]
 
@@ -1060,7 +1119,8 @@ final class UnitTests: XCTestCase {
         // Spanish text: ¡Hola Mundo! Esta es una prueba, ¿no?
         let wordTimings = [
             WordTiming(word: "<|notimestamps|>", tokens: [50363], start: 0, end: 1, probability: 1),
-            WordTiming(word: "¡Hola", tokens: [24364, 48529], start: 1, end: 2, probability: 1),
+            WordTiming(word: " ¡", tokens: [24364], start: 0, end: 1, probability: 1),
+            WordTiming(word: "Hola", tokens: [48529], start: 1, end: 2, probability: 1),
             WordTiming(word: " Mundo", tokens: [376, 6043], start: 2, end: 3, probability: 1),
             WordTiming(word: "!", tokens: [0], start: 3, end: 4, probability: 1),
             WordTiming(word: " Esta", tokens: [20547], start: 4, end: 5, probability: 1),
@@ -1068,23 +1128,24 @@ final class UnitTests: XCTestCase {
             WordTiming(word: " una", tokens: [2002], start: 6, end: 7, probability: 1),
             WordTiming(word: " prueba", tokens: [48241], start: 7, end: 8, probability: 1),
             WordTiming(word: ",", tokens: [11], start: 8, end: 9, probability: 1),
-            WordTiming(word: " ¿no", tokens: [3841, 1771], start: 9, end: 10, probability: 1),
-            WordTiming(word: "?", tokens: [30], start: 10, end: 11, probability: 1),
-            WordTiming(word: "<|endoftext|>", tokens: [50257], start: 11, end: 12, probability: 1),
+            WordTiming(word: " ¿", tokens: [3841], start: 9, end: 10, probability: 1),
+            WordTiming(word: "no", tokens: [1771], start: 10, end: 11, probability: 1),
+            WordTiming(word: "?", tokens: [30], start: 11, end: 12, probability: 1),
+            WordTiming(word: "<|endoftext|>", tokens: [50257], start: 12, end: 13, probability: 1),
         ]
 
-        let mergedAlignmentTiming = SegmentSeeker().mergePunctuations(alignment: wordTimings, prepended: "\"'“¿([{-", appended: "\"'.。,，!！?？:：”)]}、")
+        let mergedAlignmentTiming = SegmentSeeker().mergePunctuations(alignment: wordTimings, prepended: "\"'“¡¿([{-", appended: "\"'.。,，!！?？:：”)]}、")
 
         let expectedWordTimings = [
             WordTiming(word: "<|notimestamps|>", tokens: [50363], start: 0, end: 1, probability: 1),
-            WordTiming(word: "¡Hola", tokens: [24364, 48529], start: 1, end: 2, probability: 1),
-            WordTiming(word: " Mundo!", tokens: [376, 6043, 0], start: 2, end: 4, probability: 1),
+            WordTiming(word: " ¡Hola", tokens: [24364, 48529], start: 1, end: 2, probability: 1),
+            WordTiming(word: " Mundo!", tokens: [376, 6043, 0], start: 2, end: 3, probability: 1),
             WordTiming(word: " Esta", tokens: [20547], start: 4, end: 5, probability: 1),
             WordTiming(word: " es", tokens: [785], start: 5, end: 6, probability: 1),
             WordTiming(word: " una", tokens: [2002], start: 6, end: 7, probability: 1),
-            WordTiming(word: " prueba,", tokens: [48241, 11], start: 7, end: 9, probability: 1),
-            WordTiming(word: " ¿no?", tokens: [3841, 1771, 30], start: 9, end: 11, probability: 1),
-            WordTiming(word: "<|endoftext|>", tokens: [50257], start: 11, end: 12, probability: 1),
+            WordTiming(word: " prueba,", tokens: [48241, 11], start: 7, end: 8, probability: 1),
+            WordTiming(word: " ¿no?", tokens: [3841, 1771, 30], start: 10, end: 11, probability: 1),
+            WordTiming(word: "<|endoftext|>", tokens: [50257], start: 12, end: 13, probability: 1),
         ]
 
         // First, assert the counts are as expected
@@ -1121,13 +1182,13 @@ final class UnitTests: XCTestCase {
 
         let expectedWordTimings = [
             WordTiming(word: "<|0.00|>", tokens: [50364], start: 0, end: 1, probability: 1),
-            WordTiming(word: "こんにちは、", tokens: [38088, 1231], start: 1, end: 3, probability: 1),
-            WordTiming(word: "世界！", tokens: [24486, 171, 120, 223], start: 3, end: 5, probability: 1),
+            WordTiming(word: "こんにちは、", tokens: [38088, 1231], start: 1, end: 2, probability: 1),
+            WordTiming(word: "世界！", tokens: [24486, 171, 120, 223], start: 3, end: 4, probability: 1),
             WordTiming(word: "これは", tokens: [25212], start: 5, end: 6, probability: 1),
             WordTiming(word: "テ", tokens: [22985], start: 6, end: 7, probability: 1),
             WordTiming(word: "スト", tokens: [40498], start: 7, end: 8, probability: 1),
             WordTiming(word: "です", tokens: [4767], start: 8, end: 9, probability: 1),
-            WordTiming(word: "よね？", tokens: [30346, 171, 120, 253], start: 9, end: 11, probability: 1),
+            WordTiming(word: "よね？", tokens: [30346, 171, 120, 253], start: 9, end: 10, probability: 1),
             WordTiming(word: "<|endoftext|>", tokens: [50257], start: 11, end: 12, probability: 1),
         ]
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -583,12 +583,12 @@ final class UnitTests: XCTestCase {
         // To detect language only, set `sampleLength` to 1 and no prefill prompt
         let optionsDetectOnly = DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, sampleLength: 1, detectLanguage: true)
 
-        let resultNoPrefill = try await XCTUnwrapAsync(
+        let result = try await XCTUnwrapAsync(
             await whisperKit.transcribe(audioPath: audioFilePath, decodeOptions: optionsDetectOnly),
             "Failed to transcribe"
         )
 
-        XCTAssertEqual(resultNoPrefill.language, targetLanguage)
+        XCTAssertEqual(result.language, targetLanguage)
     }
 
     func testDetectJapaneseOptions() async throws {

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -594,7 +594,6 @@ final class UnitTests: XCTestCase {
     func testDetectJapaneseOptions() async throws {
         let optionsPairs: [(options: DecodingOptions, language: String)] = [
             (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true), "ja"), // recommended usage for transcribing unknown language
-            (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: true, promptTokens: [0]), "ja"), // ensure prompt doesnt interfere
             (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: false), "en"), // en is the default prompt language
             (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: true, detectLanguage: nil), "en"), // en is the default prompt language
             (DecodingOptions(task: .transcribe, temperatureFallbackCount: 0, usePrefillPrompt: false, detectLanguage: true), "ja"), // Unecessary combination, but can be useful if used with low `sampleLength` values to purely detect language and not decode (see above)


### PR DESCRIPTION
This addresses a couple of issues

1. Word level timestamps slightly off, noticed in #105 
2. Detect language was not usable easily in conjunction with prefill or prompt tokens noticed by [Diirge in discord](https://discord.com/channels/1171912382512115722/1201632730446823444/1227657405811396711).

The word timestamps are still not using a median filter but they line up quite well without it. With these changes, the main differences are when words start, most of the endings are perfectly in line.

Here are some comparisons using the [audio](https://github.com/argmaxinc/WhisperKit/files/14853582/out.m4a.zip) provided in #105 (Top is ours, bottom is from HEAD openai/whisper python repo)

WhisperKit better starting point:
<img width="760" alt="image" src="https://github.com/argmaxinc/WhisperKit/assets/1981179/42fc7a01-b70d-46f3-b4ac-356fb4279bd8">

OpenAI better starting point:
<img width="655" alt="image" src="https://github.com/argmaxinc/WhisperKit/assets/1981179/305799b8-64bc-4b8e-b391-6bb6da2f76eb">

Will continue to refine these over time, thanks @finnvoor for finding this and providing a great example to replicate.



