### PR TITLE
Allow protocol defined types for model inputs and outputs

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -2,7 +2,6 @@ name: Development Tests
 
 on:
   pull_request:
-    branches: ["main"]
   pull_request_review:
     types: [submitted]
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,8 +75,19 @@ jobs:
           sleep 15
           xcrun simctl list devices
       - name: Build and Test - ${{ matrix.run-config['name'] }}
+        id: test-step
         if: ${{ matrix.run-config['condition'] == true }}
+        continue-on-error: true
         run: |
           set -o pipefail
           xcodebuild clean build-for-testing -scheme whisperkit-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcpretty
           xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination '${{ matrix.run-config['test-destination'] }}'
+
+      - name: Upload Test Results
+        if: failure() && steps.test-step.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.run-config['name'] }}
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
+          retention-days: 5

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -178,7 +178,6 @@ public class AudioProcessor: NSObject, AudioProcessing {
     }
 
     public var audioBufferCallback: (([Float]) -> Void)?
-    public var maxBufferLength = WhisperKit.sampleRate * WhisperKit.chunkLength // 30 seconds of audio at 16,000 Hz
     public var minBufferLength = Int(Double(WhisperKit.sampleRate) * 0.1) // 0.1 second of audio at 16,000 Hz
 
     // MARK: - Loading and conversion

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -93,7 +93,7 @@ public extension AudioProcessing {
     }
 
     static func padOrTrimAudio(fromArray audioArray: [Float], startAt startIndex: Int = 0, toLength frameLength: Int = 480_000, saveSegment: Bool = false) -> MLMultiArray? {
-        guard startIndex >= 0 && startIndex < audioArray.count else {
+        guard startIndex >= 0, startIndex < audioArray.count else {
             Logging.error("startIndex is outside the buffer size")
             return nil
         }
@@ -228,7 +228,11 @@ public class AudioProcessor: NSObject, AudioProcessing {
             guard let buffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: frameCount) else {
                 throw WhisperError.loadAudioFailed("Unable to create audio buffer")
             }
-            try audioFile.read(into: buffer, frameCount: frameCount)
+            do {
+                try audioFile.read(into: buffer, frameCount: frameCount)
+            } catch {
+                throw WhisperError.loadAudioFailed("Failed to read audio file: \(error)")
+            }
             outputBuffer = buffer
         } else {
             // Audio needs resampling to 16khz

--- a/Sources/WhisperKit/Core/Audio/VoiceActivityDetector.swift
+++ b/Sources/WhisperKit/Core/Audio/VoiceActivityDetector.swift
@@ -117,7 +117,7 @@ open class VoiceActivityDetector {
         }
     }
 
-    // MARK - Utility
+    // MARK: - Utility
 
     func voiceActivityClipTimestamps(in waveform: [Float]) -> [Float] {
         let nonSilentChunks = calculateActiveChunks(in: waveform)

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -7,10 +7,15 @@ import CoreGraphics
 import CoreML
 import Foundation
 
+public protocol FeatureExtractorOutputType {}
+extension MLMultiArray: FeatureExtractorOutputType {}
+
 public protocol FeatureExtracting {
+    associatedtype OutputType: FeatureExtractorOutputType
+
     var melCount: Int? { get }
     var windowSamples: Int? { get }
-    func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> MLMultiArray?
+    func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> OutputType?
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)

--- a/Sources/WhisperKit/Core/FeatureExtractor.swift
+++ b/Sources/WhisperKit/Core/FeatureExtractor.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public protocol FeatureExtracting {
     var melCount: Int? { get }
+    var windowSamples: Int? { get }
     func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> MLMultiArray?
 }
 
@@ -26,6 +27,14 @@ open class FeatureExtractor: FeatureExtracting, WhisperMLModel {
         return shape[1]
     }
 
+    public var windowSamples: Int? {
+        guard let inputDescription = model?.modelDescription.inputDescriptionsByName["audio"] else { return nil }
+        guard inputDescription.type == .multiArray else { return nil }
+        guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }
+        let shape = shapeConstraint.shape.map { $0.intValue }
+        return shape[0]  // The audio input is a 1D array
+    }
+
     public func logMelSpectrogram(fromAudio inputAudio: MLMultiArray) async throws -> MLMultiArray? {
         guard let model else {
             throw WhisperError.modelsUnavailable()
@@ -40,4 +49,5 @@ open class FeatureExtractor: FeatureExtracting, WhisperMLModel {
         let output = MelSpectrogramOutput(features: outputFeatures)
         return output.melspectrogramFeatures
     }
+
 }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -49,6 +49,7 @@ public extension WhisperMLModel {
 
 // MARK: - Whisper Models
 
+@frozen
 public enum ModelVariant: CustomStringConvertible, CaseIterable {
     case tiny
     case tinyEn
@@ -100,6 +101,7 @@ public enum ModelVariant: CustomStringConvertible, CaseIterable {
     }
 }
 
+@frozen
 public enum ModelState: CustomStringConvertible {
     case unloading
     case unloaded
@@ -282,6 +284,7 @@ public struct AudioChunk {
 
 // MARK: - Decoding
 
+@frozen
 public enum DecodingTask: Codable, CustomStringConvertible, CaseIterable {
     case transcribe
     case translate
@@ -355,6 +358,7 @@ public struct DecodingCache {
     }
 }
 
+@frozen
 public enum ChunkingStrategy: String, Codable, CaseIterable {
     case none
     case vad
@@ -444,6 +448,7 @@ public struct DecodingResult {
     }
 }
 
+@frozen
 public enum WhisperError: Error, LocalizedError, Equatable {
     case tokenizerUnavailable(String = "Tokenizer is unavailable")
     case modelsUnavailable(String = "Models are unavailable")
@@ -647,6 +652,7 @@ public typealias ModelStateCallback = (_ oldState: ModelState?, _ newState: Mode
 public typealias TranscriptionStateCallback = (_ state: TranscriptionState) -> Void
 
 /// Represents the different states of the transcription process.
+@frozen
 public enum TranscriptionState: CustomStringConvertible {
     /// The audio is being converted to the required format for transcription
     case convertingAudio
@@ -1372,6 +1378,7 @@ extension WhisperTokenizerWrapper {
 
 // MARK: Constants
 
+@frozen
 public enum Constants {
     enum Logging {
         static let subsystem = "com.argmax.whisperkit"

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -299,7 +299,7 @@ public enum DecodingTask: Codable, CustomStringConvertible, CaseIterable {
     }
 }
 
-public struct DecodingInputs {
+open class DecodingInputs {
     public var initialPrompt: [Int]
     public var inputIds: MLMultiArray
     public var cacheLength: MLMultiArray
@@ -580,6 +580,7 @@ public struct TranscriptionResult: Codable {
         Total Tokens:                  \(totalTokens)
         Tokens per Second:             \(String(format: "%.2f", tokensPerSecond)) tok/s
         Real Time Factor:              \(String(format: "%.3f", rtf))
+        Speed Factor:                  \(String(format: "%.3f", 1.0 / rtf))
         Fallbacks:                     \(timings.totalDecodingFallbacks)
         """)
     }

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -1509,6 +1509,8 @@ public enum Constants {
 
     public static let defaultAudioReadFrameSize: AVAudioFrameCount = 1_323_000 // 30s of audio at commonly found 44.1khz sample rate
 
+    public static let defaultWindowSamples: Int = 480_000 // 30s of audio at 16khz sample rate default for Whisper models
+
     public static let fallbackModelSupportConfig: ModelSupportConfig = {
         var config = ModelSupportConfig(
             repoName: "whisperkit-coreml-fallback",

--- a/Sources/WhisperKit/Core/Text/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/Text/LogitsFilter.swift
@@ -75,8 +75,9 @@ open class TimestampRulesFilter: LogitsFiltering {
 
     public func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray {
         guard let sampleBegin = sampleBegin(for: tokens),
-              sampleBegin > tokens.count
+              sampleBegin <= tokens.count
         else {
+            // Early return if we are still prefilling the prompt
             return logits
         }
 

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -109,17 +109,18 @@ final class TranscribeTask {
             let previousSeekProgress = progress.completedUnitCount
 
             let windowPadding = 16000 // prevent hallucinations at the end of the clip by stopping up to 1.0s early
+            let windowSamples = featureExtractor.windowSamples ?? Constants.defaultWindowSamples
             while seek < seekClipEnd - windowPadding {
                 // calculate new encoder segment features
                 let timeOffset = Float(seek) / Float(WhisperKit.sampleRate)
-                let segmentSize = min(WhisperKit.windowSamples, contentFrames - seek, seekClipEnd - seek)
+                let segmentSize = min(windowSamples, contentFrames - seek, seekClipEnd - seek)
                 let timeOffsetEnd = Float(seek + segmentSize) / Float(WhisperKit.sampleRate)
                 Logging.debug("Decoding Seek: \(seek) (\(formatTimestamp(timeOffset))s)")
                 Logging.debug("Decoding Window Size: \(segmentSize) (\(formatTimestamp(timeOffsetEnd - timeOffset))s)")
 
                 let audioProcessingStart = Date()
                 let clipAudioSamples = Array(audioArray[seek..<(seek + segmentSize)])
-                guard let audioSamples = AudioProcessor.padOrTrimAudio(fromArray: clipAudioSamples, startAt: 0, toLength: WhisperKit.windowSamples) else {
+                guard let audioSamples = AudioProcessor.padOrTrimAudio(fromArray: clipAudioSamples, startAt: 0, toLength: windowSamples) else {
                     throw WhisperError.transcriptionFailed("Audio samples are nil")
                 }
                 let processTime = Date().timeIntervalSince(audioProcessingStart)

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -261,7 +261,7 @@ final class TranscribeTask {
         // MARK: - Decode with Fallback Logic
 
         func decodeWithFallback(
-            encoderSegment encoderOutput: MLMultiArray,
+            encoderSegment encoderOutput: any AudioEncoderOutputType,
             decodingOptions options: DecodingOptions,
             callback: TranscriptionCallback = nil
         ) async throws -> DecodingResult {

--- a/Sources/WhisperKit/Core/Utils/Concurrency.swift
+++ b/Sources/WhisperKit/Core/Utils/Concurrency.swift
@@ -1,0 +1,34 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import Foundation
+
+/// An actor that provides thread-safe early stopping functionality using UUIDs as keys
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+public actor EarlyStopActor {
+    private var shouldStop = [UUID: Bool]()
+
+    public init() {}
+
+    /// Sets the stop flag for a given UUID
+    /// - Parameters:
+    ///   - value: The boolean value to set
+    ///   - uuid: The UUID key
+    public func set(_ value: Bool, for uuid: UUID) {
+        shouldStop[uuid] = value
+    }
+
+    /// Gets the stop flag for a given UUID
+    /// - Parameter uuid: The UUID key
+    /// - Returns: The current stop flag value, or false if not set
+    public func get(for uuid: UUID) -> Bool {
+        return shouldStop[uuid] ?? false
+    }
+
+    /// Removes and returns the stop flag for a given UUID
+    /// - Parameter uuid: The UUID key
+    /// - Returns: The removed stop flag value, if it existed
+    public func remove(for uuid: UUID) -> Bool? {
+        return shouldStop.removeValue(forKey: uuid)
+    }
+}

--- a/Sources/WhisperKit/Core/Utils/Utils.swift
+++ b/Sources/WhisperKit/Core/Utils/Utils.swift
@@ -109,6 +109,74 @@ extension MLMultiArray {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public extension MLTensor {
+    func asIntArray() -> [Int] {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: [Int] = []
+
+        Task(priority: .high) {
+            result = await self.shapedArray(of: Int32.self).scalars.map { Int($0) }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return result
+    }
+
+    func asFloatArray() -> [Float] {
+        let semaphore = DispatchSemaphore(value: 0)
+        let tensorType = self.scalarType
+
+        var result: [Float] = []
+
+        Task(priority: .high) {
+            switch tensorType {
+                case is Float32.Type:
+                    result = await self.shapedArray(of: Float32.self).scalars.map { Float($0) }
+                case is FloatType.Type:
+                    result = await self.shapedArray(of: FloatType.self).scalars.map { Float($0) }
+                case is Float.Type:
+                    result = await self.shapedArray(of: Float.self).scalars.map { Float($0) }
+                case is Int32.Type:
+                    result = await self.shapedArray(of: Int32.self).scalars.map { Float($0) }
+                default:
+                    fatalError("Unsupported data type")
+            }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return result
+    }
+
+    func asMLMultiArray() -> MLMultiArray {
+        let semaphore = DispatchSemaphore(value: 0)
+        let tensorType = self.scalarType
+
+        var result: MLMultiArray = initMLMultiArray(shape: [1], dataType: .float16, initialValue: 0.0)
+
+        Task(priority: .high) {
+            switch tensorType {
+                case is Float32.Type:
+                    result = MLMultiArray(await self.shapedArray(of: Float32.self))
+                case is FloatType.Type:
+                    result = MLMultiArray(await self.shapedArray(of: FloatType.self))
+                case is Float.Type:
+                    result = MLMultiArray(await self.shapedArray(of: Float.self))
+                case is Int32.Type:
+                    result = MLMultiArray(await self.shapedArray(of: Int32.self))
+                default:
+                    fatalError("Unsupported data type")
+            }
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return result
+    }
+}
+
 extension MLModel {
     func asyncPrediction(
         from input: MLFeatureProvider,

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -151,14 +151,22 @@ open class WhisperKit {
         return modelSupport(for: deviceName)
     }
 
-    public static func recommendedRemoteModels(from repo: String = "argmaxinc/whisperkit-coreml", downloadBase: URL? = nil) async -> ModelSupport {
+    public static func recommendedRemoteModels(
+        from repo: String = "argmaxinc/whisperkit-coreml",
+        downloadBase: URL? = nil,
+        token: String? = nil
+    ) async -> ModelSupport {
         let deviceName = Self.deviceName()
-        let config = await Self.fetchModelSupportConfig(from: repo, downloadBase: downloadBase)
+        let config = await Self.fetchModelSupportConfig(from: repo, downloadBase: downloadBase, token: token)
         return modelSupport(for: deviceName, from: config)
     }
 
-    public static func fetchModelSupportConfig(from repo: String = "argmaxinc/whisperkit-coreml", downloadBase: URL? = nil) async -> ModelSupportConfig {
-        let hubApi = HubApi(downloadBase: downloadBase)
+    public static func fetchModelSupportConfig(
+        from repo: String = "argmaxinc/whisperkit-coreml",
+        downloadBase: URL? = nil,
+        token: String? = nil
+    ) async -> ModelSupportConfig {
+        let hubApi = HubApi(downloadBase: downloadBase, hfToken: token)
         var modelSupportConfig = Constants.fallbackModelSupportConfig
 
         do {
@@ -175,8 +183,13 @@ open class WhisperKit {
         return modelSupportConfig
     }
 
-    public static func fetchAvailableModels(from repo: String = "argmaxinc/whisperkit-coreml", matching: [String] = ["*"], downloadBase: URL? = nil) async throws -> [String] {
-        let modelSupportConfig = await fetchModelSupportConfig(from: repo, downloadBase: downloadBase)
+    public static func fetchAvailableModels(
+        from repo: String = "argmaxinc/whisperkit-coreml",
+        matching: [String] = ["*"],
+        downloadBase: URL? = nil,
+        token: String? = nil
+    ) async throws -> [String] {
+        let modelSupportConfig = await fetchModelSupportConfig(from: repo, downloadBase: downloadBase, token: token)
         let supportedModels = modelSupportConfig.modelSupport().supported
         var filteredSupportSet: Set<String> = []
         for glob in matching {
@@ -228,9 +241,10 @@ open class WhisperKit {
         downloadBase: URL? = nil,
         useBackgroundSession: Bool = false,
         from repo: String = "argmaxinc/whisperkit-coreml",
+        token: String? = nil,
         progressCallback: ((Progress) -> Void)? = nil
     ) async throws -> URL {
-        let hubApi = HubApi(downloadBase: downloadBase, useBackgroundSession: useBackgroundSession)
+        let hubApi = HubApi(downloadBase: downloadBase, hfToken: token, useBackgroundSession: useBackgroundSession)
         let repo = Hub.Repo(id: repo, type: .models)
         let modelSearchPath = "*\(variant.description)/*"
         do {

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1420,6 +1420,8 @@ final class UnitTests: XCTestCase {
 
     func testVADAudioChunker() async throws {
         let chunker = VADAudioChunker()
+        // Setting windowSamples to default value as WhisperKit.windowSamples is not accessible in this scope
+        let windowSamples: Int = 480_000
 
         let singleChunkPath = try XCTUnwrap(
             Bundle.current.path(forResource: "jfk", ofType: "wav"),
@@ -1430,7 +1432,7 @@ final class UnitTests: XCTestCase {
 
         var audioChunks = try await chunker.chunkAll(
             audioArray: audioArray,
-            maxChunkLength: WhisperKit.windowSamples,
+            maxChunkLength: windowSamples,
             decodeOptions: DecodingOptions()
         )
 
@@ -1445,7 +1447,7 @@ final class UnitTests: XCTestCase {
 
         audioChunks = try await chunker.chunkAll(
             audioArray: audioArray,
-            maxChunkLength: WhisperKit.windowSamples,
+            maxChunkLength: windowSamples,
             decodeOptions: DecodingOptions()
         )
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -342,6 +342,202 @@ final class UnitTests: XCTestCase {
         XCTAssertGreaterThan(energyVeryLoud, energyLoud, "Audio energy is not very loud")
     }
 
+    // MARK: - Protocol Conformance Tests
+
+    func testMLMultiArrayConformsToFeatureExtractorOutputType() {
+        let array = try! MLMultiArray(shape: [1], dataType: .float16)
+        XCTAssertNotNil(array as FeatureExtractorOutputType)
+    }
+
+    func testMLMultiArrayConformsToAudioEncoderOutputType() {
+        let array = try! MLMultiArray(shape: [1], dataType: .float16)
+        XCTAssertNotNil(array as AudioEncoderOutputType)
+    }
+
+    func testMLMultiArrayConformsToTextDecoderTensorType() {
+        let array = try! MLMultiArray(shape: [1], dataType: .float16)
+        XCTAssertNotNil(array as TextDecoderTensorType)
+    }
+
+    // MARK: - Generic Type Tests
+
+    func testEncodeFeatureWithGenericType() async throws {
+        let audioEncoder = AudioEncoder()
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "AudioEncoder.mlmodelc")
+        try await audioEncoder.loadModel(at: modelPath, computeUnits: .cpuAndNeuralEngine)
+
+        // Create a test input that conforms to FeatureExtractorOutputType
+        let input = try MLMultiArray(shape: [1, 80, 1, 3000], dataType: .float16)
+
+        // Test encoding with generic type
+        let output = try await audioEncoder.encodeFeatures(input)
+
+        XCTAssertNotNil(output)
+        XCTAssertNotNil(output! as AudioEncoderOutputType)
+
+        // Test specific shape of output
+        if let mlOutput = output {
+            XCTAssertEqual(mlOutput.shape, [1, 384, 1, 1500])
+        } else {
+            XCTFail("Output should be MLMultiArray")
+        }
+    }
+
+    func testEncodeFeatureWithInvalidType() async throws {
+        let audioEncoder = AudioEncoder()
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "AudioEncoder.mlmodelc")
+        try await audioEncoder.loadModel(at: modelPath, computeUnits: .cpuAndNeuralEngine)
+
+        // Create an invalid input type
+        struct InvalidType: FeatureExtractorOutputType {}
+        let invalidInput = InvalidType()
+
+        // Test that encoding fails with invalid type
+        do {
+            _ = try await audioEncoder.encodeFeatures(invalidInput)
+            XCTFail("Should throw error for invalid input type")
+        } catch let WhisperError.audioProcessingFailed(message) {
+            XCTAssertEqual(message, "AudioEncoder input must be MLMultiArray")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - TextDecoder Generic Type Tests
+
+    func testPredictLogitsWithGenericType() async throws {
+        let textDecoder = TextDecoder()
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
+
+        // Create test inputs
+        let input = try TextDecoderMLMultiArrayInputType(
+            inputIds: MLMultiArray(shape: [1], dataType: .int32),
+            cacheLength: MLMultiArray(shape: [1], dataType: .int32),
+            keyCache: MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16),
+            valueCache: MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16),
+            kvCacheUpdateMask: MLMultiArray(shape: [1, 224], dataType: .float16),
+            encoderOutputEmbeds: MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16),
+            decoderKeyPaddingMask: MLMultiArray(shape: [1, 224], dataType: .float16)
+        )
+
+        // Test prediction with generic type
+        let output = try await textDecoder.predictLogits(input)
+
+        XCTAssertNotNil(output)
+        XCTAssertNotNil(output as? TextDecoderMLMultiArrayOutputType)
+    }
+
+    func testPredictLogitsWithInvalidType() async throws {
+        let textDecoder = TextDecoder()
+        let modelPath = try URL(filePath: tinyModelPath()).appending(path: "TextDecoder.mlmodelc")
+        try await textDecoder.loadModel(at: modelPath, computeUnits: ModelComputeOptions().textDecoderCompute)
+
+        // Create an invalid input type
+        struct InvalidType: TextDecoderInputType {}
+        let invalidInput = InvalidType()
+
+        // Test that prediction fails with invalid type
+        do {
+            _ = try await textDecoder.predictLogits(invalidInput)
+            XCTFail("Should throw error for invalid input type")
+        } catch let WhisperError.transcriptionFailed(message) {
+            XCTAssertEqual(message, "Input must be TextDecoderMLMultiArrayInputType")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testTextDecoderMLMultiArrayInputType() {
+        let inputIds = try! MLMultiArray(shape: [1], dataType: .int32)
+        let cacheLength = try! MLMultiArray(shape: [1], dataType: .int32)
+        let keyCache = try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16)
+        let valueCache = try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16)
+        let kvCacheUpdateMask = try! MLMultiArray(shape: [1, 224], dataType: .float16)
+        let encoderOutputEmbeds = try! MLMultiArray(shape: [1, 384, 1, 1500], dataType: .float16)
+        let decoderKeyPaddingMask = try! MLMultiArray(shape: [1, 224], dataType: .float16)
+        
+        let input = TextDecoderMLMultiArrayInputType(
+            inputIds: inputIds,
+            cacheLength: cacheLength,
+            keyCache: keyCache,
+            valueCache: valueCache,
+            kvCacheUpdateMask: kvCacheUpdateMask,
+            encoderOutputEmbeds: encoderOutputEmbeds,
+            decoderKeyPaddingMask: decoderKeyPaddingMask
+        )
+        
+        XCTAssertNotNil(input as TextDecoderInputType)
+        XCTAssertEqual(input.inputIds.shape, [1])
+        XCTAssertEqual(input.cacheLength.shape, [1])
+        XCTAssertEqual(input.keyCache.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(input.valueCache.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(input.kvCacheUpdateMask.shape, [1, 224])
+        XCTAssertEqual(input.encoderOutputEmbeds.shape, [1, 384, 1, 1500])
+        XCTAssertEqual(input.decoderKeyPaddingMask.shape, [1, 224])
+    }
+    
+    func testTextDecoderMLMultiArrayOutputType() {
+        let logits = try! MLMultiArray(shape: [1, 51865, 1, 1], dataType: .float16)
+        let cache = DecodingCache(
+            keyCache: try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16),
+            valueCache: try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16),
+            alignmentWeights: try! MLMultiArray(shape: [1, 224], dataType: .float16)
+        )
+        
+        let output = TextDecoderMLMultiArrayOutputType(logits: logits, cache: cache)
+        
+        XCTAssertNotNil(output as TextDecoderOutputType)
+        XCTAssertEqual(output.logits?.shape, [1, 51865, 1, 1])
+        XCTAssertNotNil(output.cache)
+        XCTAssertEqual(output.cache?.keyCache?.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(output.cache?.valueCache?.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(output.cache?.alignmentWeights?.shape, [1, 224])
+    }
+
+    func testTextDecoderMLMultiArrayOutputTypeWithNilValues() {
+        let output = TextDecoderMLMultiArrayOutputType()
+
+        XCTAssertNotNil(output as TextDecoderOutputType)
+        XCTAssertNil(output.logits)
+        XCTAssertNil(output.cache)
+    }
+    
+    func testDecodingCacheInitialization() {
+        let keyCache = try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16)
+        let valueCache = try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16)
+        let alignmentWeights = try! MLMultiArray(shape: [1, 224], dataType: .float16)
+        
+        let cache = DecodingCache(
+            keyCache: keyCache,
+            valueCache: valueCache,
+            alignmentWeights: alignmentWeights
+        )
+
+        XCTAssertEqual(cache.keyCache?.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(cache.valueCache?.shape, [1, 1536, 1, 224])
+        XCTAssertEqual(cache.alignmentWeights?.shape, [1, 224])
+    }
+
+    func testDecodingCacheWithNilValues() {
+        let cache = DecodingCache()
+
+        XCTAssertNil(cache.keyCache)
+        XCTAssertNil(cache.valueCache)
+        XCTAssertNil(cache.alignmentWeights)
+    }
+    
+    func testDecodingCacheWithPartialValues() {
+        let keyCache = try! MLMultiArray(shape: [1, 1536, 1, 224], dataType: .float16)
+        
+        let cache = DecodingCache(keyCache: keyCache)
+        
+        XCTAssertNotNil(cache.keyCache)
+        XCTAssertNil(cache.valueCache)
+        XCTAssertNil(cache.alignmentWeights)
+        XCTAssertEqual(cache.keyCache?.shape, [1, 1536, 1, 224])
+    }
+
     // MARK: - Feature Extractor Tests
 
     func testLogmelOutput() async throws {
@@ -561,8 +757,8 @@ final class UnitTests: XCTestCase {
         )
 
         XCTAssertNotNil(result)
-        let tokenCount = result.segments.flatMap { $0.tokens }.count
-        let decodingTimePerToken = result.timings.decodingLoop / Double(tokenCount)
+        let tokenCountWithEarlyStop = result.segments.flatMap { $0.tokens }.count
+        let decodingTimePerTokenWithEarlyStop = result.timings.decodingLoop / Double(tokenCountWithEarlyStop)
 
         // Work done in the callback should not block the decoding loop
         let continuationCallbackWithWait: TranscriptionCallback = { (progress: TranscriptionProgress) -> Bool? in
@@ -581,10 +777,10 @@ final class UnitTests: XCTestCase {
         Logging.debug("Decoding loop without wait: \(result.timings.decodingLoop), with wait: \(resultWithWait.timings.decodingLoop)")
 
         // Assert that the decoding predictions per token are not slower with the waiting
-        XCTAssertEqual(decodingTimePerTokenWithWait, decodingTimePerToken, accuracy: decodingTimePerToken, "Decoding predictions per token should not be significantly slower with waiting")
+        XCTAssertEqual(decodingTimePerTokenWithWait, decodingTimePerTokenWithEarlyStop, accuracy: decodingTimePerTokenWithEarlyStop, "Decoding predictions per token should not be significantly slower with waiting")
 
         // Assert that more tokens are returned in the callback with waiting
-        XCTAssertGreaterThan(tokenCountWithWait, tokenCount, "More tokens should be returned in the callback with waiting")
+        XCTAssertGreaterThan(tokenCountWithWait, tokenCountWithEarlyStop, "More tokens should be returned in the callback with waiting")
     }
 
     // MARK: - Tokenizer Tests
@@ -662,7 +858,7 @@ final class UnitTests: XCTestCase {
 
         let transcribeResult: [TranscriptionResult] = try await whisperKit.transcribe(audioArray: multiWindowSamples, decodeOptions: options)
         let result = try XCTUnwrap(transcribeResult.first)
-        XCTAssertEqual(result.segments.count, 2, "Expected 3 segments")
+        XCTAssertEqual(result.segments.count, 3, "Expected 3 segments")
 
         // Compare last timestamp to the length of the audio
         let endTimestamp = try XCTUnwrap(
@@ -1064,7 +1260,7 @@ final class UnitTests: XCTestCase {
             "Failed to transcribe"
         )
 
-        XCTAssertEqual(result.segments.first?.text, " and so my fellow americans ask not what your country can do for you ask what you can do for your country.")
+        XCTAssertEqual(result.segments.first?.text, " and so my fellow americans ask not what your country can do for you ask what you can do for your country")
     }
 
     func testCallbacks() async throws {
@@ -1223,91 +1419,76 @@ final class UnitTests: XCTestCase {
     }
 
     func testTimestampRulesFilter() throws {
-        // NOTE: for non-multilingual models we supress tokens immediately
-        let tokensFilter1 = TimestampRulesFilter(
+        // NOTE: for non-multilingual models we suppress tokens immediately
+        let tokensFilter = TimestampRulesFilter(
             specialTokens: .default(
                 endToken: 3,
                 noTimestampsToken: 2,
-                timeTokenBegin: 4,
-                transcribeToken: 100,
-                translateToken: 101
+                timeTokenBegin: 6,
+                transcribeToken: 4,
+                translateToken: 5
             ),
-            sampleBegin: 2,
+            sampleBegin: 0,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: false
         )
 
-        let logits1 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2])
-        let result1 = tokensFilter1.filterLogits(logits1, withTokens: [])
-        XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, 0.2])
 
-        let tokensFilter2 = TimestampRulesFilter(
-            specialTokens: .default(
-                endToken: 3,
-                noTimestampsToken: 2,
-                timeTokenBegin: 4,
-                transcribeToken: 100,
-                translateToken: 101
-            ),
-            sampleBegin: 2,
-            maxInitialTimestampIndex: nil,
-            isModelMultilingual: false
-        )
+        // noTimestampToken should always be suppressed if tokens pass sampleBegin
+        let logits1 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result1 = tokensFilter.filterLogits(logits1, withTokens: [4])
+        XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
 
-        let logits2 = try MLMultiArray.logits([1.1, 0.2, 0.3, 0.4, 0.2, 0.1, 0.2])
-        let result2 = tokensFilter2.filterLogits(logits2, withTokens: [])
-        XCTAssertEqual(result2.data(for: 2), [-.infinity, -.infinity, -.infinity, -.infinity, 0.2, 0.1, 0.2])
+        // Timestamps should not decrease (filters up to last seen timestamp)
+        let logits2 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result2 = tokensFilter.filterLogits(logits2, withTokens: [0, 6, 7, 3])
+        XCTAssertEqual(result2.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, -.infinity, -.infinity, 0.1])
+
+        // If last two tokens are timestamps, filter all timestamps (allows text token to be next)
+        let logits3 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result3 = tokensFilter.filterLogits(logits3, withTokens: [0, 6, 7])
+        XCTAssertEqual(result3.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, -.infinity, -.infinity, -.infinity])
+
+        // If only one previous token was a timestamp, filter all text and non-decreasing timestamps (to find matching timestamp pair)
+        let logits4 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result4 = tokensFilter.filterLogits(logits4, withTokens: [0, 4, 7])
+        XCTAssertEqual(result4.data(for: 2), [-.infinity, -.infinity, -.infinity, -.infinity, -.infinity, -.infinity, -.infinity, 0.1, 0.1])
     }
 
     func testTimestampRulesFilterMultilingual() throws {
-        // NOTE: for multilingual models we supress tokens only after transcribe or translate token
-        let tokensFilter1 = TimestampRulesFilter(
+        // NOTE: for multilingual models we suppress tokens only after transcribe or translate token
+        let tokensFilter = TimestampRulesFilter(
             specialTokens: .default(
                 endToken: 3,
                 noTimestampsToken: 2,
-                timeTokenBegin: 4,
-                transcribeToken: 100,
-                translateToken: 101
+                timeTokenBegin: 6,
+                transcribeToken: 4,
+                translateToken: 5
             ),
-            sampleBegin: 2,
+            sampleBegin: 0,
             maxInitialTimestampIndex: nil,
             isModelMultilingual: true
         )
-        let logits1 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2])
-        let result1 = tokensFilter1.filterLogits(logits1, withTokens: [])
-        XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2])
 
-        let tokensFilter2 = TimestampRulesFilter(
-            specialTokens: .default(
-                endToken: 3,
-                noTimestampsToken: 2,
-                timeTokenBegin: 4,
-                transcribeToken: 100,
-                translateToken: 101
-            ),
-            sampleBegin: 2,
-            maxInitialTimestampIndex: nil,
-            isModelMultilingual: true
-        )
-        let logits2 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2])
-        let result2 = tokensFilter2.filterLogits(logits2, withTokens: [100])
-        XCTAssertEqual(result2.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, 0.2])
+        // Without task token, nothing should be suppressed even with tokens past sampleBegin
+        let logits1 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result1 = tokensFilter.filterLogits(logits1, withTokens: [0, 1, 2])
+        XCTAssertEqual(result1.data(for: 2), [1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
 
-        let tokensFilter3 = TimestampRulesFilter(
-            specialTokens: .default(
-                endToken: 3,
-                noTimestampsToken: 2,
-                timeTokenBegin: 4,
-                transcribeToken: 100,
-                translateToken: 101
-            ),
-            sampleBegin: 2,
-            maxInitialTimestampIndex: nil,
-            isModelMultilingual: true
-        )
-        let logits3 = try MLMultiArray.logits([1.1, 0.2, 0.3, 0.4, 0.2, 0.1, 0.2])
-        let result3 = tokensFilter3.filterLogits(logits3, withTokens: [101])
-        XCTAssertEqual(result3.data(for: 2), [-.infinity, -.infinity, -.infinity, -.infinity, 0.2, 0.1, 0.2])
+        // Timestamps should not decrease after task token (filters up to last seen timestamp)
+        let logits2 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result2 = tokensFilter.filterLogits(logits2, withTokens: [0, 4, 6, 7, 3])
+        XCTAssertEqual(result2.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, -.infinity, -.infinity, 0.1])
+
+        // If last two tokens after task are timestamps, filter all timestamps (allows text token to be next)
+        let logits3 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result3 = tokensFilter.filterLogits(logits3, withTokens: [0, 5, 6, 7])
+        XCTAssertEqual(result3.data(for: 2), [1.1, 5.2, -.infinity, 0.4, 0.2, 0.1, -.infinity, -.infinity, -.infinity])
+
+        // After transcribe token with text and single timestamp (should force timestamp tokens)
+        let logits4 = try MLMultiArray.logits([1.1, 5.2, 0.3, 0.4, 0.2, 0.1, 0.2, 0.1, 0.1])
+        let result4 = tokensFilter.filterLogits(logits4, withTokens: [0, 4, 0, 7])
+        XCTAssertEqual(result4.data(for: 2), [-.infinity, -.infinity, -.infinity, -.infinity, -.infinity, -.infinity, -.infinity, 0.1, 0.1])
     }
 
     // MARK: - VAD Tests


### PR DESCRIPTION
This change will allow arbitrary input and output types as part of the model protocols, supporting full MLX or MLTensor pipelines without the need to convert between types during inference.

This PR also contains some general fixes and cleanup
- Uses the MelSpectrogram model input shapes for audio input length
	- Breaking change: `WhisperKit.windowSamples` is now `Constants.defaultWindowSamples`
- Fixed the timestamp token filter rules
	- Transcripts will now have more timestamp tokens (segments) within each 30s window
- Uses MLTensor operations for sampling on > iOS 18 and macOS 15 for a 2x speedup vs BNNS
- CI and QoL upgrades