### PR TITLE
Remove purported OGG support from CLI

### DIFF
--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -28,7 +28,7 @@ struct TranscribeCLI: AsyncParsableCommand {
                 throw ValidationError("Either audioPath or audioFolder must be provided.")
             }
             let fileManager = FileManager.default
-            let audioExtensions = ["mp3", "wav", "m4a", "flac", "aiff", "aac", "ogg"]
+            let audioExtensions = ["mp3", "wav", "m4a", "flac", "aiff", "aac"]
             let audioFiles = try fileManager.contentsOfDirectory(atPath: audioFolder)
                 .filter { fileName in
                     let fileExtension = fileName.lowercased().components(separatedBy: ".").last


### PR DESCRIPTION
I think the mention of OGG here is a typo, as the CLI doesn't work with OGG files (I think due to lack of support in AVFoundation).

Error when transcribing ../test.ogg: Error Domain=com.apple.coreaudio.avfaudio Code=1954115647 "(null)" UserInfo={failed call=ExtAudioFileOpenURL((CFURLRef)fileURL, &_extAudioFile)}