### PR TITLE
Allow MLX and CoreML to coexist

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,8 +31,8 @@ jobs:
               condition: true,
               clean-destination: "generic/platform=iOS",
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
-              test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
-              mlx-disabled: "0",
+              test-cases: "-only-testing WhisperKitTests/UnitTests",
+              mlx-disabled: "1",
               scheme: "whisperkit-Package",
             }
           - {
@@ -49,8 +49,8 @@ jobs:
               condition: "${{ inputs.macos-runner == 'macos-14' }}",
               clean-destination: "generic/platform=visionOS",
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
-              test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
-              mlx-disabled: "0",
+              test-cases: "-only-testing WhisperKitTests/UnitTests",
+              mlx-disabled: "1",
               scheme: "whisperkit-Package",
             }
     timeout-minutes: 20

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit-Package",
+              scheme: "whisperkit",
             }
           - {
               name: "watchOS",
@@ -51,7 +51,7 @@ jobs:
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit-Package",
+              scheme: "whisperkit",
             }
     timeout-minutes: 20
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,7 @@ jobs:
               condition: true,
               clean-destination: "generic/platform=macOS",
               test-destination: "platform=macOS,arch=arm64",
+              test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
               mlx-disabled: "0",
               scheme: "whisperkit-Package",
             }
@@ -30,6 +31,7 @@ jobs:
               condition: true,
               clean-destination: "generic/platform=iOS",
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
+              test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
               mlx-disabled: "0",
               scheme: "whisperkit-Package",
             }
@@ -38,6 +40,7 @@ jobs:
               condition: "${{ inputs.macos-runner == 'macos-14' }}",
               clean-destination: "generic/platform=watchOS",
               test-destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Ultra 2 (49mm)",
+              test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
               scheme: "whisperkit",
             }
@@ -46,6 +49,7 @@ jobs:
               condition: "${{ inputs.macos-runner == 'macos-14' }}",
               clean-destination: "generic/platform=visionOS",
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
+              test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
               mlx-disabled: "0",
               scheme: "whisperkit-Package",
             }
@@ -82,4 +86,4 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild clean build-for-testing -scheme ${{ matrix.run-config['scheme'] }} -destination "${{ matrix.run-config['clean-destination'] }}" -skipPackagePluginValidation | xcpretty
-          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme ${{ matrix.run-config['scheme'] }} -destination "${{ matrix.run-config['test-destination'] }}" -skipPackagePluginValidation | xcpretty
+          xcodebuild test ${{ matrix.run-config['test-cases'] }} -scheme ${{ matrix.run-config['scheme'] }} -destination "${{ matrix.run-config['test-destination'] }}" -skipPackagePluginValidation | xcpretty

--- a/Sources/WhisperKit/Core/AudioEncoder.swift
+++ b/Sources/WhisperKit/Core/AudioEncoder.swift
@@ -37,7 +37,7 @@ public class AudioEncoder: AudioEncoding, WhisperMLModel {
     public init() {}
 
     public func encodeFeatures(_ features: MLMultiArray) async throws -> MLMultiArray? {
-        // Make sure features is shape MultiArray (Float32 1 × {80,128} × 3000)
+        // Make sure features is shape MultiArray (Float16 1 × {80,128} x 1 × 3000)
         guard let model else {
             throw WhisperError.modelsUnavailable()
         }

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -280,6 +280,12 @@ open class WhisperKit {
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded feature extractor")
+        } else if let featureExtractor = featureExtractor as? WhisperMLXModel {
+            Logging.debug("Loading MLX feature extractor")
+            try await featureExtractor.loadModel(
+                at: path
+            )
+            Logging.debug("Loaded MLX feature extractor")
         }
 
         if let audioEncoder = audioEncoder as? WhisperMLModel {
@@ -290,6 +296,12 @@ open class WhisperKit {
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded audio encoder")
+        } else if let audioEncoder = audioEncoder as? WhisperMLXModel {
+            Logging.debug("Loading MLX audio encoder")
+            try await audioEncoder.loadModel(
+                at: path
+            )
+            Logging.debug("Loaded MLX audio encoder")
         }
 
         if let textDecoder = textDecoder as? WhisperMLModel {

--- a/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
+++ b/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
@@ -20,11 +20,10 @@ public class MLXAudioEncoder: AudioEncoding {
             throw WhisperError.modelsUnavailable()
         }
         try Task.checkCancellation()
-        let input = features.withUnsafeBytes { ptr in
-            MLXArray(ptr, features.shape.map { $0.intValue }, type: FloatType.self)
-        }
-        let ouput = encoder(input)
-        return try ouput.asMLMultiArray()
+        let inputArray = features.asMLXArray(FloatType.self)
+        let input = inputArray.asMLXInput()
+        let output = encoder(input[.newAxis])
+        return try output.asMLXOutput().asMLMultiArray()
     }
 }
 

--- a/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
+++ b/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
@@ -27,17 +27,15 @@ open class MLXFeatureExtractor: FeatureExtracting {
 
     public func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> MLMultiArray? {
         try Task.checkCancellation()
-        let input = inputAudio.withUnsafeBytes { ptr in
-            MLXArray(ptr, inputAudio.shape.map { $0.intValue }, type: Float.self)
-        }
-        let logMelSpectrogram = MLXFeatureExtractor.logMelSpectrogram(
+        let input = inputAudio.asMLXArray(Float.self)
+        let output = MLXFeatureExtractor.logMelSpectrogram(
             audio: input,
             filters: filters,
             nMels: melCount ?? 80,
             nFFT: nFFT,
             hopLength: hopLength
         )
-        return try logMelSpectrogram.asMLMultiArray()
+        return try output.asType(FloatType.self).asMLXOutput().asMLMultiArray()
     }
 }
 

--- a/Sources/WhisperKit/MLX/MLXModels.swift
+++ b/Sources/WhisperKit/MLX/MLXModels.swift
@@ -9,7 +9,7 @@ public enum PadMode {
     case reflect
 }
 
-struct ModelConfig: Codable {
+struct MLXModelConfig: Codable {
     let nMels: Int
     let nAudioCtx: Int
     let nAudioState: Int

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -11,9 +11,10 @@ import CoreML
 extension MLMultiArray {
     func asMLXArray<T: MLShapedArrayScalar & HasDType>(_ type: T.Type) -> MLXArray {
         let shape = shape.map(\.intValue)
+        let strides = strides.map(\.intValue)
         return withUnsafeBufferPointer(ofType: T.self) { ptr in
             let buffer = UnsafeBufferPointer(start: ptr.baseAddress, count: shape.reduce(1, *))
-            return MLXArray(buffer, shape)
+            return asStrided(MLXArray(buffer, shape), shape, strides: strides)
         }
     }
 }

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -8,6 +8,32 @@ import CoreML
 
 // MARK: - Extensions
 
+extension MLMultiArray {
+    func asMLXArray<T: MLShapedArrayScalar & HasDType>(_ type: T.Type) -> MLXArray {
+        let shape = shape.map(\.intValue)
+        return withUnsafeBufferPointer(ofType: T.self) { ptr in
+            let buffer = UnsafeBufferPointer(start: ptr.baseAddress, count: shape.reduce(1, *))
+            return MLXArray(buffer, shape)
+        }
+    }
+}
+
+extension MLXArray {
+    /// Adapts the shape of the output array so MLX is compatible with CoreML
+    ///
+    /// Remove empty dimensions, swap axes and add empty dimensions, result: [1, n, 1, m]
+    func asMLXOutput() -> MLXArray {
+        squeezed().swappedAxes(0, 1).expandedDimensions(axes: [0, 2])
+    }
+
+    /// Adapts the shape of the input array so MLX is compatible with CoreML
+    ///
+    /// Remove empty dimensions, swap axes, result: [n, m]
+    func asMLXInput() -> MLXArray {
+        squeezed().swappedAxes(0, 1)
+    }
+}
+
 extension MLXArray {
     func asMLMultiArray() throws -> MLMultiArray {
         let dataType = multiArrayDataType()
@@ -67,8 +93,8 @@ func loadParameters(at url: URL, forKey key: String? = nil) throws -> NestedDict
     return NestedDictionary(item: keyParams)
 }
 
-func loadConfig(at url: URL) throws -> ModelConfig {
+func loadConfig(at url: URL) throws -> MLXModelConfig {
     let configDecoder = JSONDecoder()
     configDecoder.keyDecodingStrategy = .convertFromSnakeCase
-    return try configDecoder.decode(ModelConfig.self, from: Data(contentsOf: url))
+    return try configDecoder.decode(MLXModelConfig.self, from: Data(contentsOf: url))
 }

--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -311,8 +311,6 @@ struct TranscribeCLI: AsyncParsableCommand {
             modelFolder: cliArguments.modelPath,
             tokenizerFolder: downloadTokenizerFolder,
             computeOptions: computeOptions,
-            featureExtractor: MLXFeatureExtractor(),
-            audioEncoder: MLXAudioEncoder(),
             verbose: cliArguments.verbose,
             logLevel: .debug,
             load: true,

--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -5,6 +5,7 @@ import ArgumentParser
 import CoreML
 import Foundation
 import WhisperKit
+import WhisperKitMLX
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 struct TranscribeCLI: AsyncParsableCommand {
@@ -310,6 +311,8 @@ struct TranscribeCLI: AsyncParsableCommand {
             modelFolder: cliArguments.modelPath,
             tokenizerFolder: downloadTokenizerFolder,
             computeOptions: computeOptions,
+            featureExtractor: MLXFeatureExtractor(),
+            audioEncoder: MLXAudioEncoder(),
             verbose: cliArguments.verbose,
             logLevel: .debug,
             load: true,

--- a/Tests/WhisperKitMLXTests/MLXUnitTests.swift
+++ b/Tests/WhisperKitMLXTests/MLXUnitTests.swift
@@ -55,8 +55,11 @@ final class MLXUnitTests: XCTestCase {
         let arr3 = arr1.asMLXOutput().asMLXInput()
         XCTAssertTrue(MLX.allClose(arr1, arr3).item(), "Input output conversion failed")
 
-        let arr4 = try arr1.asMLXOutput().asMLMultiArray().asMLXArray(Int32.self).asMLXInput()
+        let arr4 = try arr1.asMLXOutput().asMLXInput().asMLMultiArray().asMLXArray(Int32.self)
         XCTAssertTrue(MLX.allClose(arr1, arr4).item(), "Complex conversion failed")
+
+        let arr5 = try arr1.asMLXOutput().asMLMultiArray().asMLXArray(Int32.self).asMLXInput()
+        XCTAssertTrue(MLX.allClose(arr1, arr5).item(), "Complex conversion failed")
     }
 
     func testAsMLMultiArray() throws {


### PR DESCRIPTION
## PR

This PR allows `MLX` and `CoreML` to coexist, this is done by:

- added `MLX` model loading to `WhisperKit`
- adding shape adapters so the ouput of feature extraction and audio encoder is compatible with `CoreML`
- added `MLX` tests to CI

## Problem

There is one problem which I've been debugging for a while now. The current architecture requires to convert back and 
forth between `MLMultiArray` and `MLXArray`. Additionally, it requires to rehape the `MLXArray` so it fits the `CoreML`
model input. There are some helper methods to do so:

- `asMLMultiArray`
- `asMLXArray`
- `asMLXOutput`
- `asMLXInput`

To tests the correctness of these methods, I've added `testArrayConversion` test. It fails for one case, when `asMLXOutput().asMLMultiArray().asMLXArray(Int32.self).asMLXInput()` are chained in that particular order. It's really hard to explain because it should be working correctly: first we expand and change the shape of the array, then we convert it to `MLMultiArray`, then we convert it back to `MLXArray` and finally we change the shape back to the original one. The result should be the same as the original array, but it's not.

This manifests itself in the `WhisperKit` when we try to use `MLXFeatureExtractor` and `MLXAudioEncoder`. The output is usually empty transcription (when I try to use just `MLXFeatureExtractor` transcription is correct).

I suspect that there might be something wrong with converting from `MLXArray` to `MLMultiArray` but I didn't find it yet

## Edit: Solution

The issue was in `asMLXArray`, pointed by @ZachNagengast -- when converting to `MLXArray` we need to use the strides of the `MLMultiArray`