### PR TITLE
Update xcconfig tracking and provisioning

### DIFF
--- a/Examples/WhisperAX/Debug.xcconfig
+++ b/Examples/WhisperAX/Debug.xcconfig
@@ -1,8 +1,0 @@
-//  For licensing see accompanying LICENSE.md file.
-//  Copyright © 2024 Argmax, Inc. All rights reserved.
-
-// Configuration settings file format documentation can be found at:
-// https://help.apple.com/xcode/#/dev745c5c974
-
-CODE_SIGN_STYLE=Automatic
-DEVELOPMENT_TEAM=

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ setup:
 
 generate-whisperax-xcconfig:
 	@echo "Updating DEVELOPMENT_TEAM in Examples/WhisperAX/Debug.xcconfig..."
-	@TEAM_ID=$$(defaults read com.apple.dt.Xcode IDEProvisioningTeamManagerLastSelectedTeamID 2>/dev/null); \
+	@TEAM_ID=$$(defaults read com.apple.dt.Xcode IDEProvisioningTeams | plutil -convert json -r -o - -- - | jq -r  'to_entries[0].value | sort_by(.teamType == "Individual") | .[0].teamID' 2>/dev/null); \
 	if [ -z "$$TEAM_ID" ]; then \
 		echo "Error: No Development Team ID found. Please log into Xcode with your Apple ID and select a team."; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ list-devices:
 #	make benchmark-devices DEVICES="iPhone 15 Pro Max,My Mac"	# Benchmark specific device names from `make list-devices`
 DEVICES ?=
 DEBUG ?= false
-benchmark-devices:
+benchmark-devices: generate-whisperax-xcconfig
 	@if [ -n "$(DEVICES)" ]; then \
 		echo "Benchmarking specific devices: $(DEVICES)"; \
 		fastlane benchmark devices:"$(DEVICES)" debug:$(DEBUG); \

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,7 @@ generate-whisperax-xcconfig:
 	if [ -z "$$TEAM_ID" ]; then \
 		echo "Error: No Development Team ID found. Please log into Xcode with your Apple ID and select a team."; \
 	else \
-		if grep -q '^DEVELOPMENT_TEAM' Examples/WhisperAX/Debug.xcconfig; then \
-			sed -i '' "s/^\(DEVELOPMENT_TEAM *= *\).*/\1$$TEAM_ID/" Examples/WhisperAX/Debug.xcconfig; \
-		else \
-			echo "DEVELOPMENT_TEAM=$$TEAM_ID" >> Examples/WhisperAX/Debug.xcconfig; \
-		fi; \
+		echo "DEVELOPMENT_TEAM=$$TEAM_ID" >> Examples/WhisperAX/Debug.xcconfig; \
 		echo "DEVELOPMENT_TEAM has been updated in Examples/WhisperAX/Debug.xcconfig with your Development Team ID: $$TEAM_ID"; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ generate-whisperax-xcconfig:
 	if [ -z "$$TEAM_ID" ]; then \
 		echo "Error: No Development Team ID found. Please log into Xcode with your Apple ID and select a team."; \
 	else \
-		echo "DEVELOPMENT_TEAM=$$TEAM_ID" >> Examples/WhisperAX/Debug.xcconfig; \
+		echo "DEVELOPMENT_TEAM=$$TEAM_ID" > Examples/WhisperAX/Debug.xcconfig; \
 		echo "DEVELOPMENT_TEAM has been updated in Examples/WhisperAX/Debug.xcconfig with your Development Team ID: $$TEAM_ID"; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Check out the demo app on [TestFlight](https://testflight.apple.com/join/LPVOyJZ
 - [Installation](#installation)
   - [Swift Package Manager](#swift-package-manager)
   - [Prerequisites](#prerequisites)
-  - [Steps](#steps)
+  - [Xcode Steps](#xcode-steps)
+  - [Package.swift](#packageswift)
   - [Homebrew](#homebrew)
 - [Getting Started](#getting-started)
   - [Quick Example](#quick-example)
@@ -52,13 +53,32 @@ WhisperKit can be integrated into your Swift project using the Swift Package Man
 - macOS 14.0 or later.
 - Xcode 15.0 or later.
 
-### Steps
+### Xcode Steps
 
 1. Open your Swift project in Xcode.
 2. Navigate to `File` > `Add Package Dependencies...`.
 3. Enter the package repository URL: `https://github.com/argmaxinc/whisperkit`.
 4. Choose the version range or specific version.
 5. Click `Finish` to add WhisperKit to your project.
+
+### Package.swift
+
+If you're using WhisperKit as part of a swift package, you can include it in your Package.swift dependencies as follows:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
+],
+```
+
+Then add `WhisperKit` as a dependency for your target:
+
+```swift
+.target(
+    name: "YourApp",
+    dependencies: ["WhisperKit"]
+),
+```
 
 ### Homebrew
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -358,7 +358,7 @@ def merge_all_summaries(summaries, devices, _config)
 
       unless result[:success]
         merged_data[:modelsTested] << model
-        merged_data[:failureInfo][model] = result[:error] || 'Test failed'
+        merged_data[:failureInfo][model] = result[:error] || "Test failed without error message, full output: #{result}"
       end
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,6 @@ require 'pathname'
 COMMIT_HASH = `git rev-parse --short HEAD`.strip
 COMMIT_TIMESTAMP = `git log -1 --format=%ct`.strip
 COMMIT_TIMESTAMP = Time.at(COMMIT_TIMESTAMP.to_i).utc.strftime('%Y-%m-%dT%H%M%S')
-XCODE_TEAM_ID = `defaults read com.apple.dt.Xcode IDEProvisioningTeams | plutil -convert json -r -o - -- - | jq -r  'to_entries[0].value | sort_by(.teamType == "Individual") | .[0].teamID'`.strip
 WORKING_DIR = Dir.pwd
 BASE_BENCHMARK_PATH = "#{WORKING_DIR}/benchmark_data".freeze
 BASE_UPLOAD_PATH = "#{WORKING_DIR}/upload_folder".freeze
@@ -196,13 +195,6 @@ def run_benchmarks(devices:, config:)
     end
   end
 
-  team_id = XCODE_TEAM_ID
-  if team_id.empty?
-    UI.user_error!('Development Team ID not found. Please log into Xcode with your Apple ID.')
-  else
-    UI.message("Using Development Team ID: #{team_id}")
-  end
-
   run_benchmark(devices, config)
 end
 
@@ -239,8 +231,7 @@ def run_benchmark(devices, config)
       xcargs = [
         "MODEL_NAME=#{model}",
         '-allowProvisioningUpdates',
-        '-allowProvisioningDeviceRegistration',
-        "DEVELOPMENT_TEAM=#{XCODE_TEAM_ID}"
+        '-allowProvisioningDeviceRegistration'
       ].join(' ')
 
       scan_result = scan(
@@ -256,9 +247,7 @@ def run_benchmark(devices, config)
         output_directory: XCRESULT_PATH,
         suppress_xcode_output: false,
         result_bundle: true,
-        # show_xcode_test_logs: true
         buildlog_path: XCRESULT_PATH,
-        # include_simulator_logs: true,
         output_style: 'raw',
         fail_build: false
       )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,7 @@ require 'pathname'
 COMMIT_HASH = `git rev-parse --short HEAD`.strip
 COMMIT_TIMESTAMP = `git log -1 --format=%ct`.strip
 COMMIT_TIMESTAMP = Time.at(COMMIT_TIMESTAMP.to_i).utc.strftime('%Y-%m-%dT%H%M%S')
-XCODE_TEAM_ID = `defaults read com.apple.dt.Xcode IDEProvisioningTeamManagerLastSelectedTeamID`.strip
+XCODE_TEAM_ID = `defaults read com.apple.dt.Xcode IDEProvisioningTeams | plutil -convert json -r -o - -- - | jq -r  'to_entries[0].value | sort_by(.teamType == "Individual") | .[0].teamID'`.strip
 WORKING_DIR = Dir.pwd
 BASE_BENCHMARK_PATH = "#{WORKING_DIR}/benchmark_data".freeze
 BASE_UPLOAD_PATH = "#{WORKING_DIR}/upload_folder".freeze
@@ -239,6 +239,7 @@ def run_benchmark(devices, config)
       xcargs = [
         "MODEL_NAME=#{model}",
         '-allowProvisioningUpdates',
+        '-allowProvisioningDeviceRegistration',
         "DEVELOPMENT_TEAM=#{XCODE_TEAM_ID}"
       ].join(' ')
 


### PR DESCRIPTION
- This will add xcconfig to gitignore so that it is no longer tracked when changed via `make setup`
- Adds a more reliable xcode default to find the provisioning team id, `IDEProvisioningTeams`, prioritizing a company type team id first.
- Allows devices to be registered automatically when running the benchmark script