### PR TITLE
MLX Cleanup

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,7 +64,7 @@ jobs:
           path: Models
           key: ${{ runner.os }}-models
       - name: Download Models
-        if: steps.model-cache.outputs.cache-hit != 'true'
+        # if: steps.model-cache.outputs.cache-hit != 'true'
         run: |
           make download-model MODEL=tiny 
           make download-mlx-model MODEL=tiny

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit",
+              scheme: "whisperkit-Package",
             }
           - {
               name: "watchOS",
@@ -39,7 +39,7 @@ jobs:
               test-destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Ultra 2 (49mm)",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit",
+              scheme: "whisperkit-Package",
             }
           - {
               name: "visionOS",
@@ -47,7 +47,7 @@ jobs:
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit",
+              scheme: "whisperkit-Package",
             }
     timeout-minutes: 30
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,6 +75,8 @@ jobs:
           echo "Available schemes:"
           xcodebuild -list
           xcodebuild -downloadAllPlatforms
+          echo "Destinations for testing:"
+          export ${{ matrix.run-config['compiler-flags'] }} && xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme ${{ matrix.run-config['scheme'] }} -showdestinations -skipPackagePluginValidation
       - name: Boot Simulator and Wait
         if: ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-14' }}
         # Slower runners require some time to fully boot the simulator

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
         id: model-cache
         uses: actions/cache@v4
         with:
-          path: Sources/WhisperKitTestsUtils/Models
+          path: Models
           key: ${{ runner.os }}-models
       - name: Download Models
         if: steps.model-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,6 @@ jobs:
           - {
               name: "macOS",
               condition: true,
-              clean-destination: "generic/platform=macOS",
               test-destination: "platform=macOS,arch=arm64",
               test-cases: "-only-testing WhisperKitTests/UnitTests -only-testing WhisperKitMLXTests/MLXUnitTests",
               mlx-disabled: "0",
@@ -29,7 +28,6 @@ jobs:
           - {
               name: "iOS",
               condition: true,
-              clean-destination: "generic/platform=iOS",
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
@@ -38,7 +36,6 @@ jobs:
           - {
               name: "watchOS",
               condition: "${{ inputs.macos-runner == 'macos-14' }}",
-              clean-destination: "generic/platform=watchOS",
               test-destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Ultra 2 (49mm)",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
@@ -47,7 +44,6 @@ jobs:
           - {
               name: "visionOS",
               condition: "${{ inputs.macos-runner == 'macos-14' }}",
-              clean-destination: "generic/platform=visionOS",
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
@@ -79,8 +75,6 @@ jobs:
           echo "Available schemes:"
           xcodebuild -list
           xcodebuild -downloadAllPlatforms
-          echo "Destinations for testing:"
-          export ${{ matrix.run-config['compiler-flags'] }} && xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme ${{ matrix.run-config['scheme'] }} -showdestinations -skipPackagePluginValidation
       - name: Boot Simulator and Wait
         if: ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-14' }}
         # Slower runners require some time to fully boot the simulator
@@ -96,5 +90,8 @@ jobs:
         if: ${{ matrix.run-config['condition'] == true }}
         run: |
           set -o pipefail
-          xcodebuild clean build-for-testing -scheme ${{ matrix.run-config['scheme'] }} -destination '${{ matrix.run-config['clean-destination'] }}' -skipPackagePluginValidation | xcpretty
-          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme ${{ matrix.run-config['scheme'] }} -destination '${{ matrix.run-config['test-destination'] }}' -skipPackagePluginValidation
+          xcodebuild clean build-for-testing test \
+            ${{ matrix.run-config['test-cases'] }} \
+            -scheme ${{ matrix.run-config['scheme'] }} \
+            -destination '${{ matrix.run-config['test-destination'] }}' \
+            -skipPackagePluginValidation

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
               test-destination: "platform=iOS Simulator,OS=${{ inputs.ios-version }},name=iPhone 15",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit-Package",
+              scheme: "whisperkit",
             }
           - {
               name: "watchOS",
@@ -39,7 +39,7 @@ jobs:
               test-destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Ultra 2 (49mm)",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit-Package",
+              scheme: "whisperkit",
             }
           - {
               name: "visionOS",
@@ -47,7 +47,7 @@ jobs:
               test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
               test-cases: "-only-testing WhisperKitTests/UnitTests",
               mlx-disabled: "1",
-              scheme: "whisperkit-Package",
+              scheme: "whisperkit",
             }
     timeout-minutes: 30
     steps:
@@ -64,7 +64,7 @@ jobs:
           path: Models
           key: ${{ runner.os }}-models
       - name: Download Models
-        # if: steps.model-cache.outputs.cache-hit != 'true'
+        if: steps.model-cache.outputs.cache-hit != 'true'
         run: |
           make download-model MODEL=tiny 
           make download-mlx-model MODEL=tiny

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ DerivedData/
 **/*.xcscheme
 .netrc
 .env
+/.vscode
 
 # Core ML Model Files
 Models

--- a/.swiftpm/configuration/Package.resolved
+++ b/.swiftpm/configuration/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
+        "version" : "0.16.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "74b94211bdc741694ed7e700a1104c72e5ba68fe",
+        "version" : "0.1.7"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "cd17206b47bb810af9459722192530e3838d8e6629a970988e32a432aaa05f6e",
+  "originHash" : "829222b514832cb61fe0002e0eebda98f23a75169c63f7d6ed7a320d57d5318f",
   "pins" : [
     {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "branch" : "main",
-        "revision" : "c11212bff42a1b88aea83811210d42a5f99440ad"
+        "revision" : "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"
       }
     },
     {

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"
+        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup setup-huggingface-cli setup-model-repo download-models download-model download-mlx-models download-mlx-model build build-cli test mlx-test clean-package-caches
+.PHONY: setup setup-huggingface-cli setup-model-repo download-models download-model download-mlx-models download-mlx-model build build-cli test clean-package-caches
 
 PIP_COMMAND := pip3
 PYTHON_COMMAND := python3

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ PYTHON_COMMAND := python3
 MODEL_REPO := argmaxinc/whisperkit-coreml
 MLX_MODEL_REPO := argmaxinc/whisperkit-mlx
 
-MODEL_REPO_DIR := ./Sources/WhisperKitTestsUtils/Models/whisperkit-coreml
-MLX_MODEL_REPO_DIR := ./Sources/WhisperKitTestsUtils/Models/whisperkit-mlx
-BASE_MODEL_DIR := ./Sources/WhisperKitTestsUtils/Models
+MODEL_REPO_DIR := ./Models/whisperkit-coreml
+MLX_MODEL_REPO_DIR := ./Models/whisperkit-mlx
+BASE_MODEL_DIR := ./Models
 
 
 setup:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ download-mlx-model: setup-mlx-model-repo
 	@echo "Downloading mlx model $(MODEL)..."
 	@cd $(MLX_MODEL_REPO_DIR) && \
 	git lfs pull --include="openai_whisper-$(MODEL)/*"
-	@echo "MLX model $(MODEL) downloaded to $(MLX_MODEL_REPO_DIR)/openai_whisper-mlx-$(MODEL)"
+	@echo "MLX model $(MODEL) downloaded to $(MLX_MODEL_REPO_DIR)/openai_whisper-$(MODEL)"
 
 
 build:

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"
+        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "branch" : "main",
-        "revision" : "3c802c808d281c191d5f26f37a4f93135d8ca119"
+        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
+        "version" : "0.16.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "597aaa5f465b4b9a17c8646b751053f84e37925b",
-        "version" : "0.16.0"
+        "revision" : "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ func mlxDependencies() -> [PackageDescription.Package.Dependency] {
         return []
     } else {
         return [
-            .package(url: "https://github.com/ml-explore/mlx-swift", branch: "main"),
+            .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.16.0"),
         ]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ func mlxDependencies() -> [PackageDescription.Package.Dependency] {
         return []
     } else {
         return [
-            .package(url: "https://github.com/ml-explore/mlx-swift", revision: "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"),
+            .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.16.0"),
         ]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,9 @@ let package = Package(
             name: "WhisperKit",
             targets: ["WhisperKit"]
         ),
-        .executable(
-            name: "whisperkit-cli",
-            targets: ["WhisperKitCLI"]
-        ),
-    ] + mlxProducts(),
+    ] 
+    + cliProducts()
+    + mlxProducts(),
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.7"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
@@ -32,13 +30,6 @@ let package = Package(
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
             path: "Sources/WhisperKit/Core"
-        ),
-        .executableTarget(
-            name: "WhisperKitCLI",
-            dependencies: [
-                "WhisperKit",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            ] + mlxCLIDependencies()
         ),
         .target(
             name: "WhisperKitTestsUtils",
@@ -71,11 +62,39 @@ let package = Package(
                 .product(name: "Transformers", package: "swift-transformers"),
             ]
         )
-    ] + mlxTargets()
+    ] 
+    + cliTargets()
+    + mlxTargets()
 )
 
 // MARK: - MLX Helper Functions
 
+// CLI
+func cliProducts() -> [Product] {
+    guard !isMLXDisabled() else { return [] }
+    return [
+        .executable(
+            name: "whisperkit-cli",
+            targets: ["WhisperKitCLI"]
+        ),
+    ]
+}
+
+func cliTargets() -> [Target] {
+    guard !isMLXDisabled() else { return [] }
+    return [
+        .executableTarget(
+            name: "WhisperKitCLI",
+            dependencies: [
+                "WhisperKit",
+                "WhisperKitMLX",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ]
+}
+
+// MLX 
 func mlxProducts() -> [Product] {
     guard !isMLXDisabled() else { return [] }
     return [
@@ -91,11 +110,6 @@ func mlxDependencies() -> [Package.Dependency] {
     return [
         .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.16.0"),
     ]
-}
-
-func mlxCLIDependencies() -> [Target.Dependency] {
-    guard !isMLXDisabled() else { return [] }
-    return ["WhisperKitMLX"]
 }
 
 func mlxTargets() -> [Target] {
@@ -129,7 +143,7 @@ func mlxTargets() -> [Target] {
 
 // NOTE: `MLX` doesn't support `watchOS` yet, that's why we control the build using the `MLX_DISABLED` environment variable.
 // To manualy build for `watchOS` use:
-// `export MLX_DISABLED=1 && xcodebuild clean build-for-testing -scheme whisperkit -sdk watchos10.4 -destination 'platform=watchOS Simulator' -skipPackagePluginValidation`
+// `export MLX_DISABLED=1 && xcodebuild clean build-for-testing -scheme whisperkit -sdk watchos10.4 -destination 'platform=watchOS Simulator,OS=10.5,name=Apple Watch Ultra 2 (49mm)' -skipPackagePluginValidation`
 
 func isMLXDisabled() -> Bool {
     ProcessInfo.processInfo.environment["MLX_DISABLED"] == "1"

--- a/Package.swift
+++ b/Package.swift
@@ -76,10 +76,21 @@ func targets() -> [PackageDescription.Target] {
                 "WhisperKit",
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
+            path: ".",
+            exclude: [
+                "Examples",
+                "Sources/WhisperKit",
+                "Sources/WhisperKitCLI",
+                "Tests",
+                "Makefile",
+                "README.md",
+                "LICENSE",
+                "CONTRIBUTING.md",
+            ],
             resources: [
-                .copy("Models/whisperkit-coreml/"),
-                .copy("Models/whisperkit-mlx/"),
-                .process("Resources")
+                .copy("Models/whisperkit-coreml"),
+                .copy("Models/whisperkit-mlx"),
+                .process("Sources/WhisperKitTestsUtils/Resources")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,7 @@ func products() -> [PackageDescription.Product] {
 }
 
 func mlxProducts() -> [PackageDescription.Product] {
-    let isMLXDisabled = ProcessInfo.processInfo.environment["MLX_DISABLED"] == "1"
-    if isMLXDisabled {
+    if isMLXDisabled() {
         return []
     } else {
         return [
@@ -53,12 +52,11 @@ func dependencies() -> [PackageDescription.Package.Dependency] {
 }
 
 func mlxDependencies() -> [PackageDescription.Package.Dependency] {
-    let isMLXDisabled = ProcessInfo.processInfo.environment["MLX_DISABLED"] == "1"
-    if isMLXDisabled {
+    if isMLXDisabled() {
         return []
     } else {
         return [
-            .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.16.0"),
+            .package(url: "https://github.com/ml-explore/mlx-swift", revision: "d6d9472da5bf7ec2654e8914bd1d15622f45b6a9"),
         ]
     }
 }
@@ -78,21 +76,10 @@ func targets() -> [PackageDescription.Target] {
                 "WhisperKit",
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
-            path: ".",
-            exclude: [
-                "Examples",
-                "Sources/WhisperKit",
-                "Sources/WhisperKitCLI",
-                "Tests",
-                "Makefile",
-                "README.md",
-                "LICENSE",
-                "CONTRIBUTING.md",
-            ],
             resources: [
-                .copy("Models/whisperkit-coreml"),
-                .copy("Models/whisperkit-mlx"),
-                .process("Sources/WhisperKitTestsUtils/Resources")
+                .copy("Models/whisperkit-coreml/"),
+                .copy("Models/whisperkit-mlx/"),
+                .process("Resources")
             ]
         ),
         .testTarget(
@@ -107,8 +94,7 @@ func targets() -> [PackageDescription.Target] {
 }
 
 func mlxTargets() -> [PackageDescription.Target] {
-    let isMLXDisabled = ProcessInfo.processInfo.environment["MLX_DISABLED"] == "1"
-    if isMLXDisabled {
+    if isMLXDisabled() {
         return []
     } else {
         return [
@@ -145,4 +131,8 @@ func mlxTargets() -> [PackageDescription.Target] {
             )
         ]
     }
+}
+
+func isMLXDisabled() -> Bool {
+    ProcessInfo.processInfo.environment["MLX_DISABLED"] == "1"
 }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ For MLX models, see [here](https://huggingface.co/argmaxinc/whisperkit-mlx).
 If you want to get the recommended model for your device, you can use the following method:
 
 ```swift
-print(WhisperKit.recommendedModel())
+print(WhisperKit.recommendedModels())
+```
+
+it should print the default and a list of disabled models, e.g.: 
+
+```bash
+(default: "openai_whisper-base", disabled: ["openai_whisper-large-v2_turbo", "openai_whisper-large-v2_turbo_955MB", "openai_whisper-large-v3_turbo", "openai_whisper-large-v3_turbo_954MB", "distil-whisper_distil-large-v3_turbo_600MB", "distil-whisper_distil-large-v3_turbo"])
 ```
 
 ### Generating Models

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ This example demonstrates how to transcribe a local audio file:
 ```swift
 import WhisperKit
 
-// Initialize WhisperKit with default settings
-let pipe = try await WhisperKit()
+// Initialize WhisperKit by passing the model name (WhisperKit will automatically download it):
+let pipe = try await WhisperKit(model: "tiny")
 // Transcribe the audio file
 let transcription = try await pipe.transcribe(audioPath: "path/to/your/audio.{wav,mp3,m4a,flac}")?.text
 // Print the transcription

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ print(transcription)
 
 ### Model Selection
 
-WhisperKit automatically downloads the recommended model for the device if not specified. You can also select a specific model by passing in the model name:
+You have to specify the model by passing the model name:
 
 ```swift
 let pipe = try await WhisperKit(model: "large-v3")
@@ -105,6 +105,12 @@ Note that the model search must return a single model from the source repo, othe
 
 For a list of available models, see our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml).
 For MLX models, see [here](https://huggingface.co/argmaxinc/whisperkit-mlx).
+
+If you want to get the recommended model for your device, you can use the following method:
+
+```swift
+print(WhisperKit.recommendedModel())
+```
 
 ### Generating Models
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Check out the demo app on [TestFlight](https://testflight.apple.com/join/LPVOyJZ
   - [Quick Example](#quick-example)
   - [Model Selection](#model-selection)
   - [Generating Models](#generating-models)
+  - [Swift CLI](#swift-cli)
+  - [Backend Selection](#backend-selection)
   - [Testing](#testing)
 - [Contributing \& Roadmap](#contributing--roadmap)
 - [License](#license)
@@ -126,6 +128,45 @@ WhisperKit also comes with the supporting repo [`whisperkittools`](https://githu
 let pipe = try await WhisperKit(model: "large-v3", modelRepo: "username/your-model-repo")
 ```
 
+### Swift CLI
+
+The Swift CLI allows for quick testing and debugging outside of an Xcode project. To install it, run the following:
+
+```bash
+git clone https://github.com/argmaxinc/whisperkit.git
+cd whisperkit
+```
+
+Then, setup the environment and download your desired model.
+
+```bash
+make setup
+make download-model MODEL=large-v3
+```
+
+**Note**:
+
+1. This will download only the model specified by `MODEL` (see what's available in our [HuggingFace repo](https://huggingface.co/argmaxinc/whisperkit-coreml), where we use the prefix `openai_whisper-{MODEL}`)
+2. Before running `download-model`, make sure [git-lfs](https://git-lfs.com) is installed
+
+If you would like download all available models to your local folder, use this command instead:
+
+```bash
+make download-models
+```
+
+You can then run them via the CLI with:
+
+```bash
+swift run whisperkit-cli transcribe --model-path "Models/whisperkit-coreml/openai_whisper-large-v3" --audio-path "path/to/your/audio.{wav,mp3,m4a,flac}" 
+```
+
+Which should print a transcription of the audio file. If you would like to stream the audio directly from a microphone, use:
+
+```bash
+swift run whisperkit-cli transcribe --model-path "Models/whisperkit-coreml/openai_whisper-large-v3" --stream
+```
+
 ### Backend Selection
 
 WhisperKit supports both CoreML and MLX backends. By default, it uses CoreML, but you can switch some or all pipeline components to MLX.
@@ -144,6 +185,11 @@ let pipe = try await WhisperKit(
   audioEncoder: MLXAudioEncoder()
 )
 ```
+
+**Note**:
+
+`swift run` and `swift test` commands won't work when the `mlx` backend is selected.
+SwiftPM (command line) cannot build the Metal shaders so the ultimate build has to be done via Xcode.
 
 ### Testing
 

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -482,6 +482,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         return getModelInputDimention(model, named: "encoder_output_embeds", position: 1)
     }
 
+    public init() {}
+
     /// Override default so we an unload the prefill data as well
     public func unloadModel() {
         model = nil

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -44,7 +44,7 @@ extension MLMultiArray {
     ///  - index: The index of the element
     ///  - strides: The precomputed strides of the multi-array, if not provided, it will be computed. It's a performance optimization to avoid recomputing the strides every time when accessing the multi-array with multiple indexes.
     @inline(__always)
-    func linearOffset(for index: [NSNumber], strides strideInts: [Int]? = nil) -> Int {
+    public func linearOffset(for index: [NSNumber], strides strideInts: [Int]? = nil) -> Int {
         var linearOffset = 0
         let strideInts = strideInts ?? strides.map { $0.intValue }
         for (dimension, stride) in zip(index, strideInts) {

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -235,8 +235,9 @@ open class WhisperKit {
     public func loadModels(
         prewarmMode: Bool = false
     ) async throws {
-        modelState = prewarmMode ? .prewarming : .loading
+        assert(modelFolder != nil || mlxModelFolder != nil, "Please specify `modelFolder` or `mlxModelFolder`")
 
+        modelState = prewarmMode ? .prewarming : .loading
         let modelLoadStart = CFAbsoluteTimeGetCurrent()
 
         Logging.debug("Loading models with prewarmMode: \(prewarmMode)")

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -38,14 +38,18 @@ open class WhisperKit {
 
     /// Configuration
     public var modelFolder: URL?
+    public var mlxModelFolder: URL?
     public var tokenizerFolder: URL?
     public let useBackgroundDownloadSession: Bool
 
     public init(
         model: String? = nil,
+        mlxModel: String? = nil,
         downloadBase: URL? = nil,
-        modelRepo: String? = nil,
+        modelRepo: String = "argmaxinc/whisperkit-coreml",
         modelFolder: String? = nil,
+        mlxModelRepo: String = "argmaxinc/whisperkit-mlx",
+        mlxModelFolder: String? = nil,
         tokenizerFolder: URL? = nil,
         computeOptions: ModelComputeOptions? = nil,
         audioProcessor: (any AudioProcessing)? = nil,
@@ -73,11 +77,22 @@ open class WhisperKit {
         currentTimings = TranscriptionTimings()
         Logging.shared.logLevel = verbose ? logLevel : .none
 
-        try await setupModels(
-            model: model,
+        // Determine the model variant to use
+        let modelVariant = model ?? WhisperKit.recommendedModels().default
+        self.modelFolder = try await setupModels(
+            model: modelVariant,
             downloadBase: downloadBase,
             modelRepo: modelRepo,
             modelFolder: modelFolder,
+            download: download
+        )
+
+        let mlxModelVariant = mlxModel ?? "openai_whisper-base"
+        self.mlxModelFolder = try await setupModels(
+            model: mlxModelVariant,
+            downloadBase: downloadBase,
+            modelRepo: mlxModelRepo,
+            modelFolder: mlxModelFolder,
             download: download
         )
 
@@ -213,26 +228,22 @@ open class WhisperKit {
 
     /// Sets up the model folder either from a local path or by downloading from a repository.
     public func setupModels(
-        model: String?,
+        model: String,
         downloadBase: URL? = nil,
-        modelRepo: String?,
+        modelRepo: String,
         modelFolder: String?,
         download: Bool
-    ) async throws {
-        // Determine the model variant to use
-        let modelVariant = model ?? WhisperKit.recommendedModels().default
-
+    ) async throws -> URL? {
         // If a local model folder is provided, use it; otherwise, download the model
-        if let folder = modelFolder {
-            self.modelFolder = URL(fileURLWithPath: folder)
+        if let modelFolder {
+            return URL(fileURLWithPath: modelFolder)
         } else if download {
-            let repo = modelRepo ?? "argmaxinc/whisperkit-coreml"
             do {
-                self.modelFolder = try await Self.download(
-                    variant: modelVariant,
+                return try await Self.download(
+                    variant: model,
                     downloadBase: downloadBase,
                     useBackgroundSession: useBackgroundDownloadSession,
-                    from: repo
+                    from: modelRepo
                 )
             } catch {
                 // Handle errors related to model downloading
@@ -241,6 +252,8 @@ open class WhisperKit {
                 Error: \(error)
                 """)
             }
+        } else {
+            return nil
         }
     }
 
@@ -255,36 +268,32 @@ open class WhisperKit {
 
         let modelLoadStart = CFAbsoluteTimeGetCurrent()
 
-        guard let path = modelFolder else {
-            throw WhisperError.modelsUnavailable("Model folder is not set.")
-        }
+        Logging.debug("Loading models with prewarmMode: \(prewarmMode)")
 
-        Logging.debug("Loading models from \(path.path) with prewarmMode: \(prewarmMode)")
-
-        if let featureExtractor = featureExtractor as? WhisperMLModel {
-            Logging.debug("Loading feature extractor")
+        if let path = modelFolder, let featureExtractor = featureExtractor as? WhisperMLModel {
+            Logging.debug("Loading feature extractor from \(path.path)")
             try await featureExtractor.loadModel(
                 at: path.appending(path: "MelSpectrogram.mlmodelc"),
                 computeUnits: modelCompute.melCompute, // hardcoded to use GPU
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded feature extractor")
-        } else if let featureExtractor = featureExtractor as? WhisperMLXModel {
-            Logging.debug("Loading MLX feature extractor")
+        } else if let path = mlxModelFolder, let featureExtractor = featureExtractor as? WhisperMLXModel {
+            Logging.debug("Loading MLX feature extractor from \(path.path)")
             try await featureExtractor.loadModel(at: path, configPath: path)
             Logging.debug("Loaded MLX feature extractor")
         }
 
-        if let audioEncoder = audioEncoder as? WhisperMLModel {
-            Logging.debug("Loading audio encoder")
+        if let path = modelFolder, let audioEncoder = audioEncoder as? WhisperMLModel {
+            Logging.debug("Loading audio encoder from \(path.path)")
             try await audioEncoder.loadModel(
                 at: path.appending(path: "AudioEncoder.mlmodelc"),
                 computeUnits: modelCompute.audioEncoderCompute,
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded audio encoder")
-        } else if let audioEncoder = audioEncoder as? WhisperMLXModel {
-            Logging.debug("Loading MLX audio encoder")
+        } else if let path = mlxModelFolder, let audioEncoder = audioEncoder as? WhisperMLXModel {
+            Logging.debug("Loading MLX audio encoder from \(path.path)")
             try await audioEncoder.loadModel(
                 at: path.appending(path: "encoder.safetensors"),
                 configPath: path.appending(path: "config.json")
@@ -292,16 +301,16 @@ open class WhisperKit {
             Logging.debug("Loaded MLX audio encoder")
         }
 
-        if let textDecoder = textDecoder as? WhisperMLModel {
-            Logging.debug("Loading text decoder")
+        if let path = modelFolder, let textDecoder = textDecoder as? WhisperMLModel {
+            Logging.debug("Loading text decoder from \(path.path)")
             try await textDecoder.loadModel(
                 at: path.appending(path: "TextDecoder.mlmodelc"),
                 computeUnits: modelCompute.textDecoderCompute,
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded text decoder")
-        } else if let textDecoder = textDecoder as? WhisperMLXModel {
-            Logging.debug("Loading MLX text decoder")
+        } else if let path = mlxModelFolder, let textDecoder = textDecoder as? WhisperMLXModel {
+            Logging.debug("Loading MLX text decoder from \(path.path)")
             try await textDecoder.loadModel(
                 at: path.appending(path: "decoder.safetensors"),
                 configPath: path.appending(path: "config.json")
@@ -309,16 +318,18 @@ open class WhisperKit {
             Logging.debug("Loaded MLX text decoder")
         }
 
-        let decoderPrefillUrl = path.appending(path: "TextDecoderContextPrefill.mlmodelc")
-        if FileManager.default.fileExists(atPath: decoderPrefillUrl.path) {
-            Logging.debug("Loading text decoder prefill data")
-            textDecoder.prefillData = TextDecoderContextPrefill()
-            try await textDecoder.prefillData?.loadModel(
-                at: decoderPrefillUrl,
-                computeUnits: modelCompute.prefillCompute,
-                prewarmMode: prewarmMode
-            )
-            Logging.debug("Loaded text decoder prefill data")
+        if let path = modelFolder {
+            let decoderPrefillUrl = path.appending(path: "TextDecoderContextPrefill.mlmodelc")
+            if FileManager.default.fileExists(atPath: decoderPrefillUrl.path) {
+                Logging.debug("Loading text decoder prefill data")
+                textDecoder.prefillData = TextDecoderContextPrefill()
+                try await textDecoder.prefillData?.loadModel(
+                    at: decoderPrefillUrl,
+                    computeUnits: modelCompute.prefillCompute,
+                    prewarmMode: prewarmMode
+                )
+                Logging.debug("Loaded text decoder prefill data")
+            }
         }
 
         if prewarmMode {

--- a/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
+++ b/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
@@ -103,9 +103,6 @@ public extension MLXFeatureExtractor {
         nFFT: Int = 400,
         hopLength: Int = 160
     ) -> MLXArray {
-        let device = MLX.Device.defaultDevice()
-        MLX.Device.setDefault(device: .cpu)
-        defer { MLX.Device.setDefault(device: device) }
         let window = hanning(nFFT)
         let freqs = stft(audio, window: window, nPerSeg: nFFT, nOverlap: hopLength)
         let magnitudes = freqs[..<(-1)].abs().square()

--- a/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
+++ b/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
@@ -108,9 +108,6 @@ public extension MLXFeatureExtractor {
         nFFT: Int = 400,
         hopLength: Int = 160
     ) -> MLXArray {
-        let device = MLX.Device.defaultDevice()
-        MLX.Device.setDefault(device: .cpu)
-        defer { MLX.Device.setDefault(device: device) }
         let window = hanning(nFFT)
         let freqs = stft(audio, window: window, nPerSeg: nFFT, nOverlap: hopLength)
         let magnitudes = freqs[..<(-1)].abs().square()

--- a/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
+++ b/Sources/WhisperKit/MLX/MLXFeatureExtractor.swift
@@ -39,6 +39,11 @@ open class MLXFeatureExtractor: FeatureExtracting {
     }
 }
 
+extension MLXFeatureExtractor: WhisperMLXModel {
+    public func loadModel(at modelPath: URL, configPath: URL) async throws {}
+    public func unloadModel() {}
+}
+
 public extension MLXFeatureExtractor {
     /// Return the Hanning window.
     /// Taken from [numpy](https://numpy.org/doc/stable/reference/generated/numpy.hanning.html) implementation
@@ -103,6 +108,9 @@ public extension MLXFeatureExtractor {
         nFFT: Int = 400,
         hopLength: Int = 160
     ) -> MLXArray {
+        let device = MLX.Device.defaultDevice()
+        MLX.Device.setDefault(device: .cpu)
+        defer { MLX.Device.setDefault(device: device) }
         let window = hanning(nFFT)
         let freqs = stft(audio, window: window, nPerSeg: nFFT, nOverlap: hopLength)
         let magnitudes = freqs[..<(-1)].abs().square()

--- a/Sources/WhisperKit/MLX/MLXTextDecoder.swift
+++ b/Sources/WhisperKit/MLX/MLXTextDecoder.swift
@@ -13,7 +13,7 @@ public final class MLXTextDecoder: TextDecoding {
     public var isModelMultilingual: Bool = false
     public let supportsWordTimestamps: Bool = false
     public var logitsSize: Int? {
-        decoder?.nState
+        decoder?.nVocab
     }
 
     public var kvCacheEmbedDim: Int? {

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -11,9 +11,10 @@ import MLXNN
 extension MLMultiArray {
     func asMLXArray<T: MLShapedArrayScalar & HasDType>(_ type: T.Type) -> MLXArray {
         let shape = shape.map(\.intValue)
+        let strides = strides.map(\.intValue)
         return withUnsafeBufferPointer(ofType: T.self) { ptr in
             let buffer = UnsafeBufferPointer(start: ptr.baseAddress, count: shape.reduce(1, *))
-            return MLXArray(buffer, shape)
+            return asStrided(MLXArray(buffer, shape), shape, strides: strides)
         }
     }
 }

--- a/Sources/WhisperKit/MLX/MLXUtils.swift
+++ b/Sources/WhisperKit/MLX/MLXUtils.swift
@@ -11,10 +11,9 @@ import MLXNN
 extension MLMultiArray {
     func asMLXArray<T: MLShapedArrayScalar & HasDType>(_ type: T.Type) -> MLXArray {
         let shape = shape.map(\.intValue)
-        let strides = strides.map(\.intValue)
         return withUnsafeBufferPointer(ofType: T.self) { ptr in
             let buffer = UnsafeBufferPointer(start: ptr.baseAddress, count: shape.reduce(1, *))
-            return asStrided(MLXArray(buffer, shape), shape, strides: strides)
+            return MLXArray(buffer, shape)
         }
     }
 }

--- a/Sources/WhisperKitCLI/CLIArguments.swift
+++ b/Sources/WhisperKitCLI/CLIArguments.swift
@@ -3,6 +3,11 @@
 
 import ArgumentParser
 
+enum ModelType: String, Decodable, ExpressibleByArgument {
+    case coreML = "coreml"
+    case mlx = "mlx"
+}
+
 struct CLIArguments: ParsableArguments {
     @Option(help: "Paths to audio files")
     var audioPath = [String]()
@@ -16,14 +21,32 @@ struct CLIArguments: ParsableArguments {
     @Option(help: "Model to download if no modelPath is provided")
     var model: String?
 
+    @Option(help: "Path of MLX model files")
+    var mlxModelPath: String?
+
+    @Option(help: "MLX Model to download if no mlxModelPath is provided")
+    var mlxModel: String?
+
     @Option(help: "Text to add in front of the model name to specify between different types of the same variant (values: \"openai\", \"distil\")")
     var modelPrefix: String = "openai"
+
+    @Option(help: "Text to add in front of the mlx model name to specify between different types of the same variant (values: \"openai\")")
+    var mlxModelPrefix: String = "openai"
 
     @Option(help: "Path to save the downloaded model")
     var downloadModelPath: String?
 
     @Option(help: "Path to save the downloaded tokenizer files")
     var downloadTokenizerPath: String?
+
+    @Option(help: "Which feature extractor to use (supported: `coreml` and `mlx`)")
+    var featureExtractorType: ModelType = .coreML
+
+    @Option(help: "Which audio encoder to use (supported: `coreml` and `mlx`)")
+    var audioEncoderType: ModelType = .coreML
+
+    @Option(help: "Which text decoder to use (supported: `coreml` and `mlx`)")
+    var textDecoderType: ModelType = .coreML
 
     @Option(help: "Compute units for audio encoder model with {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine,random}")
     var audioEncoderComputeUnits: ComputeUnits = .cpuAndNeuralEngine

--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -305,12 +305,47 @@ struct TranscribeCLI: AsyncParsableCommand {
                 nil
             }
 
+        let mlxModelName: String? =
+            if let modelVariant = cliArguments.mlxModel {
+                cliArguments.mlxModelPrefix + "*" + modelVariant
+            } else {
+                nil
+            }
+
+        let featureExtractor: FeatureExtracting =
+            switch cliArguments.featureExtractorType {
+            case .coreML:
+                FeatureExtractor()
+            case .mlx:
+                MLXFeatureExtractor()
+            }
+
+        let audioEncoder: AudioEncoding =
+            switch cliArguments.audioEncoderType {
+            case .coreML:
+                AudioEncoder()
+            case .mlx:
+                MLXAudioEncoder()
+            }
+
+        let textDecoder: TextDecoding =
+            switch cliArguments.textDecoderType {
+            case .coreML:
+                TextDecoder()
+            case .mlx:
+                MLXTextDecoder()
+            }
+
         return try await WhisperKit(
             model: modelName,
+            mlxModel: mlxModelName,
             downloadBase: downloadModelFolder,
             modelFolder: cliArguments.modelPath,
             tokenizerFolder: downloadTokenizerFolder,
             computeOptions: computeOptions,
+            featureExtractor: featureExtractor,
+            audioEncoder: audioEncoder,
+            textDecoder: textDecoder,
             verbose: cliArguments.verbose,
             logLevel: .debug,
             load: true,

--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -312,8 +312,19 @@ struct TranscribeCLI: AsyncParsableCommand {
                 nil
             }
 
+        var featureExtractorType = cliArguments.featureExtractorType
+        var audioEncoderType = cliArguments.featureExtractorType
+        var textDecoderType = cliArguments.featureExtractorType
+
+        if modelName == nil, mlxModelName != nil {
+            // CoreML model not provided, default to MLX
+            featureExtractorType = .mlx
+            audioEncoderType = .mlx
+            textDecoderType = .mlx
+        }
+
         let featureExtractor: FeatureExtracting =
-            switch cliArguments.featureExtractorType {
+            switch featureExtractorType {
             case .coreML:
                 FeatureExtractor()
             case .mlx:
@@ -321,7 +332,7 @@ struct TranscribeCLI: AsyncParsableCommand {
             }
 
         let audioEncoder: AudioEncoding =
-            switch cliArguments.audioEncoderType {
+            switch audioEncoderType {
             case .coreML:
                 AudioEncoder()
             case .mlx:
@@ -329,7 +340,7 @@ struct TranscribeCLI: AsyncParsableCommand {
             }
 
         let textDecoder: TextDecoding =
-            switch cliArguments.textDecoderType {
+            switch textDecoderType {
             case .coreML:
                 TextDecoder()
             case .mlx:

--- a/Sources/WhisperKitTestsUtils/TestUtils.swift
+++ b/Sources/WhisperKitTestsUtils/TestUtils.swift
@@ -1,7 +1,7 @@
 import CoreML
 import Combine
 import Foundation
-@testable import WhisperKit
+import WhisperKit
 import XCTest
 
 public enum TestError: Error {
@@ -133,7 +133,8 @@ public extension MLMultiArray {
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public extension XCTestCase {
     func transcribe(
-        modelPath: String,
+        modelPath: String? = nil,
+        mlxModelPath: String? = nil,
         options: DecodingOptions,
         callback: TranscriptionCallback = nil,
         audioFile: String = "jfk.wav",
@@ -151,6 +152,7 @@ public extension XCTestCase {
         )
         let whisperKit = try await WhisperKit(
             modelFolder: modelPath,
+            mlxModelFolder: mlxModelPath,
             computeOptions: computeOptions,
             featureExtractor: featureExtractor,
             audioEncoder: audioEncoder,
@@ -170,7 +172,7 @@ public extension XCTestCase {
     func tinyModelPath() throws -> String {
         let modelDir = "whisperkit-coreml/openai_whisper-tiny"
         guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "mlmodelc", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
-            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-models`")
+            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-model MODEL=tiny`")
         }
         return modelPath
     }
@@ -178,7 +180,7 @@ public extension XCTestCase {
     func tinyMLXModelPath() throws -> String {
         let modelDir = "whisperkit-mlx/openai_whisper-tiny"
         guard let modelPath = Bundle.module.urls(forResourcesWithExtension: "safetensors", subdirectory: modelDir)?.first?.deletingLastPathComponent().path else {
-            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-mlx-models`")
+            throw TestError.missingFile("Failed to load model, ensure \"Models/\(modelDir)\" exists via Makefile command: `make download-mlx-model MODEL=tiny`")
         }
         return modelPath
     }

--- a/Tests/WhisperKitMLXTests/MLXUnitTests.swift
+++ b/Tests/WhisperKitMLXTests/MLXUnitTests.swift
@@ -423,19 +423,19 @@ final class MLXUnitTests: XCTestCase {
 
     func testAdditiveCausalMask() {
         let result1 = additiveCausalMask(0)
-        XCTAssertEqual(result1.shape, [0 ,0])
-        XCTAssertEqual(result1.dtype, .float32)
+        XCTAssertEqual(result1.shape, [0 ,0], "Array shape should be [0, 0]")
+        XCTAssertEqual(result1.dtype, .float32, "Array type should be .float32")
 
         let result2 = additiveCausalMask(3)
-        XCTAssertEqual(result2.shape, [3 ,3])
-        XCTAssertEqual(result2.dtype, .float32)
+        XCTAssertEqual(result2.shape, [3 ,3], "Array shape should be [3, 3]")
+        XCTAssertEqual(result2.dtype, .float32, "Array type should be .float32")
         XCTAssertEqual(result2[0].asArray(Float.self), [0.0, -1e9, -1e9], accuracy: accuracy)
         XCTAssertEqual(result2[1].asArray(Float.self), [0.0, 0.0, -1e9], accuracy: accuracy)
         XCTAssertEqual(result2[2].asArray(Float.self), [0.0, 0.0, 0.0], accuracy: accuracy)
 
         let result3 = additiveCausalMask(4)
-        XCTAssertEqual(result3.shape, [4 ,4])
-        XCTAssertEqual(result3.dtype, .float32)
+        XCTAssertEqual(result3.shape, [4 ,4], "Array shape should be [4, 4]")
+        XCTAssertEqual(result3.dtype, .float32, "Array type should be .float32")
         XCTAssertEqual(result3[0].asArray(Float.self), [0.0, -1e9, -1e9, -1e9], accuracy: accuracy)
         XCTAssertEqual(result3[1].asArray(Float.self), [0.0, 0.0, -1e9, -1e9], accuracy: accuracy)
         XCTAssertEqual(result3[2].asArray(Float.self), [0.0, 0.0, 0.0, -1e9], accuracy: accuracy)

--- a/Tests/WhisperKitMLXTests/MLXUnitTests.swift
+++ b/Tests/WhisperKitMLXTests/MLXUnitTests.swift
@@ -154,7 +154,7 @@ final class MLXUnitTests: XCTestCase {
 
         let result = try await XCTUnwrapAsync(
             try await transcribe(
-                modelPath: tinyModelPath,
+                mlxModelPath: tinyModelPath,
                 options: options,
                 audioFile: "es_test_clip.wav",
                 featureExtractor: MLXFeatureExtractor(),
@@ -173,7 +173,7 @@ final class MLXUnitTests: XCTestCase {
 
         let result = try await XCTUnwrapAsync(
             try await transcribe(
-                modelPath: tinyModelPath,
+                mlxModelPath: tinyModelPath,
                 options: options,
                 audioFile: "es_test_clip.wav",
                 featureExtractor: MLXFeatureExtractor(),
@@ -189,7 +189,7 @@ final class MLXUnitTests: XCTestCase {
     func testDetectSpanish() async throws {
         let targetLanguage = "es"
         let whisperKit = try await WhisperKit(
-            modelFolder: tinyModelPath,
+            mlxModelFolder: tinyModelPath,
             featureExtractor: MLXFeatureExtractor(),
             audioEncoder: MLXAudioEncoder(),
             textDecoder: MLXTextDecoder(),
@@ -215,7 +215,7 @@ final class MLXUnitTests: XCTestCase {
 
         let result = try await XCTUnwrapAsync(
             try await transcribe(
-                modelPath: tinyModelPath,
+                mlxModelPath: tinyModelPath,
                 options: options,
                 audioFile: "ja_test_clip.wav",
                 featureExtractor: MLXFeatureExtractor(),
@@ -234,7 +234,7 @@ final class MLXUnitTests: XCTestCase {
 
         let result = try await XCTUnwrapAsync(
             try await transcribe(
-                modelPath: tinyModelPath,
+                mlxModelPath: tinyModelPath,
                 options: options,
                 audioFile: "ja_test_clip.wav",
                 featureExtractor: MLXFeatureExtractor(),
@@ -250,7 +250,7 @@ final class MLXUnitTests: XCTestCase {
     func testDetectJapanese() async throws {
         let targetLanguage = "ja"
         let whisperKit = try await WhisperKit(
-            modelFolder: tinyModelPath,
+            mlxModelFolder: tinyModelPath,
             featureExtractor: MLXFeatureExtractor(),
             audioEncoder: MLXAudioEncoder(),
             textDecoder: MLXTextDecoder(),
@@ -283,7 +283,7 @@ final class MLXUnitTests: XCTestCase {
         for (i, option) in optionsPairs.enumerated() {
             let result = try await XCTUnwrapAsync(
                 try await transcribe(
-                    modelPath: tinyModelPath,
+                    mlxModelPath: tinyModelPath,
                     options: option.options,
                     audioFile: "ja_test_clip.wav",
                     featureExtractor: MLXFeatureExtractor(),

--- a/Tests/WhisperKitMLXTests/MLXUnitTests.swift
+++ b/Tests/WhisperKitMLXTests/MLXUnitTests.swift
@@ -312,19 +312,35 @@ final class MLXUnitTests: XCTestCase {
 
     // MARK: - Utils Tests
 
+    func testContiguousStrides() {
+        let count = 24
+        let arr1 = MLXArray(0..<count, [count]).asType(Int32.self)
+        XCTAssertEqual(arr1.contiguousStrides, [1])
+
+        let arr2 = MLXArray(0..<count, [2, count / 2]).asType(Int32.self)
+        XCTAssertEqual(arr2.contiguousStrides, [12, 1])
+
+        let arr3 = MLXArray(0..<count, [2, count / 2]).asType(Int32.self).asMLXInput()
+        XCTAssertEqual(arr3.contiguousStrides, [24, 2, 1])
+    }
+
     func testArrayConversion() throws {
         let count = 16
         let arr1 = MLXArray(0..<count, [2, count / 2]).asType(Int32.self)
         let arr2 = try arr1.asMLMultiArray().asMLXArray(Int32.self)
+        XCTAssertEqual(arr2.contiguousStrides, [8, 1])
         XCTAssertTrue(MLX.allClose(arr1, arr2).item(), "Array conversion failed")
 
         let arr3 = arr1.asMLXOutput().asMLXInput()
+        XCTAssertEqual(arr3.contiguousStrides, [16, 8, 1])
         XCTAssertTrue(MLX.allClose(arr1, arr3).item(), "Input output conversion failed")
 
         let arr4 = try arr1.asMLXOutput().asMLXInput().asMLMultiArray().asMLXArray(Int32.self)
+        XCTAssertEqual(arr4.contiguousStrides, [16, 8, 1])
         XCTAssertTrue(MLX.allClose(arr1, arr4).item(), "Complex conversion failed")
 
         let arr5 = try arr1.asMLXOutput().asMLMultiArray().asMLXArray(Int32.self).asMLXInput()
+        XCTAssertEqual(arr5.contiguousStrides, [16, 8, 1])
         XCTAssertTrue(MLX.allClose(arr1, arr5).item(), "Complex conversion failed")
     }
 


### PR DESCRIPTION
In this PR:

- added new params to `WhisperKit`: 
  - `mlxModel` if specified, it will be used to specify which mlx model to download
  - `mlxModelRepo` if specified, it will be used to specify the repo where the mlx model is stored
  - `mlxModelFolder` if specified, it will point to the local folder where the mlx model is stored

- added new options to `CLIArguments`:
  - `mlxModel`, `mlxModelPath` see the explanation above
  - `featureExtractorType`, `audioEncoderType`, `textDecoderType` to specify which type (coreml or or mlx) should be used for given pipeline step

- updated readme to reflect the changes above
- updated makefile to reflect the changes above
- simplified CI unit test

To do:
- update MLX to the latest version, right now blocked by https://github.com/ml-explore/mlx-swift/issues/117, edit: fixed
- update the way we build brew, we should use `xcodebuild` instead of `swift build`