### PR TITLE
Add public callbacks to help expose internal state a little more

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -629,7 +629,7 @@ public struct TranscriptionProgress {
     }
 }
 
-/// Callbacks to receive state updates during transcription.
+// Callbacks to receive state updates during transcription.
 
 /// A callback that provides transcription segments as they are discovered.
 /// - Parameters:

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -630,6 +630,7 @@ public struct TranscriptionProgress {
 }
 
 public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
+public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
 /// Callback to receive progress updates during transcription.
 ///
 /// - Parameters:

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -629,6 +629,7 @@ public struct TranscriptionProgress {
     }
 }
 
+public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
 /// Callback to receive progress updates during transcription.
 ///
 /// - Parameters:

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -629,16 +629,46 @@ public struct TranscriptionProgress {
     }
 }
 
-public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
-public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
-public typealias FractionCompletedCallback = ((Float) -> Void)
-public typealias TranscriptionPhaseCallback = ((TranscriptionPhase) -> Void)
+/// Callbacks to receive state updates during transcription.
 
-public enum TranscriptionPhase {
+/// A callback that provides transcription segments as they are discovered.
+/// - Parameters:
+///   - segments: An array of `TranscriptionSegment` objects representing the transcribed segments
+public typealias SegmentDiscoveryCallback = (_ segments: [TranscriptionSegment]) -> Void
+
+/// A callback that reports changes in the model's state.
+/// - Parameters:
+///   - oldState: The previous state of the model, if any
+///   - newState: The current state of the model
+public typealias ModelStateCallback = (_ oldState: ModelState?, _ newState: ModelState) -> Void
+
+/// A callback that reports changes in the transcription process.
+/// - Parameter state: The current `TranscriptionState` of the transcription process
+public typealias TranscriptionStateCallback = (_ state: TranscriptionState) -> Void
+
+/// Represents the different states of the transcription process.
+public enum TranscriptionState: CustomStringConvertible {
+    /// The audio is being converted to the required format for transcription
     case convertingAudio
+
+    /// The audio is actively being transcribed to text
     case transcribing
+
+    /// The transcription process has completed
     case finished
-} 
+
+    /// A human-readable description of the transcription state
+    public var description: String {
+        switch self {
+            case .convertingAudio:
+                return "Converting Audio"
+            case .transcribing:
+                return "Transcribing"
+            case .finished:
+                return "Finished"
+        }
+    }
+}
 
 /// Callback to receive progress updates during transcription.
 ///

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -632,6 +632,14 @@ public struct TranscriptionProgress {
 public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
 public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
 public typealias FractionCompletedCallback = ((Float) -> Void)
+public typealias TranscriptionPhaseCallback = ((TranscriptionPhase) -> Void)
+
+public enum TranscriptionPhase {
+    case convertingAudio
+    case transcribing
+    case finished
+} 
+
 /// Callback to receive progress updates during transcription.
 ///
 /// - Parameters:

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -631,6 +631,7 @@ public struct TranscriptionProgress {
 
 public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
 public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
+public typealias FractionCompletedCallback = ((Float) -> Void)
 /// Callback to receive progress updates during transcription.
 ///
 /// - Parameters:

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -16,6 +16,8 @@ final class TranscribeTask {
     private let tokenizer: any WhisperTokenizer
 
     public var segmentDiscoveryCallback: (([TranscriptionSegment]) -> Void)?
+    public var fractionCompletedCallback: ((Float) -> Void)?
+ 
     init(
         currentTimings: TranscriptionTimings,
         progress: Progress?,
@@ -115,6 +117,9 @@ final class TranscribeTask {
                 let timeOffsetEnd = Float(seek + segmentSize) / Float(WhisperKit.sampleRate)
                 Logging.debug("Decoding Seek: \(seek) (\(formatTimestamp(timeOffset))s)")
                 Logging.debug("Decoding Window Size: \(segmentSize) (\(formatTimestamp(timeOffsetEnd - timeOffset))s)")
+
+                let totalLength = Float(seekClipEnd)/Float(WhisperKit.sampleRate)
+                self.fractionCompletedCallback?(timeOffset / totalLength)
 
                 let audioProcessingStart = Date()
                 let clipAudioSamples = Array(audioArray[seek..<(seek + segmentSize)])

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -15,9 +15,8 @@ final class TranscribeTask {
     private let textDecoder: any TextDecoding
     private let tokenizer: any WhisperTokenizer
 
-    public var segmentDiscoveryCallback: (([TranscriptionSegment]) -> Void)?
-    public var fractionCompletedCallback: ((Float) -> Void)?
- 
+    public var segmentDiscoveryCallback: SegmentDiscoveryCallback?
+
     init(
         currentTimings: TranscriptionTimings,
         progress: Progress?,
@@ -117,9 +116,6 @@ final class TranscribeTask {
                 let timeOffsetEnd = Float(seek + segmentSize) / Float(WhisperKit.sampleRate)
                 Logging.debug("Decoding Seek: \(seek) (\(formatTimestamp(timeOffset))s)")
                 Logging.debug("Decoding Window Size: \(segmentSize) (\(formatTimestamp(timeOffsetEnd - timeOffset))s)")
-
-                let totalLength = Float(seekClipEnd)/Float(WhisperKit.sampleRate)
-                self.fractionCompletedCallback?(timeOffset / totalLength)
 
                 let audioProcessingStart = Date()
                 let clipAudioSamples = Array(audioArray[seek..<(seek + segmentSize)])

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -15,6 +15,7 @@ final class TranscribeTask {
     private let textDecoder: any TextDecoding
     private let tokenizer: any WhisperTokenizer
 
+    public var segmentDiscoveryCallback: (([TranscriptionSegment]) -> Void)?
     init(
         currentTimings: TranscriptionTimings,
         progress: Progress?,
@@ -229,6 +230,8 @@ final class TranscribeTask {
                         Logging.debug(line)
                     }
                 }
+
+                segmentDiscoveryCallback?(currentSegments)
 
                 // add them to the `allSegments` list
                 allSegments.append(contentsOf: currentSegments)

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -104,8 +104,7 @@ open class WhisperKit {
         prewarm: Bool? = nil,
         load: Bool? = nil,
         download: Bool = true,
-        useBackgroundDownloadSession: Bool = false,
-        modelStateDidChangeCallback: ModelStateCallback? = nil
+        useBackgroundDownloadSession: Bool = false
     ) async throws {
         let config = WhisperKitConfig(
             model: model,

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -48,6 +48,7 @@ open class WhisperKit {
 
     /// Callbacks
     public var segmentDiscoveryCallback: SegmentDiscoveryCallback?
+    public var fractionCompletedCallback: FractionCompletedCallback?
     public var modelStateCallback: ModelStateCallback?
 
     public init(_ config: WhisperKitConfig = WhisperKitConfig(), modelStateDidChangeCallback: ModelStateCallback? = nil) async throws {
@@ -884,6 +885,7 @@ open class WhisperKit {
             )
 
             transcribeTask.segmentDiscoveryCallback = self.segmentDiscoveryCallback
+            transcribeTask.fractionCompletedCallback = self.fractionCompletedCallback
 
             let transcribeTaskResult = try await transcribeTask.run(
                 audioArray: audioArray,

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -42,6 +42,8 @@ open class WhisperKit {
     public var tokenizerFolder: URL?
     public private(set) var useBackgroundDownloadSession: Bool
 
+    /// Callbacks
+    public var segmentDiscoveryCallback: SegmentDiscoveryCallback?
     public init(_ config: WhisperKitConfig = WhisperKitConfig()) async throws {
         modelCompute = config.computeOptions ?? ModelComputeOptions()
         audioProcessor = config.audioProcessor ?? AudioProcessor()
@@ -871,6 +873,8 @@ open class WhisperKit {
                 textDecoder: textDecoder,
                 tokenizer: tokenizer
             )
+
+            transcribeTask.segmentDiscoveryCallback = self.segmentDiscoveryCallback
 
             let transcribeTaskResult = try await transcribeTask.run(
                 audioArray: audioArray,


### PR DESCRIPTION
I've been using these four extra callbacks to help me keep track of WK internal state more easily:

```swift
public typealias SegmentDiscoveryCallback = (([TranscriptionSegment]) -> Void)
public typealias ModelStateCallback = ((ModelState?, ModelState) -> Void)
public typealias FractionCompletedCallback = ((Float) -> Void)
public typealias TranscriptionPhaseCallback = ((TranscriptionPhase) -> Void)

public enum TranscriptionPhase {
    case convertingAudio
    case transcribing
    case finished
} 
```

I just wanted to share in case they'd be useful for others. Happy to remove any that shouldn't be pulled in, or to rename them or whatever!