### PR TITLE
MLX text decoder

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -195,18 +195,42 @@ public enum DecodingTask: CustomStringConvertible, CaseIterable {
 }
 
 public struct DecodingInputs {
-    var initialPrompt: [Int]
-    var inputIds: MLMultiArray
-    var cacheLength: MLMultiArray
-    var keyCache: MLMultiArray
-    var valueCache: MLMultiArray
-    var alignmentWeights: MLMultiArray
-    var kvCacheUpdateMask: MLMultiArray
-    var decoderKeyPaddingMask: MLMultiArray
-    var prefillKeyCache: MLMultiArray
-    var prefillValueCache: MLMultiArray
+    public var initialPrompt: [Int]
+    public var inputIds: MLMultiArray
+    public var cacheLength: MLMultiArray
+    public var keyCache: MLMultiArray?
+    public var valueCache: MLMultiArray?
+    public var alignmentWeights: MLMultiArray
+    public var kvCacheUpdateMask: MLMultiArray
+    public var decoderKeyPaddingMask: MLMultiArray
+    public var prefillKeyCache: MLMultiArray
+    public var prefillValueCache: MLMultiArray
 
-    func reset(prefilledCacheSize: Int, maxTokenContext: Int) {
+    public init(
+        initialPrompt: [Int],
+        inputIds: MLMultiArray,
+        cacheLength: MLMultiArray,
+        keyCache: MLMultiArray?,
+        valueCache: MLMultiArray?,
+        alignmentWeights: MLMultiArray,
+        kvCacheUpdateMask: MLMultiArray,
+        decoderKeyPaddingMask: MLMultiArray,
+        prefillKeyCache: MLMultiArray,
+        prefillValueCache: MLMultiArray
+    ) {
+        self.initialPrompt = initialPrompt
+        self.inputIds = inputIds
+        self.cacheLength = cacheLength
+        self.keyCache = keyCache
+        self.valueCache = valueCache
+        self.alignmentWeights = alignmentWeights
+        self.kvCacheUpdateMask = kvCacheUpdateMask
+        self.decoderKeyPaddingMask = decoderKeyPaddingMask
+        self.prefillKeyCache = prefillKeyCache
+        self.prefillValueCache = prefillValueCache
+    }
+
+    public func reset(prefilledCacheSize: Int, maxTokenContext: Int) {
         // NOTE: Because we have a mask on the kvcache,
         // we can simply shift the masks without touching the data,
         // it will be overwritten by the new data without impact on the output
@@ -230,9 +254,19 @@ public struct DecodingInputs {
 }
 
 public struct DecodingCache {
-    var keyCache: MLMultiArray?
-    var valueCache: MLMultiArray?
-    var alignmentWeights: MLMultiArray?
+    public var keyCache: MLMultiArray?
+    public var valueCache: MLMultiArray?
+    public var alignmentWeights: MLMultiArray?
+
+    public init(
+        keyCache: MLMultiArray?,
+        valueCache: MLMultiArray?,
+        alignmentWeights: MLMultiArray?
+    ) {
+        self.keyCache = keyCache
+        self.valueCache = valueCache
+        self.alignmentWeights = alignmentWeights
+    }
 }
 
 public enum ChunkingStrategy: String, CaseIterable {
@@ -409,6 +443,34 @@ public struct DecodingResult {
     public var cache: DecodingCache?
     public var timings: TranscriptionTimings?
     public var fallback: DecodingFallback?
+
+    public init(
+        language: String,
+        languageProbs: [String : Float],
+        tokens: [Int],
+        tokenLogProbs: [[Int : Float]],
+        text: String,
+        avgLogProb: Float,
+        noSpeechProb: Float,
+        temperature: Float,
+        compressionRatio: Float,
+        cache: DecodingCache?,
+        timings: TranscriptionTimings?,
+        fallback: DecodingFallback?
+    ) {
+        self.language = language
+        self.languageProbs = languageProbs
+        self.tokens = tokens
+        self.tokenLogProbs = tokenLogProbs
+        self.text = text
+        self.avgLogProb = avgLogProb
+        self.noSpeechProb = noSpeechProb
+        self.temperature = temperature
+        self.compressionRatio = compressionRatio
+        self.cache = cache
+        self.timings = timings
+        self.fallback = fallback
+    }
 
     public static var emptyResults: DecodingResult {
         return DecodingResult(language: "",
@@ -596,6 +658,23 @@ public struct TranscriptionProgress {
     public var avgLogprob: Float?
     public var compressionRatio: Float?
     public var windowId: Int = 0
+
+    public init(
+        timings: TranscriptionTimings,
+        text: String,
+        tokens: [Int],
+        temperature: Float?,
+        avgLogprob: Float?,
+        compressionRatio: Float?,
+        windowId: Int = 0
+    ) {
+        self.timings = timings
+        self.text = text
+        self.tokens = tokens
+        self.temperature = temperature
+        self.avgLogprob = avgLogprob
+        self.compressionRatio = compressionRatio
+    }
 }
 
 /// Callback to receive progress updates during transcription.

--- a/Sources/WhisperKit/Core/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/TokenSampler.swift
@@ -14,6 +14,12 @@ public struct SamplingResult {
     public var tokens: [Int]
     public var logProbs: [Float]
     public var completed: Bool
+
+    public init(tokens: [Int], logProbs: [Float], completed: Bool) {
+        self.tokens = tokens
+        self.logProbs = logProbs
+        self.completed = completed
+    }
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -149,14 +149,14 @@ public extension WhisperKit {
     }
 }
 
-extension Float {
+public extension Float {
     func rounded(_ decimalPlaces: Int) -> Float {
         let divisor = pow(10.0, Float(decimalPlaces))
         return (self * divisor).rounded() / divisor
     }
 }
 
-extension String {
+public extension String {
     var normalized: String {
         // Trim whitespace and newlines
         let trimmedString = self.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -206,7 +206,7 @@ func prepareSeekClips(contentFrames: Int, decodeOptions: DecodingOptions?) -> [(
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-func initMLMultiArray(shape: [NSNumber], dataType: MLMultiArrayDataType, initialValue: Any) -> MLMultiArray {
+public func initMLMultiArray(shape: [NSNumber], dataType: MLMultiArrayDataType, initialValue: Any) -> MLMultiArray {
     var multiArray: MLMultiArray
     switch dataType {
         case .float16:

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -261,59 +261,49 @@ open class WhisperKit {
 
         Logging.debug("Loading models from \(path.path) with prewarmMode: \(prewarmMode)")
 
-        let logmelUrl = path.appending(path: "MelSpectrogram.mlmodelc")
-        let encoderUrl = path.appending(path: "AudioEncoder.mlmodelc")
-        let decoderUrl = path.appending(path: "TextDecoder.mlmodelc")
-        let decoderPrefillUrl = path.appending(path: "TextDecoderContextPrefill.mlmodelc")
-
-        for item in [logmelUrl, encoderUrl, decoderUrl] {
-            if !FileManager.default.fileExists(atPath: item.path) {
-                throw WhisperError.modelsUnavailable("Model file not found at \(item.path)")
-            }
-        }
-
         if let featureExtractor = featureExtractor as? WhisperMLModel {
             Logging.debug("Loading feature extractor")
             try await featureExtractor.loadModel(
-                at: logmelUrl,
+                at: path.appending(path: "MelSpectrogram.mlmodelc"),
                 computeUnits: modelCompute.melCompute, // hardcoded to use GPU
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded feature extractor")
         } else if let featureExtractor = featureExtractor as? WhisperMLXModel {
             Logging.debug("Loading MLX feature extractor")
-            try await featureExtractor.loadModel(
-                at: path
-            )
+            try await featureExtractor.loadModel(at: path)
             Logging.debug("Loaded MLX feature extractor")
         }
 
         if let audioEncoder = audioEncoder as? WhisperMLModel {
             Logging.debug("Loading audio encoder")
             try await audioEncoder.loadModel(
-                at: encoderUrl,
+                at: path.appending(path: "AudioEncoder.mlmodelc"),
                 computeUnits: modelCompute.audioEncoderCompute,
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded audio encoder")
         } else if let audioEncoder = audioEncoder as? WhisperMLXModel {
             Logging.debug("Loading MLX audio encoder")
-            try await audioEncoder.loadModel(
-                at: path
-            )
+            try await audioEncoder.loadModel(at: path)
             Logging.debug("Loaded MLX audio encoder")
         }
 
         if let textDecoder = textDecoder as? WhisperMLModel {
             Logging.debug("Loading text decoder")
             try await textDecoder.loadModel(
-                at: decoderUrl,
+                at: path.appending(path: "TextDecoder.mlmodelc"),
                 computeUnits: modelCompute.textDecoderCompute,
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded text decoder")
+        } else if let textDecoder = textDecoder as? WhisperMLXModel {
+            Logging.debug("Loading MLX text decoder")
+            try await textDecoder.loadModel(at: path)
+            Logging.debug("Loaded MLX text decoder")
         }
 
+        let decoderPrefillUrl = path.appending(path: "TextDecoderContextPrefill.mlmodelc")
         if FileManager.default.fileExists(atPath: decoderPrefillUrl.path) {
             Logging.debug("Loading text decoder prefill data")
             textDecoder.prefillData = TextDecoderContextPrefill()

--- a/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
+++ b/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
@@ -22,7 +22,7 @@ public class MLXAudioEncoder: AudioEncoding {
         try Task.checkCancellation()
         let inputArray = features.asMLXArray(FloatType.self)
         let input = inputArray.asMLXInput()
-        let output = encoder(input[.newAxis])
+        let output = encoder(input)
         return try output.asMLXOutput().asMLMultiArray()
     }
 }

--- a/Sources/WhisperKit/MLX/MLXModels.swift
+++ b/Sources/WhisperKit/MLX/MLXModels.swift
@@ -22,9 +22,25 @@ struct MLXModelConfig: Codable {
     let nTextLayer: Int
 }
 
+struct KV {
+    var k: MLXArray
+    var v: MLXArray
+}
+
+struct TextDecoderResult {
+    var logits: MLXArray
+    var kvCache: [KV]
+}
+
 struct ResidualAttentionBlockResult {
     var x: MLXArray
-    var kv: (MLXArray, MLXArray)
-    var crossKv: MLXArray?
+    var kv: KV
+    var crossKv: KV?
     var crossQk: MLXArray?
+}
+
+struct MultiHeadAttentionResult {
+    var x: MLXArray
+    var kv: KV
+    var qk: MLXArray
 }

--- a/Sources/WhisperKit/MLX/MLXTextDecoder.swift
+++ b/Sources/WhisperKit/MLX/MLXTextDecoder.swift
@@ -1,0 +1,543 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import CoreML
+import MLX
+import MLXNN
+import WhisperKit
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+public final class MLXTextDecoder: TextDecoding {
+    public var tokenizer: (any WhisperTokenizer)?
+    public var prefillData: (any WhisperMLModel)?
+    public var isModelMultilingual: Bool = false
+    public let supportsWordTimestamps: Bool = false
+    public var logitsSize: Int? {
+        decoder?.nState
+    }
+    public var kvCacheEmbedDim: Int? {
+        guard let config else { return nil }
+        return config.nTextState * config.nTextLayer
+    }
+    public var kvCacheMaxSequenceLength: Int? {
+        guard let config else { return nil }
+        return config.nTextCtx / 2
+    }
+    public var windowSize: Int? {
+        guard let config else { return nil }
+        return config.nAudioCtx
+    }
+    public var embedSize: Int? {
+        guard let config else { return nil }
+        return config.nTextState
+    }
+    private var decoder: TextDecoder?
+    private var config: MLXModelConfig?
+    private var languageLogitsFilter: LanguageLogitsFilter?
+
+    public init() {}
+
+    private static func toKvCache(keyCache: MLMultiArray?, valueCache: MLMultiArray?) -> [KV]? {
+        guard let keyCache, let valueCache else {
+            return nil
+        }
+        let keyCacheMlx = keyCache.asMLXArray(FloatType.self)
+        let valueCacheMlx = valueCache.asMLXArray(FloatType.self)
+        assert(keyCacheMlx.shape == valueCacheMlx.shape)
+        var result = [KV]()
+        for index in 0..<keyCacheMlx.shape[0] {
+            let k = keyCacheMlx[index]
+            let v = valueCacheMlx[index]
+            result.append(KV(k: k, v: v))
+        }
+        return result
+    }
+
+    public func prepareDecoderInputs(withPrompt initialPrompt: [Int]) throws -> DecodingInputs {
+        let tokenShape = [NSNumber(value: 1), NSNumber(value: initialPrompt.count)]
+
+        // Initialize MLMultiArray for tokens
+        let tokenMultiArray = try MLMultiArray(shape: tokenShape, dataType: .int32)
+
+        // Assign token values to the MLMultiArray
+        for (index, token) in initialPrompt.enumerated() {
+            tokenMultiArray[index] = NSNumber(value: token)
+        }
+
+        guard let kvCacheEmbedDim = self.kvCacheEmbedDim else {
+            throw WhisperError.prepareDecoderInputsFailed("Unable to determine kvCacheEmbedDim")
+        }
+
+        guard let kvCacheMaxSequenceLength = self.kvCacheMaxSequenceLength else {
+            throw WhisperError.prepareDecoderInputsFailed("Unable to determine kvCacheMaxSequenceLength")
+        }
+
+        guard let encoderOutputDim = self.windowSize else {
+            throw WhisperError.prepareDecoderInputsFailed("Unable to determine encoderOutputDim")
+        }
+
+        // Initialize each MLMultiArray
+        let kvCacheEmbedDimValue = NSNumber(value: kvCacheEmbedDim)
+        let kvCacheMaxSequenceLengthValue = NSNumber(value: kvCacheMaxSequenceLength)
+        let encoderOutputDimValue = NSNumber(value: encoderOutputDim)
+
+        let inputIds = initMLMultiArray(shape: [1], dataType: .int32, initialValue: Int32(0))
+        let cacheLength = initMLMultiArray(shape: [1], dataType: .int32, initialValue: Int32(0))
+        let alignmentWeights = initMLMultiArray(shape: [kvCacheMaxSequenceLengthValue, encoderOutputDimValue], dataType: .float16, initialValue: FloatType(0))
+        let kvCacheUpdateMask = initMLMultiArray(shape: [1, kvCacheMaxSequenceLengthValue], dataType: .int32, initialValue: Int32(0))
+        let decoderKeyPaddingMask = initMLMultiArray(shape: [1, kvCacheMaxSequenceLengthValue], dataType: .float16, initialValue: FloatType(-10000))
+        let prefillKeyCache = try! MLMultiArray(shape: [1, kvCacheEmbedDimValue, 1, kvCacheMaxSequenceLengthValue], dataType: .float16)
+        let prefillValueCache = try! MLMultiArray(shape: [1, kvCacheEmbedDimValue, 1, kvCacheMaxSequenceLengthValue], dataType: .float16)
+        let decoderInputs = DecodingInputs(
+            initialPrompt: initialPrompt,
+            inputIds: inputIds,
+            cacheLength: cacheLength,
+            keyCache: nil,
+            valueCache: nil,
+            alignmentWeights: alignmentWeights,
+            kvCacheUpdateMask: kvCacheUpdateMask,
+            decoderKeyPaddingMask: decoderKeyPaddingMask,
+            prefillKeyCache: prefillKeyCache,
+            prefillValueCache: prefillValueCache
+        )
+        return decoderInputs
+    }
+
+    public func predictLogits(
+        inputIds: MLMultiArray,
+        cacheLength: MLMultiArray,
+        keyCache: MLMultiArray?,
+        valueCache: MLMultiArray?,
+        kvCacheUpdateMask: MLMultiArray,
+        encoderOutputEmbeds: MLMultiArray,
+        decoderKeyPaddingMask: MLMultiArray
+    ) async throws -> (logits: MLMultiArray?, cache: DecodingCache?)? {
+        guard let decoder else {
+            return nil
+        }
+        let tokens = inputIds.asMLXArray(Int32.self)
+        let audioFeatures = encoderOutputEmbeds.asMLXArray(FloatType.self).asMLXInput()
+        let result = decoder(
+            tokens,
+            xa: audioFeatures,
+            kvCache: Self.toKvCache(keyCache: keyCache, valueCache: valueCache)
+        )
+        let keyCache = try MLX.stacked(result.kvCache.map(\.k)).asMLMultiArray()
+        let valueCache = try MLX.stacked(result.kvCache.map(\.v)).asMLMultiArray()
+        let decodingCache = DecodingCache(
+            keyCache: keyCache,
+            valueCache: valueCache,
+            alignmentWeights: nil
+        )
+        return try (result.logits.asMLMultiArray(), decodingCache)
+    }
+
+    public func decodeText(
+        from encoderOutput: MLMultiArray,
+        using decoderInputs: DecodingInputs,
+        sampler tokenSampler: TokenSampling,
+        options: DecodingOptions,
+        callback: TranscriptionCallback = nil
+    ) async throws -> DecodingResult {
+        guard let tokenizer else {
+            // Tokenizer required for decoding
+            throw WhisperError.tokenizerUnavailable()
+        }
+
+        // Single loop variables
+        var timings = TranscriptionTimings()
+        let prefilledIndex = decoderInputs.cacheLength[0].intValue
+        let intialPromptIndex = decoderInputs.initialPrompt.count
+        var currentTokens: [Int] = decoderInputs.initialPrompt
+        var nextToken: Int = decoderInputs.initialPrompt.last!
+        var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
+
+        // Logits filters
+        var logitsFilters: [any LogitsFiltering] = []
+        if options.suppressBlank {
+            logitsFilters.append(
+                SuppressBlankFilter(
+                    specialTokens: tokenizer.specialTokens,
+                    sampleBegin: prefilledIndex
+                )
+            )
+        }
+
+        if !options.supressTokens.isEmpty {
+            logitsFilters.append(SuppressTokensFilter(suppressTokens: options.supressTokens))
+        }
+
+        if !options.withoutTimestamps {
+            let maxInitialTimestampIndex: Int? =
+                if let maxInitialTimestamp = options.maxInitialTimestamp {
+                    Int(maxInitialTimestamp / WhisperKit.secondsPerTimeToken)
+                } else {
+                    nil
+                }
+            logitsFilters.append(
+                TimestampRulesFilter(
+                    specialTokens: tokenizer.specialTokens,
+                    sampleBegin: intialPromptIndex,
+                    maxInitialTimestampIndex: maxInitialTimestampIndex,
+                    isModelMultilingual: isModelMultilingual
+                )
+            )
+        }
+
+        // MARK: Main loop
+
+        let loopCount = min(options.sampleLength, Constants.maxTokenContext - 1)
+        Logging.debug("Running main loop for a maximum of \(loopCount) iterations, starting at index \(prefilledIndex)")
+        var hasAlignment = false
+        var isFirstTokenLogProbTooLow = false
+        var keyCache = decoderInputs.keyCache
+        var valueCache = decoderInputs.valueCache
+        for tokenIndex in prefilledIndex..<loopCount {
+            let loopStart = Date()
+
+            let isPrefill = tokenIndex < intialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
+            let isFirstToken = tokenIndex == prefilledIndex
+
+            // Check if current index is part of the initial prompt
+            if tokenIndex < intialPromptIndex {
+                nextToken = currentTokens[tokenIndex]
+                Logging.debug("Forcing prompt tokenIndex: \(tokenIndex), token: \(nextToken), text: \(tokenizer.decode(tokens: [nextToken]))")
+            }
+
+            // Set the current token as model input
+            decoderInputs.inputIds[0] = NSNumber(value: nextToken)
+            decoderInputs.cacheLength[0] = NSNumber(value: tokenIndex)
+
+            if tokenIndex <= prefilledIndex + 3 {
+                debugCaches(decoderInputs: decoderInputs, tokenIndex: tokenIndex, prefillSize: prefilledIndex)
+            }
+
+            // MARK: Decoding Inference
+
+            // Predict next token
+            let inferenceTime = Date()
+
+            let predictedLogits = try await self.predictLogits(
+                inputIds: decoderInputs.inputIds,
+                cacheLength: decoderInputs.cacheLength,
+                keyCache: keyCache,
+                valueCache: valueCache,
+                kvCacheUpdateMask: decoderInputs.kvCacheUpdateMask,
+                encoderOutputEmbeds: encoderOutput,
+                decoderKeyPaddingMask: decoderInputs.decoderKeyPaddingMask
+            )
+
+            guard let decoderOutput = predictedLogits else {
+                throw WhisperError.decodingLogitsFailed("Unable to decode logits")
+            }
+
+            keyCache = decoderOutput.cache?.keyCache
+            valueCache = decoderOutput.cache?.valueCache
+
+            let decodingInferenceTime = Date().timeIntervalSince(inferenceTime)
+            timings.decodingPredictions += decodingInferenceTime
+
+            // MARK: Non-inference
+
+            let nonInferenceStartTime = Date()
+
+            // Update predicted token as current
+            var logits = decoderOutput.logits!
+            for filter in logitsFilters {
+                logits = filter.filterLogits(logits, withTokens: currentTokens)
+            }
+
+            let filteringTime = Date().timeIntervalSince(nonInferenceStartTime)
+            timings.decodingFiltering += filteringTime
+
+            // MARK: Sampling
+
+            let samplingStartTime = Date()
+
+            let sampleResult = tokenSampler.update(tokens: currentTokens, logits: logits, logProbs: logProbs)
+
+            nextToken = sampleResult.tokens.last!
+            let nextTokenLogProb = sampleResult.logProbs.last!
+
+            let samplingTime = Date().timeIntervalSince(samplingStartTime)
+            timings.decodingSampling += samplingTime
+
+            isFirstTokenLogProbTooLow =
+                if isFirstToken, let firstTokenLogProbThreshold = options.firstTokenLogProbThreshold, nextTokenLogProb < firstTokenLogProbThreshold {
+                    true
+                } else {
+                    false
+                }
+            let isSegmentCompleted =
+                sampleResult.completed ||
+                currentTokens.count >= Constants.maxTokenContext - 1 ||
+                isFirstTokenLogProbTooLow
+
+            if isSegmentCompleted {
+                // Completed segment, stop the loop
+                timings.decodingNonPrediction += Date().timeIntervalSince(nonInferenceStartTime)
+                timings.decodingLoop += Date().timeIntervalSince(loopStart)
+                timings.totalDecodingLoops += 1
+                break
+            } else {
+                // MARK: KV Caching
+
+                if !isPrefill {
+                    // Found the next token, store it
+                    currentTokens.append(nextToken)
+                    logProbs.append(nextTokenLogProb)
+                }
+
+                decoderInputs.decoderKeyPaddingMask[tokenIndex + 1] = 0
+                decoderInputs.kvCacheUpdateMask[tokenIndex] = 0
+                decoderInputs.kvCacheUpdateMask[tokenIndex + 1] = 1
+
+                // Update alignment weights for token if present
+                if let newAlignmentWeights = decoderOutput.cache?.alignmentWeights {
+                    hasAlignment = true
+                    for column in 0..<decoderInputs.alignmentWeights.shape[1].intValue {
+                        let alignmentWeightIndex = [tokenIndex + 1, column] as [NSNumber] // +1 to account for SOT
+                        let weightValue = newAlignmentWeights[[0, column] as [NSNumber]].doubleValue
+                        decoderInputs.alignmentWeights[alignmentWeightIndex] = NSNumber(value: weightValue)
+                    }
+                }
+
+                // Prepare results
+                let wordTokens = currentTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+                let slicedTextTokens = options.skipSpecialTokens ? wordTokens : currentTokens
+                let currentTranscript = tokenizer.decode(tokens: slicedTextTokens)
+                let averageLogProb = logProbs.reduce(0, +) / Float(logProbs.count)
+                let compressionRatio = compressionRatio(of: currentTokens)
+
+                let result = TranscriptionProgress(
+                    timings: timings,
+                    text: currentTranscript,
+                    tokens: currentTokens,
+                    temperature: nil,
+                    avgLogprob: averageLogProb,
+                    compressionRatio: compressionRatio
+                )
+                Logging.debug("Predicted next tokenIndex: \(tokenIndex + 1), token: \(nextToken), text: \(tokenizer.decode(tokens: [nextToken]))")
+
+                // Call the callback if it is provided
+                if let shouldContinue = callback?(result) {
+                    if !shouldContinue && !isPrefill {
+                        Logging.debug("Early stopping")
+                        break
+                    }
+                }
+            }
+
+            timings.decodingNonPrediction += Date().timeIntervalSince(nonInferenceStartTime)
+            timings.decodingLoop += Date().timeIntervalSince(loopStart)
+            timings.totalDecodingLoops += 1
+
+            if tokenIndex == prefilledIndex {
+                timings.firstTokenTime = CFAbsoluteTimeGetCurrent()
+            }
+        }
+
+        let cache = DecodingCache(
+            keyCache: decoderInputs.keyCache,
+            valueCache: decoderInputs.valueCache,
+            alignmentWeights: hasAlignment ? decoderInputs.alignmentWeights : nil
+        )
+
+        // NOTE:
+        // While `currentTokens` and `logProbs` are usually the same length
+        // `currentTokens` does not always contain an end of text token at the end (it is added by this finalize function),
+        let finalSamplingResult = tokenSampler.finalize(tokens: currentTokens, logProbs: logProbs)
+        let segmentTokens = finalSamplingResult.tokens
+        let segmentLogProbs = finalSamplingResult.logProbs
+
+        let startIndex = segmentTokens.firstIndex(of: tokenizer.specialTokens.startOfTranscriptToken) ?? 0
+        let endIndex = segmentTokens.firstIndex(of: tokenizer.specialTokens.endToken) ?? segmentTokens.count
+        let filteredTokens = Array(segmentTokens[startIndex...endIndex])
+        let filteredLogProbs = Array(segmentLogProbs[startIndex...endIndex])
+
+        let sumLogProbs = filteredLogProbs.reduce(0, +)
+        let avgLogProbs = sumLogProbs / Float(filteredLogProbs.count)
+
+        var tokenProbs = [[Int: Float]]()
+        for (index, token) in filteredTokens.enumerated() {
+            tokenProbs.append([token: filteredLogProbs[index]])
+        }
+
+        let wordTokens = filteredTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+        let compressionRatio = compressionRatio(of: wordTokens)
+
+        var temperature = options.temperature
+        if let sampler = tokenSampler as? GreedyTokenSampler {
+            // Convert Float16 temperature to Float with 3 decimal places
+            temperature = Float(sampler.temperature).rounded(3)
+        }
+
+        let noSpeechProb: Float = 0 // TODO: implement no speech prob
+
+        // If language is still nil here, check language can be inferred from tokens
+        var language = options.language ?? Constants.defaultLanguageCode
+        var languageProbs = [String: Float]()
+        if options.language == nil {
+            // Find the first token that is a recognized language token
+            if let predictedLanguageIndex = filteredTokens.firstIndex(where: { tokenizer.allLanguageTokens.contains($0) }),
+               predictedLanguageIndex < tokenProbs.count
+            {
+                let predictedLanguageToken = filteredTokens[predictedLanguageIndex]
+                // Decode the predicted language token to get the language
+                language = tokenizer.decode(tokens: [predictedLanguageToken]).trimmingSpecialTokenCharacters()
+
+                // Fetch the corresponding probability for the predicted language
+                let probsDict = tokenProbs[predictedLanguageIndex]
+                languageProbs[language] = probsDict[predictedLanguageToken] ?? 0.0
+            } else {
+                // Set default values if no language token is found
+                languageProbs[language] = 0.0
+            }
+        } else {
+            // If language is provided, set the logprob to 0.0
+            languageProbs[language] = 0.0
+        }
+
+        let transcript = tokenizer.decode(tokens: filteredTokens)
+
+        let decodingFallback = DecodingFallback(
+            options: options,
+            isFirstTokenLogProbTooLow: isFirstTokenLogProbTooLow,
+            noSpeechProb: noSpeechProb,
+            compressionRatio: compressionRatio,
+            avgLogProb: avgLogProbs
+        )
+
+        let decodingResult = DecodingResult(
+            language: language,
+            languageProbs: languageProbs,
+            tokens: filteredTokens,
+            tokenLogProbs: tokenProbs,
+            text: transcript,
+            avgLogProb: avgLogProbs,
+            noSpeechProb: noSpeechProb,
+            temperature: temperature,
+            compressionRatio: compressionRatio,
+            cache: cache,
+            timings: timings,
+            fallback: decodingFallback
+        )
+        return decodingResult
+    }
+
+    public func detectLanguage(
+        from encoderOutput: MLMultiArray,
+        using decoderInputs: DecodingInputs,
+        sampler tokenSampler: TokenSampling,
+        options: DecodingOptions,
+        temperature: FloatType
+    ) async throws -> DecodingResult {
+        guard let tokenizer else {
+            throw WhisperError.tokenizerUnavailable()
+        }
+        guard let logitsSize else {
+            throw WhisperError.modelsUnavailable("Failed to read logits size from model")
+        }
+        let languageLogitsFilter = self.languageLogitsFilter ?? LanguageLogitsFilter(
+            allLanguageTokens: tokenizer.allLanguageTokens,
+            logitsDim: logitsSize,
+            sampleBegin: 0
+        )
+        self.languageLogitsFilter = languageLogitsFilter
+        return try await MLXTextDecoder.detectLanguage(
+            textDecoder: self,
+            languageLogitsFilter: languageLogitsFilter,
+            from: encoderOutput,
+            using: decoderInputs,
+            sampler: tokenSampler,
+            options: options,
+            temperature: temperature
+        )
+    }
+}
+
+extension MLXTextDecoder: WhisperMLXModel {
+    public func loadModel(at modelPath: URL) async throws {
+        let parameters = try loadParameters(at: modelPath.appending(path: "weights.safetensors"), forKey: "decoder")
+        let config = try loadConfig(at: modelPath.appending(path: "config.json"))
+        let decoder = TextDecoder(
+            nVocab: config.nVocab,
+            nCtx: config.nTextCtx,
+            nState: config.nTextState,
+            nHead: config.nTextHead,
+            nLayer: config.nTextLayer,
+            dtype: .float16
+        )
+        let loadedDecoder = try decoder.update(parameters: parameters, verify: [.noUnusedKeys])
+        MLX.eval(loadedDecoder)
+        self.decoder = loadedDecoder
+        self.config = config
+    }
+
+    public func unloadModel() {
+        decoder = nil
+        config = nil
+        prefillData = nil
+        languageLogitsFilter = nil
+    }
+}
+
+final class TextDecoder: Module {
+    let nVocab: Int
+    let nCtx: Int
+    let nState: Int
+    let nHead: Int
+    let nLayer: Int
+    let dtype: MLX.DType
+
+    private let token_embedding: Embedding
+    private let positional_embedding: MLXArray
+    private let blocks: [ResidualAttentionBlock]
+    private let ln: LayerNorm
+    private let _mask: MLXArray
+
+    init(
+        nVocab: Int,
+        nCtx: Int,
+        nState: Int,
+        nHead: Int,
+        nLayer: Int,
+        dtype: MLX.DType = .float16
+    ) {
+        self.nVocab = nVocab
+        self.nCtx = nCtx
+        self.nState = nState
+        self.nHead = nHead
+        self.nLayer = nLayer
+        self.dtype = dtype
+
+        self.token_embedding = Embedding(embeddingCount: nVocab, dimensions: nState)
+        self.positional_embedding = MLX.zeros([nCtx, nState])
+        self.blocks = (0..<nLayer).map { _ in
+            ResidualAttentionBlock(nState: nState, nHead: nHead, crossAttention: true)
+        }
+        self.ln = LayerNorm(dimensions: nState)
+        self._mask = additiveCausalMask(nCtx).asType(dtype)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        xa: MLXArray,
+        kvCache: [KV?]?
+    ) -> TextDecoderResult {
+        let offset = kvCache?.first??.k.shape[1] ?? 0
+        var x = x[.newAxis, .ellipsis]
+        x = token_embedding(x) + positional_embedding[offset..<offset + x.shape[x.shape.count - 1]]
+        var kvCache: [KV?] = kvCache ?? Array(repeating: nil, count: blocks.count)
+        for (index, block) in blocks.enumerated() {
+            let result = block(x, xa: xa, mask: _mask, kvCache: kvCache[index])
+            x = result.x
+            kvCache[index] = result.kv
+        }
+        x = ln(x)
+        return TextDecoderResult(
+            logits: token_embedding.asLinear(x),
+            kvCache: kvCache.compactMap { $0 }
+        )
+    }
+}

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -29,9 +29,9 @@ extension MLXArray {
 
     /// Adapts the shape of the input array so MLX is compatible with CoreML
     ///
-    /// Remove empty dimensions, swap axes, result: [n, m]
+    /// Remove empty dimensions, swap axes, result: [1, n, m]
     func asMLXInput() -> MLXArray {
-        squeezed().swappedAxes(0, 1)
+        squeezed().swappedAxes(0, 1).expandedDimensions(axes: [0])
     }
 }
 
@@ -72,7 +72,19 @@ extension MLXArray {
     }
 }
 
+extension Embedding {
+    func asLinear(_ x: MLXArray) -> MLXArray {
+        x.matmul(weight.T)
+    }
+}
+
 // MARK: - Functions
+
+func additiveCausalMask(_ n: Int, dType: MLX.DType = .float32) -> MLXArray {
+    let indices = MLXArray(Array(0..<n))
+    let mask = indices[0..., .newAxis] .< indices[.newAxis]
+    return mask.asType(dType) * -1e9
+}
 
 func sinusoids(length: Int, channels: Int, maxTimescale: Int = 10000) -> MLXArray {
     assert(channels % 2 == 0)


### PR DESCRIPTION
In this PR:

- added `MLXTextDecoder` and relevant `MLX` layers implementations
- added basic `MLXTextDecoder` tests

Tested with https://huggingface.co/jkrukowski/whisper-base-mlx-safetensors and https://huggingface.co/jkrukowski/whisper-tiny-mlx-safetensors models.
Tested different pipelines with combinations of `MLX` and `Core` decoder / encoder.

Possible improvements:
- refactor `decodeText` method, it's a bit messy and copy pasted from `TextEncoder`
- add support for weights alignment in `MLXTextDecoder`
- make weight loading more efficient, right now we basically load the full model 2 times (for encoder and decoder)
- add more tests
