### PR TITLE
Fix progress when using VAD chunking

### DIFF
--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -769,9 +769,12 @@ open class WhisperKit {
         }
         try Task.checkCancellation()
 
+        let childProgress = Progress()
+        progress.totalUnitCount += 1
+        progress.addChild(childProgress, withPendingUnitCount: 1)
         let transcribeTask = TranscribeTask(
             currentTimings: currentTimings,
-            progress: progress,
+            progress: childProgress,
             audioEncoder: audioEncoder,
             featureExtractor: featureExtractor,
             segmentSeeker: segmentSeeker,

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -1,4 +1,5 @@
 import CoreML
+import Combine
 import Foundation
 @testable import WhisperKit
 import XCTest
@@ -272,5 +273,13 @@ extension Collection where Element == TranscriptionResult {
 extension Collection where Element == TranscriptionResult {
     var segments: [TranscriptionSegment] {
         flatMap(\.segments)
+    }
+}
+
+extension Publisher {
+    public func withPrevious() -> AnyPublisher<(previous: Output?, current: Output), Failure> {
+        scan((Output?, Output)?.none) { ($0?.1, $1) }
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
Previously progress would jump around as the same progress object was used for every chunk. Now every chunk is added as a child progress with equal unit count.

fixes #151 