### PR TITLE
Fix audio file requirement for streaming mode

### DIFF
--- a/Sources/WhisperKitCLI/Transcribe.swift
+++ b/Sources/WhisperKitCLI/Transcribe.swift
@@ -22,7 +22,7 @@ struct Transcribe: AsyncParsableCommand {
             }
         }
         
-        if cliArguments.audioPath.isEmpty {
+        if cliArguments.audioPath.isEmpty && !cliArguments.stream {
             guard let audioFolder = cliArguments.audioFolder else {
                 throw ValidationError("Either audioPath or audioFolder must be provided.")
             }


### PR DESCRIPTION
When running cli with the `--stream` flag, an error occurs:
```
Either audioPath or audioFolder must be provided.
```

This PR resolves the issue by introducing a conditional to skip the audio file check in streaming mode.