### PR TITLE
Make additional initializers, functions, members public for extensibility

### DIFF
--- a/Sources/WhisperKit/Core/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/AudioProcessor.swift
@@ -80,7 +80,7 @@ public extension AudioProcessing {
     @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
     static func loadAudioAsync(fromPath audioFilePath: String) async throws -> AVAudioPCMBuffer {
         return try await Task {
-            return try AudioProcessor.loadAudio(fromPath: audioFilePath)
+            try AudioProcessor.loadAudio(fromPath: audioFilePath)
         }.value
     }
 
@@ -305,7 +305,8 @@ public class AudioProcessor: NSObject, AudioProcessing {
                 try audioFile.read(into: inputBuffer, frameCount: framesToRead)
                 guard let resampledChunk = resampleAudio(fromBuffer: inputBuffer,
                                                          toSampleRate: outputFormat.sampleRate,
-                                                         channelCount: outputFormat.channelCount) else {
+                                                         channelCount: outputFormat.channelCount)
+                else {
                     Logging.error("Failed to resample audio chunk")
                     return nil
                 }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -188,7 +188,6 @@ public enum DecodingTask: CustomStringConvertible, CaseIterable {
 }
 
 public struct DecodingInputs {
-
     public var initialPrompt: [Int]
     public var inputIds: MLMultiArray
     public var cacheLength: MLMultiArray
@@ -212,7 +211,7 @@ public struct DecodingInputs {
         self.prefillKeyCache = prefillKeyCache
         self.prefillValueCache = prefillValueCache
     }
-    
+
     func reset(prefilledCacheSize: Int, maxTokenContext: Int) {
         // NOTE: Because we have a mask on the kvcache,
         // we can simply shift the masks without touching the data,
@@ -237,7 +236,6 @@ public struct DecodingInputs {
 }
 
 public struct DecodingCache {
-
     public var keyCache: MLMultiArray?
     public var valueCache: MLMultiArray?
     public var alignmentWeights: MLMultiArray?
@@ -246,7 +244,6 @@ public struct DecodingCache {
         self.valueCache = valueCache
         self.alignmentWeights = alignmentWeights
     }
-    
 }
 
 public enum ChunkingStrategy: String, CaseIterable {
@@ -411,7 +408,6 @@ public extension DecodingFallback {
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public struct DecodingResult {
-
     public var language: String
     public var languageProbs: [String: Float]
     public var tokens: [Int]
@@ -440,7 +436,7 @@ public struct DecodingResult {
                               fallback: nil)
     }
 
-    public init(language: String, languageProbs: [String : Float], tokens: [Int], tokenLogProbs: [[Int : Float]], text: String, avgLogProb: Float, noSpeechProb: Float, temperature: Float, compressionRatio: Float, cache: DecodingCache? = nil, timings: TranscriptionTimings? = nil, fallback: DecodingFallback? = nil) {
+    public init(language: String, languageProbs: [String: Float], tokens: [Int], tokenLogProbs: [[Int: Float]], text: String, avgLogProb: Float, noSpeechProb: Float, temperature: Float, compressionRatio: Float, cache: DecodingCache? = nil, timings: TranscriptionTimings? = nil, fallback: DecodingFallback? = nil) {
         self.language = language
         self.languageProbs = languageProbs
         self.tokens = tokens
@@ -454,7 +450,6 @@ public struct DecodingResult {
         self.timings = timings
         self.fallback = fallback
     }
-    
 }
 
 public enum WhisperError: Error, LocalizedError, Equatable {
@@ -619,7 +614,6 @@ public struct WordTiming: Hashable, Codable {
 }
 
 public struct TranscriptionProgress {
-
     public var timings: TranscriptionTimings
     public var text: String
     public var tokens: [Int]
@@ -627,7 +621,7 @@ public struct TranscriptionProgress {
     public var avgLogprob: Float?
     public var compressionRatio: Float?
     public var windowId: Int = 0
-    
+
     public init(timings: TranscriptionTimings, text: String, tokens: [Int], temperature: Float? = nil, avgLogprob: Float? = nil, compressionRatio: Float? = nil, windowId: Int = 0) {
         self.timings = timings
         self.text = text
@@ -637,7 +631,6 @@ public struct TranscriptionProgress {
         self.compressionRatio = compressionRatio
         self.windowId = windowId
     }
-    
 }
 
 /// Callback to receive progress updates during transcription.

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -188,17 +188,31 @@ public enum DecodingTask: CustomStringConvertible, CaseIterable {
 }
 
 public struct DecodingInputs {
-    var initialPrompt: [Int]
-    var inputIds: MLMultiArray
-    var cacheLength: MLMultiArray
-    var keyCache: MLMultiArray
-    var valueCache: MLMultiArray
-    var alignmentWeights: MLMultiArray
-    var kvCacheUpdateMask: MLMultiArray
-    var decoderKeyPaddingMask: MLMultiArray
-    var prefillKeyCache: MLMultiArray
-    var prefillValueCache: MLMultiArray
 
+    public var initialPrompt: [Int]
+    public var inputIds: MLMultiArray
+    public var cacheLength: MLMultiArray
+    public var keyCache: MLMultiArray
+    public var valueCache: MLMultiArray
+    public var alignmentWeights: MLMultiArray
+    public var kvCacheUpdateMask: MLMultiArray
+    public var decoderKeyPaddingMask: MLMultiArray
+    public var prefillKeyCache: MLMultiArray
+    public var prefillValueCache: MLMultiArray
+
+    public init(initialPrompt: [Int], inputIds: MLMultiArray, cacheLength: MLMultiArray, keyCache: MLMultiArray, valueCache: MLMultiArray, alignmentWeights: MLMultiArray, kvCacheUpdateMask: MLMultiArray, decoderKeyPaddingMask: MLMultiArray, prefillKeyCache: MLMultiArray, prefillValueCache: MLMultiArray) {
+        self.initialPrompt = initialPrompt
+        self.inputIds = inputIds
+        self.cacheLength = cacheLength
+        self.keyCache = keyCache
+        self.valueCache = valueCache
+        self.alignmentWeights = alignmentWeights
+        self.kvCacheUpdateMask = kvCacheUpdateMask
+        self.decoderKeyPaddingMask = decoderKeyPaddingMask
+        self.prefillKeyCache = prefillKeyCache
+        self.prefillValueCache = prefillValueCache
+    }
+    
     func reset(prefilledCacheSize: Int, maxTokenContext: Int) {
         // NOTE: Because we have a mask on the kvcache,
         // we can simply shift the masks without touching the data,
@@ -223,9 +237,16 @@ public struct DecodingInputs {
 }
 
 public struct DecodingCache {
-    var keyCache: MLMultiArray?
-    var valueCache: MLMultiArray?
-    var alignmentWeights: MLMultiArray?
+
+    public var keyCache: MLMultiArray?
+    public var valueCache: MLMultiArray?
+    public var alignmentWeights: MLMultiArray?
+    public init(keyCache: MLMultiArray? = nil, valueCache: MLMultiArray? = nil, alignmentWeights: MLMultiArray? = nil) {
+        self.keyCache = keyCache
+        self.valueCache = valueCache
+        self.alignmentWeights = alignmentWeights
+    }
+    
 }
 
 public enum ChunkingStrategy: String, CaseIterable {
@@ -390,6 +411,7 @@ public extension DecodingFallback {
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
 public struct DecodingResult {
+
     public var language: String
     public var languageProbs: [String: Float]
     public var tokens: [Int]
@@ -417,6 +439,22 @@ public struct DecodingResult {
                               timings: nil,
                               fallback: nil)
     }
+
+    public init(language: String, languageProbs: [String : Float], tokens: [Int], tokenLogProbs: [[Int : Float]], text: String, avgLogProb: Float, noSpeechProb: Float, temperature: Float, compressionRatio: Float, cache: DecodingCache? = nil, timings: TranscriptionTimings? = nil, fallback: DecodingFallback? = nil) {
+        self.language = language
+        self.languageProbs = languageProbs
+        self.tokens = tokens
+        self.tokenLogProbs = tokenLogProbs
+        self.text = text
+        self.avgLogProb = avgLogProb
+        self.noSpeechProb = noSpeechProb
+        self.temperature = temperature
+        self.compressionRatio = compressionRatio
+        self.cache = cache
+        self.timings = timings
+        self.fallback = fallback
+    }
+    
 }
 
 public enum WhisperError: Error, LocalizedError, Equatable {
@@ -581,6 +619,7 @@ public struct WordTiming: Hashable, Codable {
 }
 
 public struct TranscriptionProgress {
+
     public var timings: TranscriptionTimings
     public var text: String
     public var tokens: [Int]
@@ -588,6 +627,17 @@ public struct TranscriptionProgress {
     public var avgLogprob: Float?
     public var compressionRatio: Float?
     public var windowId: Int = 0
+    
+    public init(timings: TranscriptionTimings, text: String, tokens: [Int], temperature: Float? = nil, avgLogprob: Float? = nil, compressionRatio: Float? = nil, windowId: Int = 0) {
+        self.timings = timings
+        self.text = text
+        self.tokens = tokens
+        self.temperature = temperature
+        self.avgLogprob = avgLogprob
+        self.compressionRatio = compressionRatio
+        self.windowId = windowId
+    }
+    
 }
 
 /// Callback to receive progress updates during transcription.

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -760,7 +760,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 break
             }
         }
-        
+
         // Cleanup the early stop flag after loop completion
         if shouldEarlyStop.removeValue(forKey: windowUUID) == nil {
             Logging.error("Early stop flag not found for window: \(windowUUID)")

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -156,14 +156,14 @@ public extension WhisperKit {
 }
 
 public extension Float {
-    public func rounded(_ decimalPlaces: Int) -> Float {
+    func rounded(_ decimalPlaces: Int) -> Float {
         let divisor = pow(10.0, Float(decimalPlaces))
         return (self * divisor).rounded() / divisor
     }
 }
 
 public extension String {
-    public var normalized: String {
+    var normalized: String {
         // Trim whitespace and newlines
         let trimmedString = self.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -182,18 +182,18 @@ public extension String {
         return singleSpacedString
     }
 
-    public func trimmingSpecialTokenCharacters() -> String {
+    func trimmingSpecialTokenCharacters() -> String {
         trimmingCharacters(in: Constants.specialTokenCharacters)
     }
 }
 
 extension AVAudioPCMBuffer {
-    // Appends the contents of another buffer to the current buffer
+    /// Appends the contents of another buffer to the current buffer
     func appendContents(of buffer: AVAudioPCMBuffer) -> Bool {
         return appendContents(of: buffer, startingFrame: 0, frameCount: buffer.frameLength)
     }
 
-    // Appends a specific range of frames from another buffer to the current buffer
+    /// Appends a specific range of frames from another buffer to the current buffer
     func appendContents(of buffer: AVAudioPCMBuffer, startingFrame: AVAudioFramePosition, frameCount: AVAudioFrameCount) -> Bool {
         guard format == buffer.format else {
             Logging.debug("Format mismatch")
@@ -225,7 +225,7 @@ extension AVAudioPCMBuffer {
         return true
     }
 
-    // Convenience initializer to concatenate multiple buffers into one
+    /// Convenience initializer to concatenate multiple buffers into one
     convenience init?(concatenating buffers: [AVAudioPCMBuffer]) {
         guard !buffers.isEmpty else {
             Logging.debug("Buffers array should not be empty")
@@ -249,7 +249,7 @@ extension AVAudioPCMBuffer {
         }
     }
 
-    // Computed property to determine the stride for float channel data
+    /// Computed property to determine the stride for float channel data
     private var stride: Int {
         return Int(format.streamDescription.pointee.mBytesPerFrame) / MemoryLayout<Float>.size
     }

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -155,15 +155,15 @@ public extension WhisperKit {
     }
 }
 
-extension Float {
-    func rounded(_ decimalPlaces: Int) -> Float {
+public extension Float {
+    public func rounded(_ decimalPlaces: Int) -> Float {
         let divisor = pow(10.0, Float(decimalPlaces))
         return (self * divisor).rounded() / divisor
     }
 }
 
-extension String {
-    var normalized: String {
+public extension String {
+    public var normalized: String {
         // Trim whitespace and newlines
         let trimmedString = self.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -182,7 +182,7 @@ extension String {
         return singleSpacedString
     }
 
-    func trimmingSpecialTokenCharacters() -> String {
+    public func trimmingSpecialTokenCharacters() -> String {
         trimmingCharacters(in: Constants.specialTokenCharacters)
     }
 }

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -399,7 +399,7 @@ open class WhisperKit {
         guard textDecoder.isModelMultilingual else {
             throw WhisperError.decodingFailed("Language detection not supported for this model")
         }
-        
+
         // Tokenizer required for decoding
         guard let tokenizer else {
             throw WhisperError.tokenizerUnavailable()


### PR DESCRIPTION
* Allows use of default internal functions & member accesses which have increased protections when imported

* Initializers were Xcode generated: right click class name -> refactor -> generate memberwise initializers
   * memberwise initializer defaults to internal, mark as public.