### PR TITLE
Audio: Fix taking a suffix of negative length from a collection

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -469,7 +469,7 @@ public class AudioProcessor: NSObject, AudioProcessing {
     ) -> Bool {
         // Calculate the number of energy values to consider based on the duration of the next buffer
         // Each energy value corresponds to 1 buffer length (100ms of audio), hence we divide by 0.1
-        let energyValuesToConsider = Int(nextBufferInSeconds / 0.1)
+        let energyValuesToConsider = max(0, Int(nextBufferInSeconds / 0.1))
 
         // Extract the relevant portion of energy values from the currentRelativeEnergy array
         let nextBufferEnergies = relativeEnergy.suffix(energyValuesToConsider)


### PR DESCRIPTION
# Overview
This pull request introduces critical bug fix to `AudioProcessor`, focusing on improving robustness and error handling in voice detection mechanisms

### Problem
In the original code, when calculating the number of energy values to consider for voice detection, there was a risk of creating a negative array index. 

This could happen if:
	•	The nextBufferInSeconds was very small
	•	The calculation resulted in a negative number

This would cause a runtime crash with the error: 
```Fatal error: Can't take a suffix of negative length from a collection```

![CleanShot 2024-12-16 at 20 07 46@2x](https://github.com/user-attachments/assets/633afca6-4714-42ce-97b8-b34747ec338c)

### Solution
Prevent negative array indices