### PR TITLE
Typo in Model Descriptions

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -127,7 +127,7 @@ public enum ModelState: CustomStringConvertible {
             case .downloading:
                 return "Downloading"
             case .downloaded:
-                return "Downloading"
+                return "Downloaded"
         }
     }
 }


### PR DESCRIPTION
It should be "Downloaded" for .downloaded, not "Downloading"