### PR TITLE
Fix progress for vad

### DIFF
--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -784,6 +784,8 @@ open class WhisperKit {
                     decodeOptions: decodeOptions
                 )
 
+                progress.totalUnitCount = max(progress.totalUnitCount, Int64(audioChunks.count))
+
                 // Reset the seek times since we've already chunked the audio
                 var chunkedOptions = decodeOptions
                 chunkedOptions?.clipTimestamps = []
@@ -844,7 +846,8 @@ open class WhisperKit {
             try Task.checkCancellation()
 
             let childProgress = Progress()
-            progress.totalUnitCount += 1
+            // Total can be set elsewhere, here ensures it is at least 1
+            progress.totalUnitCount = max(1, progress.totalUnitCount)
             progress.addChild(childProgress, withPendingUnitCount: 1)
 
             let transcribeTask = TranscribeTask(


### PR DESCRIPTION
This PR will fix progress tracking for total VAD windows in cases where concurrent workers are less than the total audioChunks of the input audio. Previously it would reset the progress to 0 for each batch of audio where there were more audioChunks than could be fully distributed among the available workers.