### PR TITLE
Add model support config fetching from model repo

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
         run: make download-model MODEL=tiny
       - name: Install and discover destinations
         run: |
-          xcodebuild -downloadAllPlatforms
+          xcodebuild -downloadPlatorm ${{ matrix.run-config['name'] }}
           echo "Destinations for testing:"
           xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
       - name: Boot Simulator and Wait

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,9 @@ jobs:
         run: make download-model MODEL=tiny
       - name: Install and discover destinations
         run: |
-          xcodebuild -downloadPlatorm ${{ matrix.run-config['name'] }}
+          if [[ "${{ matrix.run-config['name'] }}" != "macOS" ]]; then
+            xcodebuild -downloadPlatform ${{ matrix.run-config['name'] }}
+          fi
           echo "Destinations for testing:"
           xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
       - name: Boot Simulator and Wait

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "74b94211bdc741694ed7e700a1104c72e5ba68fe",
-        "version" : "0.1.7"
+        "revision" : "fc6543263e4caed9bf6107466d625cfae9357f08",
+        "version" : "0.1.8"
       }
     }
   ],

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -956,8 +956,7 @@ struct ContentView: View {
 
         localModels = WhisperKit.formatModelFiles(localModels)
         for model in localModels {
-            if !availableModels.contains(model),
-               !disabledModels.contains(model)
+            if !availableModels.contains(model)
             {
                 availableModels.append(model)
             }
@@ -967,12 +966,19 @@ struct ContentView: View {
         print("Previously selected model: \(selectedModel)")
 
         Task {
-            let remoteModels = try await WhisperKit.fetchAvailableModels(from: repoName)
-            for model in remoteModels {
-                if !availableModels.contains(model),
-                   !disabledModels.contains(model)
-                {
-                    availableModels.append(model)
+            let remoteModelSupport = await WhisperKit.recommendedRemoteModels()
+            await MainActor.run {
+                for model in remoteModelSupport.supported {
+                    if !availableModels.contains(model)
+                    {
+                        availableModels.append(model)
+                    }
+                }
+                for model in remoteModelSupport.disabled {
+                    if !disabledModels.contains(model)
+                    {
+                        disabledModels.append(model)
+                    }
                 }
             }
         }

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -110,7 +110,6 @@ struct ContentView: View {
         MenuItem(name: "Stream", image: "waveform.badge.mic"),
     ]
 
-
     private var isStreamMode: Bool {
         self.selectedCategoryId == menu.first(where: { $0.name == "Stream" })?.id
     }
@@ -202,7 +201,7 @@ struct ContentView: View {
             .toolbar(content: {
                 ToolbarItem {
                     Button {
-                        if (!enableEagerDecoding) {
+                        if !enableEagerDecoding {
                             let fullTranscript = formatSegments(confirmedSegments + unconfirmedSegments, withTimestamps: enableTimestamps).joined(separator: "\n")
                             #if os(iOS)
                             UIPasteboard.general.string = fullTranscript
@@ -956,8 +955,7 @@ struct ContentView: View {
 
         localModels = WhisperKit.formatModelFiles(localModels)
         for model in localModels {
-            if !availableModels.contains(model)
-            {
+            if !availableModels.contains(model) {
                 availableModels.append(model)
             }
         }
@@ -969,14 +967,12 @@ struct ContentView: View {
             let remoteModelSupport = await WhisperKit.recommendedRemoteModels()
             await MainActor.run {
                 for model in remoteModelSupport.supported {
-                    if !availableModels.contains(model)
-                    {
+                    if !availableModels.contains(model) {
                         availableModels.append(model)
                     }
                 }
                 for model in remoteModelSupport.disabled {
-                    if !disabledModels.contains(model)
-                    {
+                    if !disabledModels.contains(model) {
                         disabledModels.append(model)
                     }
                 }
@@ -1649,7 +1645,6 @@ struct ContentView: View {
             Logging.error("[EagerMode] Error: \(error)")
             finalizeText()
         }
-
 
         let mergedResult = mergeTranscriptionResults(eagerResults, confirmedWords: confirmedWords)
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "74b94211bdc741694ed7e700a1104c72e5ba68fe",
-        "version" : "0.1.7"
+        "revision" : "fc6543263e4caed9bf6107466d625cfae9357f08",
+        "version" : "0.1.8"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.7"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "0.1.8"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.3.0"),
     ],
     targets: [

--- a/Sources/WhisperKit/Core/Audio/AudioChunker.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioChunker.swift
@@ -81,8 +81,8 @@ open class VADAudioChunker: AudioChunking {
             // Typically this will be the full audio file, unless seek points are explicitly provided
             var startIndex = seekClipStart
             while startIndex < seekClipEnd - windowPadding {
-                let currentFrameLength = startIndex - seekClipStart
-                if startIndex >= currentFrameLength, startIndex < 0 {
+                let currentFrameLength = audioArray.count
+                if startIndex < 0 || startIndex >= currentFrameLength {
                     throw WhisperError.audioProcessingFailed("startIndex is outside the buffer size")
                 }
 

--- a/Sources/WhisperKit/Core/Audio/AudioChunker.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioChunker.swift
@@ -82,7 +82,7 @@ open class VADAudioChunker: AudioChunking {
             var startIndex = seekClipStart
             while startIndex < seekClipEnd - windowPadding {
                 let currentFrameLength = audioArray.count
-                if startIndex < 0 || startIndex >= currentFrameLength {
+                guard startIndex >= 0 && startIndex < audioArray.count else {
                     throw WhisperError.audioProcessingFailed("startIndex is outside the buffer size")
                 }
 

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -95,7 +95,7 @@ public extension AudioProcessing {
     static func padOrTrimAudio(fromArray audioArray: [Float], startAt startIndex: Int = 0, toLength frameLength: Int = 480_000, saveSegment: Bool = false) -> MLMultiArray? {
         let currentFrameLength = audioArray.count
 
-        if startIndex >= currentFrameLength, startIndex < 0 {
+        if startIndex < 0 || startIndex >= currentFrameLength {
             Logging.error("startIndex is outside the buffer size")
             return nil
         }

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -95,7 +95,7 @@ public extension AudioProcessing {
     static func padOrTrimAudio(fromArray audioArray: [Float], startAt startIndex: Int = 0, toLength frameLength: Int = 480_000, saveSegment: Bool = false) -> MLMultiArray? {
         let currentFrameLength = audioArray.count
 
-        if startIndex < 0 || startIndex >= currentFrameLength {
+        guard startIndex >= 0 && startIndex < audioArray.count else {
             Logging.error("startIndex is outside the buffer size")
             return nil
         }

--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -60,8 +60,8 @@ open class WhisperKitConfig {
                 prewarm: Bool? = nil,
                 load: Bool? = nil,
                 download: Bool = true,
-                useBackgroundDownloadSession: Bool = false
-    ) {
+                useBackgroundDownloadSession: Bool = false)
+    {
         self.model = model
         self.downloadBase = downloadBase
         self.modelRepo = modelRepo
@@ -82,7 +82,6 @@ open class WhisperKitConfig {
         self.useBackgroundDownloadSession = useBackgroundDownloadSession
     }
 }
-
 
 /// Options for how to transcribe an audio file using WhisperKit.
 ///

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -168,7 +168,7 @@ public struct ModelComputeOptions {
 public struct ModelSupport: Codable, Equatable {
     public let `default`: String
     public let supported: [String]
-    // Computed on init of ModelRepoConfig
+    /// Computed on init of ModelRepoConfig
     public var disabled: [String] = []
 
     private enum CodingKeys: String, CodingKey {
@@ -185,7 +185,7 @@ public struct ModelSupportConfig: Codable {
     public let repoName: String
     public let repoVersion: String
     public var deviceSupport: [DeviceSupport]
-    // Computed on init
+    /// Computed on init
     public private(set) var knownModels: [String]
     public private(set) var defaultSupport: DeviceSupport
 
@@ -1468,7 +1468,7 @@ public enum Constants {
                             "openai_whisper-base",
                             "openai_whisper-base.en",
                             "openai_whisper-tiny",
-                            "openai_whisper-tiny.en"
+                            "openai_whisper-tiny.en",
                         ]
                     )
                 ),
@@ -1482,7 +1482,7 @@ public enum Constants {
                             "openai_whisper-base",
                             "openai_whisper-base.en",
                             "openai_whisper-small",
-                            "openai_whisper-small.en"
+                            "openai_whisper-small.en",
                         ]
                     )
                 ),
@@ -1518,7 +1518,7 @@ public enum Constants {
                         "Macmini9",
                         "iPad13,16",
                         "iPad13,4",
-                        "iPad13,8"
+                        "iPad13,8",
                     ],
                     models: ModelSupport(
                         default: "openai_whisper-large-v3-v20240930",
@@ -1553,7 +1553,7 @@ public enum Constants {
                         "iPad14,9",
                         "iPad14,10",
                         "iPad14,11",
-                        "iPad16"
+                        "iPad16",
                     ],
                     models: ModelSupport(
                         default: "openai_whisper-large-v3-v20240930",
@@ -1582,7 +1582,7 @@ public enum Constants {
                             "openai_whisper-large-v3-v20240930_turbo_632MB",
                         ]
                     )
-                )
+                ),
             ],
             includeFallback: false
         )
@@ -1590,7 +1590,5 @@ public enum Constants {
         return config
     }()
 
-    public static let knownModels: [String] = {
-        fallbackModelSupportConfig.deviceSupport.flatMap { $0.models.supported }.orderedSet
-    }()
+    public static let knownModels: [String] = fallbackModelSupportConfig.deviceSupport.flatMap { $0.models.supported }.orderedSet
 }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -165,6 +165,114 @@ public struct ModelComputeOptions {
     }
 }
 
+public struct ModelSupport: Codable, Equatable {
+    public let `default`: String
+    public let supported: [String]
+    // Computed on init of ModelRepoConfig
+    public var disabled: [String] = []
+
+    private enum CodingKeys: String, CodingKey {
+        case `default`, supported
+    }
+}
+
+public struct DeviceSupport: Codable {
+    public let identifiers: [String]
+    public var models: ModelSupport
+}
+
+public struct ModelSupportConfig: Codable {
+    public let repoName: String
+    public let repoVersion: String
+    public var deviceSupport: [DeviceSupport]
+    // Computed on init
+    public private(set) var knownModels: [String]
+    public private(set) var defaultSupport: DeviceSupport
+
+    enum CodingKeys: String, CodingKey {
+        case repoName = "name"
+        case repoVersion = "version"
+        case deviceSupport = "device_support"
+    }
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let repoName = try container.decode(String.self, forKey: .repoName)
+        let repoVersion = try container.decode(String.self, forKey: .repoVersion)
+        let deviceSupport = try container.decode([DeviceSupport].self, forKey: .deviceSupport)
+
+        self.init(repoName: repoName, repoVersion: repoVersion, deviceSupport: deviceSupport)
+    }
+
+    public init(repoName: String, repoVersion: String, deviceSupport: [DeviceSupport], includeFallback: Bool = true) {
+        self.repoName = repoName
+        self.repoVersion = repoVersion
+
+        if includeFallback {
+            self.deviceSupport = Self.mergeDeviceSupport(remote: deviceSupport, fallback: Constants.fallbackModelSupportConfig.deviceSupport)
+            self.knownModels = self.deviceSupport.flatMap { $0.models.supported }.orderedSet
+        } else {
+            self.deviceSupport = deviceSupport
+            self.knownModels = deviceSupport.flatMap { $0.models.supported }.orderedSet
+        }
+
+        // Add default device support with all models supported for unknown devices
+        self.defaultSupport = DeviceSupport(
+            identifiers: [],
+            models: ModelSupport(
+                default: "openai_whisper-base",
+                supported: self.knownModels
+            )
+        )
+
+        computeDisabledModels()
+    }
+
+    @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+    public func modelSupport(for deviceIdentifier: String = WhisperKit.deviceName()) -> ModelSupport {
+        for support in deviceSupport {
+            if support.identifiers.contains(where: { deviceIdentifier.hasPrefix($0) }) {
+                return support.models
+            }
+        }
+        return defaultSupport.models
+    }
+
+    private mutating func computeDisabledModels() {
+        for i in 0..<deviceSupport.count {
+            let disabledModels = Set(knownModels).subtracting(deviceSupport[i].models.supported)
+            self.deviceSupport[i].models.disabled = Array(disabledModels)
+        }
+    }
+
+    private static func mergeDeviceSupport(remote: [DeviceSupport], fallback: [DeviceSupport]) -> [DeviceSupport] {
+        var mergedSupports: [DeviceSupport] = []
+        let remoteIdentifiers = Set(remote.flatMap { $0.identifiers })
+
+        // Add remote device support, merging with fallback if identifiers overlap
+        for remoteSupport in remote {
+            if let fallbackSupport = fallback.first(where: { $0.identifiers.contains(where: remoteSupport.identifiers.contains) }) {
+                let mergedModels = ModelSupport(
+                    default: remoteSupport.models.default,
+                    supported: (remoteSupport.models.supported + fallbackSupport.models.supported).orderedSet
+                )
+                mergedSupports.append(DeviceSupport(identifiers: remoteSupport.identifiers, models: mergedModels))
+            } else {
+                mergedSupports.append(remoteSupport)
+            }
+        }
+
+        // Add fallback device support that don't overlap with remote
+        for fallbackSupport in fallback {
+            if !fallbackSupport.identifiers.contains(where: remoteIdentifiers.contains) {
+                mergedSupports.append(fallbackSupport)
+            }
+        }
+
+        return mergedSupports
+    }
+}
+
 // MARK: - Chunking
 
 public struct AudioChunk {
@@ -1346,4 +1454,143 @@ public enum Constants {
     public static let defaultLanguageCode: String = "en"
 
     public static let defaultAudioReadFrameSize: AVAudioFrameCount = 1_323_000 // 30s of audio at commonly found 44.1khz sample rate
+
+    public static let fallbackModelSupportConfig: ModelSupportConfig = {
+        var config = ModelSupportConfig(
+            repoName: "whisperkit-coreml",
+            repoVersion: "0.2",
+            deviceSupport: [
+                DeviceSupport(
+                    identifiers: ["iPhone11", "iPhone12", "Watch7", "Watch8"],
+                    models: ModelSupport(
+                        default: "openai_whisper-tiny",
+                        supported: [
+                            "openai_whisper-base",
+                            "openai_whisper-base.en",
+                            "openai_whisper-tiny",
+                            "openai_whisper-tiny.en"
+                        ]
+                    )
+                ),
+                DeviceSupport(
+                    identifiers: ["iPhone13", "iPad13,18", "iPad13,1"],
+                    models: ModelSupport(
+                        default: "openai_whisper-base",
+                        supported: [
+                            "openai_whisper-tiny",
+                            "openai_whisper-tiny.en",
+                            "openai_whisper-base",
+                            "openai_whisper-base.en",
+                            "openai_whisper-small",
+                            "openai_whisper-small.en"
+                        ]
+                    )
+                ),
+                DeviceSupport(
+                    identifiers: ["iPhone14", "iPhone15", "iPhone16", "iPhone17", "iPad14,1", "iPad14,2"],
+                    models: ModelSupport(
+                        default: "openai_whisper-base",
+                        supported: [
+                            "openai_whisper-tiny",
+                            "openai_whisper-tiny.en",
+                            "openai_whisper-base",
+                            "openai_whisper-base.en",
+                            "openai_whisper-small",
+                            "openai_whisper-small.en",
+                            "openai_whisper-large-v2_949MB",
+                            "openai_whisper-large-v2_turbo_955MB",
+                            "openai_whisper-large-v3_947MB",
+                            "openai_whisper-large-v3_turbo_954MB",
+                            "distil-whisper_distil-large-v3_594MB",
+                            "distil-whisper_distil-large-v3_turbo_600MB",
+                            "openai_whisper-large-v3-v20240930_626MB",
+                            "openai_whisper-large-v3-v20240930_turbo_632MB",
+                        ]
+                    )
+                ),
+                DeviceSupport(
+                    identifiers: [
+                        "Mac13",
+                        "iMac21",
+                        "MacBookAir10,1",
+                        "MacBookPro17",
+                        "MacBookPro18",
+                        "Macmini9",
+                        "iPad13,16",
+                        "iPad13,4",
+                        "iPad13,8"
+                    ],
+                    models: ModelSupport(
+                        default: "openai_whisper-large-v3-v20240930",
+                        supported: [
+                            "openai_whisper-tiny",
+                            "openai_whisper-tiny.en",
+                            "openai_whisper-base",
+                            "openai_whisper-base.en",
+                            "openai_whisper-small",
+                            "openai_whisper-small.en",
+                            "openai_whisper-large-v2",
+                            "openai_whisper-large-v2_949MB",
+                            "openai_whisper-large-v3",
+                            "openai_whisper-large-v3_947MB",
+                            "distil-whisper_distil-large-v3",
+                            "distil-whisper_distil-large-v3_594MB",
+                            "openai_whisper-large-v3-v20240930",
+                            "openai_whisper-large-v3-v20240930_626MB",
+                        ]
+                    )
+                ),
+                DeviceSupport(
+                    identifiers: [
+                        "Mac14",
+                        "Mac15",
+                        "Mac16",
+                        "iPad14,3",
+                        "iPad14,4",
+                        "iPad14,5",
+                        "iPad14,6",
+                        "iPad14,8",
+                        "iPad14,9",
+                        "iPad14,10",
+                        "iPad14,11",
+                        "iPad16"
+                    ],
+                    models: ModelSupport(
+                        default: "openai_whisper-large-v3-v20240930",
+                        supported: [
+                            "openai_whisper-tiny",
+                            "openai_whisper-tiny.en",
+                            "openai_whisper-base",
+                            "openai_whisper-base.en",
+                            "openai_whisper-small",
+                            "openai_whisper-small.en",
+                            "openai_whisper-large-v2",
+                            "openai_whisper-large-v2_949MB",
+                            "openai_whisper-large-v2_turbo",
+                            "openai_whisper-large-v2_turbo_955MB",
+                            "openai_whisper-large-v3",
+                            "openai_whisper-large-v3_947MB",
+                            "openai_whisper-large-v3_turbo",
+                            "openai_whisper-large-v3_turbo_954MB",
+                            "distil-whisper_distil-large-v3",
+                            "distil-whisper_distil-large-v3_594MB",
+                            "distil-whisper_distil-large-v3_turbo",
+                            "distil-whisper_distil-large-v3_turbo_600MB",
+                            "openai_whisper-large-v3-v20240930",
+                            "openai_whisper-large-v3-v20240930_turbo",
+                            "openai_whisper-large-v3-v20240930_626MB",
+                            "openai_whisper-large-v3-v20240930_turbo_632MB",
+                        ]
+                    )
+                )
+            ],
+            includeFallback: false
+        )
+
+        return config
+    }()
+
+    public static let knownModels: [String] = {
+        fallbackModelSupportConfig.deviceSupport.flatMap { $0.models.supported }.orderedSet
+    }()
 }

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -460,7 +460,7 @@ public func detectModelURL(inFolder path: URL, named modelName: String) -> URL {
 
     // Swap to mlpackage only if the following is true: we found the mlmodel within the mlpackage, and we did not find a .mlmodelc
     var modelURL = compiledUrl
-    if (packageModelExists && !compiledModelExists) {
+    if packageModelExists && !compiledModelExists {
         modelURL = packageUrl
     }
 

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -134,32 +134,10 @@ open class WhisperKit {
         return deviceName
     }
 
-    public static func recommendedModels(fromRemote remote: Bool = false, timeout: TimeInterval = 1.0) -> ModelSupport {
+    public static func recommendedModels() -> ModelSupport {
         let deviceName = Self.deviceName()
         Logging.debug("Running on \(deviceName)")
-        if remote {
-            var support: ModelSupport?
-            let group = DispatchGroup()
-            group.enter()
-
-            Task {
-                let modelSupport = await Self.recommendedRemoteModels()
-                support = modelSupport
-                group.leave()
-            }
-
-            // Wait for the task to complete or timeout
-            let timeoutResult = group.wait(timeout: .now() + timeout)
-            if timeoutResult == .timedOut {
-                Logging.debug("Fetching model support timed out after \(timeout) second(s)")
-                return modelSupport(for: deviceName)
-            } else {
-                return support ?? modelSupport(for: deviceName)
-            }
-        } else {
-            // Use fallback model support
-            return modelSupport(for: deviceName)
-        }
+        return modelSupport(for: deviceName)
     }
 
     public static func recommendedRemoteModels(from repo: String = "argmaxinc/whisperkit-coreml") async -> ModelSupport {

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -113,12 +113,11 @@ open class WhisperKit {
             load: load,
             download: download,
             useBackgroundDownloadSession: useBackgroundDownloadSession
-            )
+        )
         try await self.init(config)
     }
 
     // MARK: - Model Loading
-
 
     public static func deviceName() -> String {
         #if !os(macOS) && !targetEnvironment(simulator)
@@ -795,14 +794,14 @@ open class WhisperKit {
         let isChunkable = audioArray.count > WhisperKit.windowSamples
         switch (isChunkable, decodeOptions?.chunkingStrategy) {
             case (true, .vad):
-            // We have some audio that will require multiple windows and a strategy to chunk them
-            let vad = decodeOptions?.voiceActivityDetector ?? EnergyVAD()
-            let chunker = VADAudioChunker(vad: vad)
-            let audioChunks: [AudioChunk] = try await chunker.chunkAll(
-                audioArray: audioArray,
-                maxChunkLength: WhisperKit.windowSamples,
-                decodeOptions: decodeOptions
-            )
+                // We have some audio that will require multiple windows and a strategy to chunk them
+                let vad = decodeOptions?.voiceActivityDetector ?? EnergyVAD()
+                let chunker = VADAudioChunker(vad: vad)
+                let audioChunks: [AudioChunk] = try await chunker.chunkAll(
+                    audioArray: audioArray,
+                    maxChunkLength: WhisperKit.windowSamples,
+                    decodeOptions: decodeOptions
+                )
 
                 // Reset the seek times since we've already chunked the audio
                 var chunkedOptions = decodeOptions

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -141,17 +141,18 @@ open class WhisperKit {
             var support: ModelSupport?
             let semaphore = DispatchSemaphore(value: 0)
 
-            // Start the asynchronous task
             Task {
                 let modelSupport = await Self.recommendedRemoteModels()
-                support = modelSupport
-                semaphore.signal()
+                await MainActor.run {
+                    support = modelSupport
+                    semaphore.signal()
+                }
             }
 
             // Wait for the task to complete or timeout
             let timeoutResult = semaphore.wait(timeout: .now() + timeout)
             if timeoutResult == .timedOut {
-                Logging.error("Fetching model support timed out after \(timeout) second(s)")
+                Logging.debug("Fetching model support timed out after \(timeout) second(s)")
                 return modelSupport(for: deviceName)
             } else {
                 return support ?? modelSupport(for: deviceName)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -139,18 +139,17 @@ open class WhisperKit {
         Logging.debug("Running on \(deviceName)")
         if remote {
             var support: ModelSupport?
-            let semaphore = DispatchSemaphore(value: 0)
+            let group = DispatchGroup()
+            group.enter()
 
             Task {
                 let modelSupport = await Self.recommendedRemoteModels()
-                await MainActor.run {
-                    support = modelSupport
-                    semaphore.signal()
-                }
+                support = modelSupport
+                group.leave()
             }
 
             // Wait for the task to complete or timeout
-            let timeoutResult = semaphore.wait(timeout: .now() + timeout)
+            let timeoutResult = group.wait(timeout: .now() + timeout)
             if timeoutResult == .timedOut {
                 Logging.debug("Fetching model support timed out after \(timeout) second(s)")
                 return modelSupport(for: deviceName)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -158,7 +158,7 @@ open class WhisperKit {
             modelSupportConfig = try decoder.decode(ModelSupportConfig.self, from: jsonData)
         } catch {
             // Allow this to fail gracefully as it uses fallback config by default
-            Logging.debug(error)
+            Logging.error(error)
         }
 
         return modelSupportConfig

--- a/Tests/WhisperKitTests/RegressionTests.swift
+++ b/Tests/WhisperKitTests/RegressionTests.swift
@@ -149,7 +149,7 @@ final class RegressionTests: XCTestCase {
         let iso8601DateTimeString = ISO8601DateFormatter().string(from: Date())
 
         #if os(macOS) && arch(arm64)
-        currentDevice = Process.processor
+        currentDevice = ProcessInfo.processor
         #endif
 
         do {

--- a/Tests/WhisperKitTests/Resources/config.json
+++ b/Tests/WhisperKitTests/Resources/config.json
@@ -1,0 +1,136 @@
+{
+    "name": "whisperkit-coreml",
+    "version": "0.2",
+    "device_support": [
+        {
+            "identifiers": ["iPhone11", "iPhone12", "Watch7", "Watch8"],
+            "models": {
+                "default": "openai_whisper-tiny",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en"
+                ]
+            }
+        },
+        {
+            "identifiers": ["iPhone13", "iPad13,18", "iPad13,1"],
+            "models": {
+                "default": "openai_whisper-base",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en"
+                ]
+            }
+        },
+        {
+            "identifiers": [
+                "iPhone14",
+                "iPhone15",
+                "iPhone16",
+                "iPhone17",
+                "iPad14,1",
+                "iPad14,2"
+            ],
+            "models": {
+                "default": "openai_whisper-base",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v2_turbo_955MB",
+                    "openai_whisper-large-v3_947MB",
+                    "openai_whisper-large-v3_turbo_954MB",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "distil-whisper_distil-large-v3_turbo_600MB",
+                    "openai_whisper-large-v3-v20240930_626MB",
+                    "openai_whisper-large-v3-v20240930_turbo_632MB"
+                ]
+            }
+        },
+        {
+            "identifiers": [
+                "Mac13",
+                "iMac21",
+                "MacBookAir10,1",
+                "MacBookPro17",
+                "MacBookPro18",
+                "Macmini9",
+                "iPad13,16",
+                "iPad13,4",
+                "iPad13,8"
+            ],
+            "models": {
+                "default": "openai_whisper-large-v3-v20240930",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v3",
+                    "openai_whisper-large-v3_947MB",
+                    "distil-whisper_distil-large-v3",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "openai_whisper-large-v3-v20240930",
+                    "openai_whisper-large-v3-v20240930_626MB"
+                ]
+            }
+        },
+        {
+            "identifiers": [
+                "Mac14",
+                "Mac15",
+                "Mac16",
+                "iPad14,3",
+                "iPad14,4",
+                "iPad14,5",
+                "iPad14,6",
+                "iPad14,8",
+                "iPad14,9",
+                "iPad14,10",
+                "iPad14,11",
+                "iPad16"
+            ],
+            "models": {
+                "default": "openai_whisper-large-v3-v20240930",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v2_turbo",
+                    "openai_whisper-large-v2_turbo_955MB",
+                    "openai_whisper-large-v3",
+                    "openai_whisper-large-v3_947MB",
+                    "openai_whisper-large-v3_turbo",
+                    "openai_whisper-large-v3_turbo_954MB",
+                    "distil-whisper_distil-large-v3",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "distil-whisper_distil-large-v3_turbo",
+                    "distil-whisper_distil-large-v3_turbo_600MB",
+                    "openai_whisper-large-v3-v20240930",
+                    "openai_whisper-large-v3-v20240930_turbo",
+                    "openai_whisper-large-v3-v20240930_626MB",
+                    "openai_whisper-large-v3-v20240930_turbo_632MB"
+                ]
+            }
+        }
+    ]
+}

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -175,31 +175,15 @@ final class UnitTests: XCTestCase {
 
     func testRecommendedModels() async {
         let asyncRemoteModels = await WhisperKit.recommendedRemoteModels()
-        let syncRemoteModels = WhisperKit.recommendedModels(fromRemote: true)
-        let remoteModelsWithTimeout = WhisperKit.recommendedModels(fromRemote: true, timeout: 0.0001)
         let defaultModels = WhisperKit.recommendedModels()
 
-        // Async and sync remote models should be equal
-        XCTAssertEqual(asyncRemoteModels, syncRemoteModels, "Async and sync remote models should be equal")
-
-        // Models with timeout should fall back to default models
-        XCTAssertNotEqual(syncRemoteModels, remoteModelsWithTimeout, "Models with timeout should fall back to default models")
+        // Remote models should not be nil or empty
+        XCTAssertNotNil(asyncRemoteModels, "Remote models should not be nil")
+        XCTAssertFalse(asyncRemoteModels.default.isEmpty, "Remote model name should not be empty")
 
         // Default models should not be nil or empty
         XCTAssertNotNil(defaultModels, "Default models should not be nil")
         XCTAssertFalse(defaultModels.default.isEmpty, "Default model name should not be empty")
-    }
-
-    func testDeviceName() {
-        let deviceName = WhisperKit.deviceName()
-        XCTAssertFalse(deviceName.isEmpty, "Device name should not be empty")
-        XCTAssertTrue(deviceName.contains(","), "Device name should contain a comma, found \(deviceName)")
-    }
-
-    func testOrderedSet() {
-        let testArray = ["model1", "model2", "model1", "model3", "model2"]
-        let uniqueArray = testArray.orderedSet
-        XCTAssertEqual(uniqueArray, ["model1", "model2", "model3"], "Ordered set should contain unique elements in order")
     }
 
     // MARK: - Audio Tests
@@ -1119,6 +1103,18 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual("<|end<|of|>text|>".trimmingSpecialTokenCharacters(), "end<|of|>text")
         XCTAssertEqual("<|endoftext".trimmingSpecialTokenCharacters(), "endoftext")
         XCTAssertEqual("endoftext|>".trimmingSpecialTokenCharacters(), "endoftext")
+    }
+
+    func testDeviceName() {
+        let deviceName = WhisperKit.deviceName()
+        XCTAssertFalse(deviceName.isEmpty, "Device name should not be empty")
+        XCTAssertTrue(deviceName.contains(","), "Device name should contain a comma, found \(deviceName)")
+    }
+
+    func testOrderedSet() {
+        let testArray = ["model1", "model2", "model1", "model3", "model2"]
+        let uniqueArray = testArray.orderedSet
+        XCTAssertEqual(uniqueArray, ["model1", "model2", "model3"], "Ordered set should contain unique elements in order")
     }
 
     // MARK: - LogitsFilter Tests

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -154,7 +154,7 @@ final class UnitTests: XCTestCase {
         }
     }
 
-    func testModelSupportConfigFetch () async throws {
+    func testModelSupportConfigFetch() async throws {
         // Make sure remote repo config loads successfully from HF
         let modelRepoConfig = await WhisperKit.fetchModelSupportConfig()
 


### PR DESCRIPTION
This PR adds capability to fetch supported models for a specific device based on the [config.json](https://huggingface.co/argmaxinc/whisperkit-coreml/blob/main/config.json) file in the model repo on HF. Config will update over time as new models and devices come out. Need for this arose with the latest whisper turbo model release.

Changes:
- Adds asynchronous `WhisperKit.recommendedRemoteModels()` to fetch the config.json file and return a `ModelSupport` object
- ~New optional parameters for synchronous `WhisperKit.recommendedModels()` function to try to fetch the remote config, and a timeout for the request~ This proved difficult to conform to swift concurrency as a static function for macOS 14.6 and below, so removed for now.
- Adds `Constants.fallbackModelSupportConfig` for when remote config is unavailable in offline environments
- Various supporting functions and models
- Updates `WhisperKit.deviceName()` to use a similar device identifier for mac as it does for iOS etc
