### PR TITLE
Set default concurrentWorkerCount 

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -337,7 +337,7 @@ public struct DecodingOptions {
         logProbThreshold: Float? = -1.0,
         firstTokenLogProbThreshold: Float? = -1.5,
         noSpeechThreshold: Float? = 0.6,
-        concurrentWorkerCount: Int = 0,
+        concurrentWorkerCount: Int = 16,
         chunkingStrategy: ChunkingStrategy? = nil
     ) {
         self.verbose = verbose


### PR DESCRIPTION
Set default concurrentWorkerCount in order to cap peak memory consumption for long files when chunkingStrategy is VAD.

Fixes #204 