### PR TITLE
Freeze loglevel enum

### DIFF
--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -762,12 +762,12 @@ public func getMemoryUsage() -> UInt64 {
 
 // MARK: - Singletons
 
-public class Logging {
-    static let shared = Logging()
-    var logLevel: LogLevel = .none
+open class Logging {
+    public static let shared = Logging()
+    public var logLevel: LogLevel = .none
 
     public typealias LoggingCallback = (_ message: String) -> Void
-    var loggingCallback: LoggingCallback?
+    public var loggingCallback: LoggingCallback?
 
     private let logger = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.argmax.whisperkit", category: "WhisperKit")
 

--- a/Sources/WhisperKit/Core/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils.swift
@@ -771,6 +771,7 @@ public class Logging {
 
     private let logger = OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.argmax.whisperkit", category: "WhisperKit")
 
+    @frozen
     public enum LogLevel: Int {
         case debug = 1
         case info = 2


### PR DESCRIPTION
This resolves an issue where the LogLevel enum was not accessible in some contexts by using `@frozen`.