### PR TITLE
Fix language detection

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1138,7 +1138,7 @@ struct ContentView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = Constants.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage, default: Constants.defaultLanguageCode]
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 
@@ -1354,7 +1354,7 @@ struct ContentView: View {
             return nil
         }
 
-        let languageCode = Constants.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage, default: Constants.defaultLanguageCode]
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
 
         let options = DecodingOptions(

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -490,7 +490,7 @@ struct WhisperAXWatchView: View {
     func transcribeAudioSamples(_ samples: [Float]) async throws -> TranscriptionResult? {
         guard let whisperKit = whisperKit else { return nil }
 
-        let languageCode = Constants.languages[selectedLanguage] ?? "en"
+        let languageCode = Constants.languages[selectedLanguage, default: Constants.defaultLanguageCode]
         let task: DecodingTask = selectedTask == "transcribe" ? .transcribe : .translate
         let seekClip = [lastConfirmedSegmentEndSeconds]
 

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1358,4 +1358,10 @@ public enum Constants {
             "castilian": "es",
             "mandarin": "zh",
         ]
+
+    public static var languageCodes: Set<String> = {
+        Set(languages.values)
+    }()
+
+    public static let defaultLanguageCode: String = "en"
 }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1242,6 +1242,8 @@ public enum Constants {
         static let subsystem = "com.argmax.whisperkit"
     }
 
+    static let specialTokenCharacters = CharacterSet(charactersIn: "<|>")
+
     public static let maxTokenContext = Int(448 / 2)
     public static let languages: [String: String] =
         [

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1361,9 +1361,7 @@ public enum Constants {
             "mandarin": "zh",
         ]
 
-    public static var languageCodes: Set<String> = {
-        Set(languages.values)
-    }()
+    public static let languageCodes: Set<String> = Set(languages.values)
 
     public static let defaultLanguageCode: String = "en"
 }

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -319,7 +319,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
     public var tokenizer: WhisperTokenizer?
     public var prefillData: WhisperMLModel?
     public var isModelMultilingual: Bool = false
-    private var logitsFilters: LanguageLogitsFilter?
+    private var languageLogitsFilter: LanguageLogitsFilter?
 
     public var supportsWordTimestamps: Bool {
         return getModelOutputDimention(model, named: "alignment_heads_weights", position: 0) != nil
@@ -349,7 +349,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
     public func unloadModel() {
         model = nil
         prefillData = nil
-        logitsFilters = nil
+        languageLogitsFilter = nil
     }
 
     public func predictLogits(
@@ -415,11 +415,12 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         var logProbs: [Float] = Array(repeating: 0, count: prefilledIndex + 1)
 
         // Logits filters
-        let logitsFilters = self.logitsFilters ?? LanguageLogitsFilter(
+        let languageLogitsFilter = self.languageLogitsFilter ?? LanguageLogitsFilter(
             allLanguageTokens: tokenizer.allLanguageTokens,
             logitsDim: logitsSize,
             sampleBegin: prefilledIndex
         )
+        self.languageLogitsFilter = languageLogitsFilter
 
         let tokenIndex = 0
         let prefillToken = currentTokens[tokenIndex]
@@ -456,7 +457,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // MARK: Non-inference
 
         // Update predicted token as current
-        let logits = logitsFilters.filterLogits(decoderOutput.logits!, withTokens: currentTokens)
+        let logits = languageLogitsFilter.filterLogits(decoderOutput.logits!, withTokens: currentTokens)
 
         // MARK: Sampling
 

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -351,7 +351,7 @@ final class TranscribeTask {
         return TranscriptionResult(
             text: transcription,
             segments: allSegments,
-            language: detectedLanguage ?? "en",
+            language: detectedLanguage ?? Constants.defaultLanguageCode,
             timings: timings
         )
     }

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -287,8 +287,13 @@ final class TranscribeTask {
                     if options.usePrefillPrompt {
                         decoderInputs = try await textDecoder.prefillDecoderInputs(decoderInputs, withOptions: currentDecodingOptions)
                     }
-
                     Logging.debug("Prefill prompt updated to: \(decoderInputs.initialPrompt.map { tokenizer.convertIdToToken($0) ?? "" })")
+
+                    // Update timings from the language detection
+                    if let languageDecodingTimings = languageDecodingResult?.timings {
+                        timings.decodingPredictions += languageDecodingTimings.decodingPredictions
+                        timings.decodingSampling += languageDecodingTimings.decodingSampling
+                    }
                 }
 
                 decodingResult = try await textDecoder.decodeText(

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -452,7 +452,7 @@ public func findLongestDifferentSuffix(_ words1: [WordTiming], _ words2: [WordTi
 
 public func mergeTranscriptionResults(_ results: [TranscriptionResult?], confirmedWords: [WordTiming]) -> TranscriptionResult {
     let validResults = results.compactMap { $0 }
-    let language = validResults.first?.language ?? "en"
+    let language = validResults.first?.language ?? Constants.defaultLanguageCode
 
     let mergedSegments = validResults.flatMap { $0.segments }
     let mergedText = confirmedWords.map { $0.word }.joined()

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -146,6 +146,10 @@ extension String {
 
         return singleSpacedString
     }
+
+    func trimmingSpecialTokenCharacters() -> String {
+        trimmingCharacters(in: Constants.specialTokenCharacters)
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -789,6 +789,15 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual([1, 2, 3, 4].chunked(into: 3), [[1, 2, 3], [4]])
     }
 
+    func testTrimmingSpecialTokenCharacters() {
+        XCTAssertEqual("<|en|>".trimmingSpecialTokenCharacters(), "en")
+        XCTAssertEqual("<|endoftext|>".trimmingSpecialTokenCharacters(), "endoftext")
+        XCTAssertEqual("en".trimmingSpecialTokenCharacters(), "en")
+        XCTAssertEqual("<|end<|of|>text|>".trimmingSpecialTokenCharacters(), "end<|of|>text")
+        XCTAssertEqual("<|endoftext".trimmingSpecialTokenCharacters(), "endoftext")
+        XCTAssertEqual("endoftext|>".trimmingSpecialTokenCharacters(), "endoftext")
+    }
+
     // MARK: - LogitsFilter Tests
 
     func testSuppressTokensFilter() throws {


### PR DESCRIPTION
While working on audio chunking I noticed that sometimes language detection is off. It can happen that language is detected as `<|nocaptions|>` which might result in a whole 30s segment being discarded. 

<img width="344" alt="Screenshot 2024-05-02 at 17 34 45" src="https://github.com/argmaxinc/WhisperKit/assets/487331/22f1787b-dba8-4f95-b183-e0b66cfac92b">

This PR fixes that by defaulting to "en" when the language detection is confused.