### PR TITLE
MLX model support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "7838f8cd93499f3d9e9a35b87cb74fe2664b325f",
+        "version" : "0.10.0"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,12 +7,16 @@ let package = Package(
     name: "whisperkit",
     platforms: [
         .iOS(.v16),
-        .macOS(.v13),
+        .macOS("13.3"),
     ],
     products: [
         .library(
             name: "WhisperKit",
             targets: ["WhisperKit"]
+        ),
+        .library(
+            name: "WhisperKitMLX",
+            targets: ["WhisperKitMLX"]
         ),
         .executable(
             name: "whisperkit-cli",
@@ -21,6 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.7"),
+        .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.10.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [
@@ -28,7 +33,20 @@ let package = Package(
             name: "WhisperKit",
             dependencies: [
                 .product(name: "Transformers", package: "swift-transformers"),
-            ]
+            ],
+            path: "Sources/WhisperKit/Core"
+        ),
+        .target(
+            name: "WhisperKitMLX",
+            dependencies: [
+                "WhisperKit",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXOptimizers", package: "mlx-swift"),
+                .product(name: "MLXFFT", package: "mlx-swift")
+            ],
+            path: "Sources/WhisperKit/MLX"
         ),
         .executableTarget(
             name: "WhisperKitCLI",
@@ -41,6 +59,7 @@ let package = Package(
             name: "WhisperKitTests",
             dependencies: [
                 "WhisperKit",
+                "WhisperKitMLX",
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
             path: ".",

--- a/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
+++ b/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
@@ -1,0 +1,36 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import CoreML
+import MLX
+import WhisperKit
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+public class MLXAudioEncoder: AudioEncoding {
+
+    public var embedSize: Int? {
+        return 1234
+    }
+
+    public var sequenceLength: Int? {
+        return 1234
+    }
+
+    public init() {}
+
+    public func encodeFeatures(_ features: MLMultiArray) async throws -> MLMultiArray? {
+        // Make sure features is shape MultiArray (Float32 1 × {80,128} × 3000)
+//        guard let model else {
+//            throw WhisperError.modelsUnavailable()
+//        }
+        try Task.checkCancellation()
+
+//        let interval = Logging.beginSignpost("EncodeAudio", signposter: Logging.AudioEncoding.signposter)
+//        defer { Logging.endSignpost("EncodeAudio", interval: interval, signposter: Logging.AudioEncoding.signposter) }
+
+        let modelInputs = MLXArray()
+        let outputFeatures =  MLXArray()
+        let output =  MLMultiArray()
+        return output
+    }
+}

--- a/Tests/WhisperKitTests/MLXTests.swift
+++ b/Tests/WhisperKitTests/MLXTests.swift
@@ -1,0 +1,22 @@
+//
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import XCTest
+@testable import WhisperKit
+@testable import WhisperKitMLX
+
+final class MLXTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        XCTAssertNotNil(MLXAudioEncoder())
+    }
+}


### PR DESCRIPTION
Draft PR for the early stages of supporting MLX based whisper models directly in WhisperKit. (To be updated)

Initial TODOs:
- [x] Setup swift package structure
- [ ] MLXAudioEncoder inference using `AudioEncoding` protocol
- [ ] MLXTextDecoder inference using `TextDecoding` protocol or `TextDecoder` subclass (research needed)
- [ ] Downloading MLX models (research needed to mix and match model downloads between CoreML and MLX)
- [ ] Loading MLX models with a new model protocol
- [ ] Pipeline allowing mixing CoreML and MLX models 
- [ ] Tests
- [ ] More TBD