### PR TITLE
Added `@_disfavoredOverload` for deprecated methods

### DIFF
--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -472,6 +472,7 @@ open class WhisperKit {
     // MARK: - Transcribe audio file
 
     @available(*, deprecated, message: "Subject to removal in a future version. Use `transcribe(audioPath:decodeOptions:callback:) async throws -> [TranscriptionResult]` instead.")
+    @_disfavoredOverload
     public func transcribe(
         audioPath: String,
         decodeOptions: DecodingOptions? = nil,
@@ -509,6 +510,7 @@ open class WhisperKit {
     // MARK: - Transcribe audio samples
 
     @available(*, deprecated, message: "Subject to removal in a future version. Use `transcribe(audioArray:decodeOptions:callback:) async throws -> [TranscriptionResult]` instead.")
+    @_disfavoredOverload
     public func transcribe(
         audioArray: [Float],
         decodeOptions: DecodingOptions? = nil,

--- a/Tests/WhisperKitTests/RegressionTests.swift
+++ b/Tests/WhisperKitTests/RegressionTests.swift
@@ -90,7 +90,7 @@ final class RegressionTests: XCTestCase {
         memoryStats.preTranscribeMemory = Float(SystemMemoryChecker.getMemoryUsed())
 
         let transcriptionResult = try await XCTUnwrapAsync(
-            await whisperKit.transcribe(audioPath: audioFilePath, callback: callback),
+            await whisperKit.transcribe(audioPath: audioFilePath, callback: callback).first,
             "Transcription failed"
         )
         XCTAssert(transcriptionResult.text.isEmpty == false, "Transcription failed")


### PR DESCRIPTION
Right now `WhisperKit` contains methods with the same arguments but different return type, e.g.

`func transcribe(audioPath:decodeOptions:callback:) async throws -> TranscriptionResult?`

and 

`func transcribe(audioPath:decodeOptions:callback:) async throws -> [TranscriptionResult]`

This results in the issue described here https://github.com/argmaxinc/WhisperKit/issues/142 where compiler gives an error `Ambiguous use of 'transcribe(audioPath:decodeOptions:callback:)`

This PR resolves that by adding `@_disfavoredOverload` to deprecated methods