### PR TITLE
Respect skipSpecialTokens option in the decodingCallback function

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -621,7 +621,9 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 }
 
                 // Prepare results
-                let currentTranscript = tokenizer.decode(tokens: currentTokens)
+                let wordTokens = currentTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+                let slicedTextTokens = options.skipSpecialTokens ? wordTokens : currentTokens
+                let currentTranscript = tokenizer.decode(tokens: slicedTextTokens)
                 let averageLogProb = logProbs.reduce(0, +) / Float(logProbs.count)
                 let compressionRatio = compressionRatio(of: currentTokens)
 


### PR DESCRIPTION
I want to show the live transcription process as the transcription happens, and don't want it to show special characters. Right now, regardless of how you set skipSpecialTokens in the decoder options, it will include special characters in the decodingCallback function under .text. I fixed that so it follows the skipSpecialTokens option. I've verified it in the WhisperAX app.