### PR TITLE
Cleanup and more tests for MLX

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,13 +62,13 @@ jobs:
       - name: Setup environment
         run: make setup
       - name: Setup Cache
-        id: model-cache-v2
+        id: model-cache
         uses: actions/cache@v4
         with:
           path: Sources/WhisperKitTestsUtils/Models
           key: ${{ runner.os }}-models
       - name: Download Models
-        if: steps.model-cache-v2.outputs.cache-hit != 'true'
+        if: steps.model-cache.outputs.cache-hit != 'true'
         run: make download-model MODEL=tiny && make download-mlx-model
       - name: Install and discover destinations
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,13 +62,13 @@ jobs:
       - name: Setup environment
         run: make setup
       - name: Setup Cache
-        id: model-cache
+        id: model-cache-v2
         uses: actions/cache@v4
         with:
           path: Sources/WhisperKitTestsUtils/Models
           key: ${{ runner.os }}-models
       - name: Download Models
-        if: steps.model-cache.outputs.cache-hit != 'true'
+        if: steps.model-cache-v2.outputs.cache-hit != 'true'
         run: make download-model MODEL=tiny && make download-mlx-model
       - name: Install and discover destinations
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
               mlx-disabled: "1",
               scheme: "whisperkit",
             }
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -30,7 +30,7 @@ public protocol WhisperMLModel: WhisperModel {
 }
 
 public protocol WhisperMLXModel: WhisperModel {
-    func loadModel(at modelPath: URL) async throws
+    func loadModel(at modelPath: URL, configPath: URL) async throws
 }
 
 public extension WhisperMLModel {

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -271,7 +271,7 @@ open class WhisperKit {
             Logging.debug("Loaded feature extractor")
         } else if let featureExtractor = featureExtractor as? WhisperMLXModel {
             Logging.debug("Loading MLX feature extractor")
-            try await featureExtractor.loadModel(at: path)
+            try await featureExtractor.loadModel(at: path, configPath: path)
             Logging.debug("Loaded MLX feature extractor")
         }
 
@@ -285,7 +285,10 @@ open class WhisperKit {
             Logging.debug("Loaded audio encoder")
         } else if let audioEncoder = audioEncoder as? WhisperMLXModel {
             Logging.debug("Loading MLX audio encoder")
-            try await audioEncoder.loadModel(at: path)
+            try await audioEncoder.loadModel(
+                at: path.appending(path: "encoder.safetensors"),
+                configPath: path.appending(path: "config.json")
+            )
             Logging.debug("Loaded MLX audio encoder")
         }
 
@@ -299,7 +302,10 @@ open class WhisperKit {
             Logging.debug("Loaded text decoder")
         } else if let textDecoder = textDecoder as? WhisperMLXModel {
             Logging.debug("Loading MLX text decoder")
-            try await textDecoder.loadModel(at: path)
+            try await textDecoder.loadModel(
+                at: path.appending(path: "decoder.safetensors"),
+                configPath: path.appending(path: "config.json")
+            )
             Logging.debug("Loaded MLX text decoder")
         }
 

--- a/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
+++ b/Sources/WhisperKit/MLX/MLXAudioEncoder.swift
@@ -28,9 +28,9 @@ public class MLXAudioEncoder: AudioEncoding {
 }
 
 extension MLXAudioEncoder: WhisperMLXModel {
-    public func loadModel(at modelPath: URL) async throws {
-        let parameters = try loadParameters(at: modelPath.appending(path: "weights.safetensors"), forKey: "encoder")
-        let config = try loadConfig(at: modelPath.appending(path: "config.json"))
+    public func loadModel(at modelPath: URL, configPath: URL) async throws {
+        let parameters = try loadParameters(at: modelPath)
+        let config = try loadConfig(at: configPath)
         let encoder = AudioEncoder(
             nMels: config.nMels,
             nCtx: config.nAudioCtx,
@@ -57,11 +57,11 @@ final class AudioEncoder: Module {
     let nLayer: Int
     let dType: MLX.DType
 
-    private let conv1: Conv1d
-    private let conv2: Conv1d
-    private let positionalEmbedding: MLXArray
-    private let blocks: [ResidualAttentionBlock]
-    private let ln_post: LayerNorm
+    @ModuleInfo(key: "conv1") private var conv1: Conv1d
+    @ModuleInfo(key: "conv2") private var conv2: Conv1d
+    @ModuleInfo(key: "blocks") private var blocks: [ResidualAttentionBlock]
+    @ModuleInfo(key: "ln_post") private var lnPost: LayerNorm
+    private let _positionalEmbedding: MLXArray
 
     init(
         nMels: Int,
@@ -78,22 +78,22 @@ final class AudioEncoder: Module {
         self.nLayer = nLayer
         self.dType = dType
 
-        self.conv1 = Conv1d(inputChannels: nMels, outputChannels: nState, kernelSize: 3, padding: 1)
-        self.conv2 = Conv1d(inputChannels: nState, outputChannels: nState, kernelSize: 3, stride: 2, padding: 1)
-        self.positionalEmbedding = sinusoids(length: nCtx, channels: nState).asType(dType)
-        self.blocks = (0..<nLayer).map { _ in ResidualAttentionBlock(nState: nState, nHead: nHead) }
-        self.ln_post = LayerNorm(dimensions: nState)
+        self._conv1.wrappedValue = Conv1d(inputChannels: nMels, outputChannels: nState, kernelSize: 3, padding: 1)
+        self._conv2.wrappedValue = Conv1d(inputChannels: nState, outputChannels: nState, kernelSize: 3, stride: 2, padding: 1)
+        self._blocks.wrappedValue = (0..<nLayer).map { _ in ResidualAttentionBlock(nState: nState, nHead: nHead) }
+        self._lnPost.wrappedValue = LayerNorm(dimensions: nState)
+        self._positionalEmbedding = sinusoids(length: nCtx, channels: nState).asType(dType)
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         var x = MLXNN.gelu(conv1(x))
         x = MLXNN.gelu(conv2(x))
-        assert(Array(x.shape[1...]) == positionalEmbedding.shape, "incorrect audio shape")
-        x = x + positionalEmbedding
+        assert(Array(x.shape[1...]) == _positionalEmbedding.shape, "incorrect audio shape")
+        x = x + _positionalEmbedding
         for block in blocks {
             x = block(x).x
         }
-        x = ln_post(x)
+        x = lnPost(x)
         return x
     }
 }

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -94,16 +94,9 @@ func sinusoids(length: Int, channels: Int, maxTimescale: Int = 10000) -> MLXArra
     return MLX.concatenated([MLX.sin(scaledTime), MLX.cos(scaledTime)], axis: 1)
 }
 
-func loadParameters(at url: URL, forKey key: String? = nil) throws -> NestedDictionary<String, MLXArray> {
+func loadParameters(at url: URL) throws -> NestedDictionary<String, MLXArray> {
     let arrays = try MLX.loadArrays(url: url)
-    let params = ModuleParameters.unflattened(arrays)
-    guard let key else {
-        return params
-    }
-    guard let keyParams = params[key] else {
-        throw CocoaError.error(.coderValueNotFound)
-    }
-    return NestedDictionary(item: keyParams)
+    return ModuleParameters.unflattened(arrays)
 }
 
 func loadConfig(at url: URL) throws -> MLXModelConfig {

--- a/Sources/WhisperKitTestsUtils/TestUtils.swift
+++ b/Sources/WhisperKitTestsUtils/TestUtils.swift
@@ -132,20 +132,13 @@ public extension MLMultiArray {
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public extension XCTestCase {
     func transcribe(
-        with variant: ModelVariant,
+        modelPath: String,
         options: DecodingOptions,
         callback: TranscriptionCallback = nil,
         audioFile: String = "jfk.wav",
         file: StaticString = #file,
         line: UInt = #line
     ) async throws -> [TranscriptionResult] {
-        let modelPath: String
-        switch variant {
-            case .largev3:
-                modelPath = try largev3ModelPath()
-            default:
-                modelPath = try tinyModelPath()
-        }
         let computeOptions = ModelComputeOptions(
             melCompute: .cpuOnly,
             audioEncoderCompute: .cpuOnly,

--- a/Sources/WhisperKitTestsUtils/TestUtils.swift
+++ b/Sources/WhisperKitTestsUtils/TestUtils.swift
@@ -136,6 +136,9 @@ public extension XCTestCase {
         options: DecodingOptions,
         callback: TranscriptionCallback = nil,
         audioFile: String = "jfk.wav",
+        featureExtractor: (any FeatureExtracting)? = nil,
+        audioEncoder: (any AudioEncoding)? = nil,
+        textDecoder: (any TextDecoding)? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) async throws -> [TranscriptionResult] {
@@ -145,7 +148,15 @@ public extension XCTestCase {
             textDecoderCompute: .cpuOnly,
             prefillCompute: .cpuOnly
         )
-        let whisperKit = try await WhisperKit(modelFolder: modelPath, computeOptions: computeOptions, verbose: true, logLevel: .debug)
+        let whisperKit = try await WhisperKit(
+            modelFolder: modelPath,
+            computeOptions: computeOptions,
+            featureExtractor: featureExtractor,
+            audioEncoder: audioEncoder,
+            textDecoder: textDecoder,
+            verbose: true,
+            logLevel: .debug
+        )
         trackForMemoryLeaks(on: whisperKit, file: file, line: line)
 
         let audioComponents = audioFile.components(separatedBy: ".")

--- a/Tests/WhisperKitMLXTests/MLXUnitTests.swift
+++ b/Tests/WhisperKitMLXTests/MLXUnitTests.swift
@@ -153,7 +153,14 @@ final class MLXUnitTests: XCTestCase {
         let options = DecodingOptions(task: .translate, language: targetLanguage, temperatureFallbackCount: 0)
 
         let result = try await XCTUnwrapAsync(
-            try await transcribe(modelPath: tinyModelPath, options: options, audioFile: "es_test_clip.wav"),
+            try await transcribe(
+                modelPath: tinyModelPath,
+                options: options,
+                audioFile: "es_test_clip.wav",
+                featureExtractor: MLXFeatureExtractor(),
+                audioEncoder: MLXAudioEncoder(),
+                textDecoder: MLXTextDecoder()
+            ),
             "Failed to transcribe"
         )
 
@@ -165,7 +172,14 @@ final class MLXUnitTests: XCTestCase {
         let options = DecodingOptions(task: .transcribe, language: sourceLanguage, temperatureFallbackCount: 0)
 
         let result = try await XCTUnwrapAsync(
-            try await transcribe(modelPath: tinyModelPath, options: options, audioFile: "es_test_clip.wav"),
+            try await transcribe(
+                modelPath: tinyModelPath,
+                options: options,
+                audioFile: "es_test_clip.wav",
+                featureExtractor: MLXFeatureExtractor(),
+                audioEncoder: MLXAudioEncoder(),
+                textDecoder: MLXTextDecoder()
+            ),
             "Failed to transcribe"
         )
 
@@ -176,6 +190,9 @@ final class MLXUnitTests: XCTestCase {
         let targetLanguage = "es"
         let whisperKit = try await WhisperKit(
             modelFolder: tinyModelPath,
+            featureExtractor: MLXFeatureExtractor(),
+            audioEncoder: MLXAudioEncoder(),
+            textDecoder: MLXTextDecoder(),
             verbose: true,
             logLevel: .debug
         )
@@ -197,7 +214,14 @@ final class MLXUnitTests: XCTestCase {
         let options = DecodingOptions(task: .translate, language: targetLanguage, temperatureFallbackCount: 0)
 
         let result = try await XCTUnwrapAsync(
-            try await transcribe(modelPath: tinyModelPath, options: options, audioFile: "ja_test_clip.wav"),
+            try await transcribe(
+                modelPath: tinyModelPath,
+                options: options,
+                audioFile: "ja_test_clip.wav",
+                featureExtractor: MLXFeatureExtractor(),
+                audioEncoder: MLXAudioEncoder(),
+                textDecoder: MLXTextDecoder()
+            ),
             "Failed to transcribe"
         )
 
@@ -209,7 +233,14 @@ final class MLXUnitTests: XCTestCase {
         let options = DecodingOptions(task: .transcribe, language: sourceLanguage, temperatureFallbackCount: 0)
 
         let result = try await XCTUnwrapAsync(
-            try await transcribe(modelPath: tinyModelPath, options: options, audioFile: "ja_test_clip.wav"),
+            try await transcribe(
+                modelPath: tinyModelPath,
+                options: options,
+                audioFile: "ja_test_clip.wav",
+                featureExtractor: MLXFeatureExtractor(),
+                audioEncoder: MLXAudioEncoder(),
+                textDecoder: MLXTextDecoder()
+            ),
             "Failed to transcribe"
         )
 
@@ -220,6 +251,9 @@ final class MLXUnitTests: XCTestCase {
         let targetLanguage = "ja"
         let whisperKit = try await WhisperKit(
             modelFolder: tinyModelPath,
+            featureExtractor: MLXFeatureExtractor(),
+            audioEncoder: MLXAudioEncoder(),
+            textDecoder: MLXTextDecoder(),
             verbose: true,
             logLevel: .debug
         )
@@ -248,7 +282,14 @@ final class MLXUnitTests: XCTestCase {
 
         for (i, option) in optionsPairs.enumerated() {
             let result = try await XCTUnwrapAsync(
-                try await transcribe(modelPath: tinyModelPath, options: option.options, audioFile: "ja_test_clip.wav"),
+                try await transcribe(
+                    modelPath: tinyModelPath,
+                    options: option.options,
+                    audioFile: "ja_test_clip.wav",
+                    featureExtractor: MLXFeatureExtractor(),
+                    audioEncoder: MLXAudioEncoder(),
+                    textDecoder: MLXTextDecoder()
+                ),
                 "Failed to transcribe"
             )
 


### PR DESCRIPTION
In this PR:

- refactor MLX implementation to use `@ModuleInfo` property wrapper
- refactor MLX model loading to accept separated encoder and decoder files
- added more test for MLX

I've uploaded the updated converted version of the model here https://huggingface.co/jkrukowski/whisper-base-mlx-safetensors and here https://huggingface.co/jkrukowski/whisper-tiny-mlx-safetensors

Additionally I've created a small python script that allows to convert hugging face whisper mlx model to the desired format (ie. converted to `safetensors` format and separated encoder and decoder). Here it is:

```python
import safetensors.numpy as st
import numpy as np
import re
from huggingface_hub import snapshot_download
from pathlib import Path
import argparse

def convert_model(path_or_hf_repo: str, output_path: str):
    model_path = Path(path_or_hf_repo)
    output_path = Path(output_path)
    output_path.mkdir(parents=True, exist_ok=True)
    if not model_path.exists():
        model_path = Path(snapshot_download(repo_id=path_or_hf_repo))
    tensors = np.load(str(model_path / 'weights.npz'))
    decoder = {}
    encoder = {}
    for k, v in tensors.items():
        # we split decoder and encoder weights so we can load them separately
        # that's why we remove the prefix
        if k.startswith('decoder.'):
            decoder[re.sub('^decoder.', '', k)] = v
        elif k.startswith('encoder.'):
            encoder[re.sub('^encoder.', '', k)] = v

    st.save_file(decoder, str(output_path / 'decoder.safetensors'))
    st.save_file(encoder, str(output_path / 'encoder.safetensors'))

def cli():
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--model-path",
        required=True,
        help="Local directory or Hugging Face model ID to download the model from"
    )
    parser.add_argument(
        "--output-path",
        required=True,
        help="Local directory to save the generated model files to"
    )
    args = parser.parse_args()
    convert_model(args.model_path, args.output_path)

if __name__ == '__main__':
    cli()
```