### PR TITLE
Platform-specific defaults for concurrentWorkerCount

### DIFF
--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -175,7 +175,7 @@ public struct DecodingOptions: Codable {
         logProbThreshold: Float? = -1.0,
         firstTokenLogProbThreshold: Float? = -1.5,
         noSpeechThreshold: Float? = 0.6,
-        concurrentWorkerCount: Int = 16,
+        concurrentWorkerCount: Int? = nil,
         chunkingStrategy: ChunkingStrategy? = nil
     ) {
         self.verbose = verbose
@@ -202,7 +202,13 @@ public struct DecodingOptions: Codable {
         self.logProbThreshold = logProbThreshold
         self.firstTokenLogProbThreshold = firstTokenLogProbThreshold
         self.noSpeechThreshold = noSpeechThreshold
-        self.concurrentWorkerCount = concurrentWorkerCount
+        // Set platform-specific default worker count if not explicitly provided
+        // Non-macOS devices have shown regressions with >4 workers, default to 4 for safety
+        #if os(macOS)
+        self.concurrentWorkerCount = concurrentWorkerCount ?? 16
+        #else
+        self.concurrentWorkerCount = concurrentWorkerCount ?? 4
+        #endif
         self.chunkingStrategy = chunkingStrategy
     }
 }

--- a/Tests/WhisperKitTests/RegressionTests.swift
+++ b/Tests/WhisperKitTests/RegressionTests.swift
@@ -51,7 +51,6 @@ class RegressionTests: XCTestCase {
     let vadDecodingOptions = DecodingOptions(
         verbose: true,
         task: .transcribe,
-        concurrentWorkerCount: 16,
         chunkingStrategy: .vad
     )
 


### PR DESCRIPTION
Non-macOS devices have shown regressions with >4 workers in some cases on iOS 18, default to 4 for safety
Also updates regression tests to use default, which will slightly lower the overall speeds.

The error occurred after some time transcribing a large file while using 16 concurrent workers (task group tasks) with async prediction. The inference would suspend without throwing, which caused the pipeline to lock up.

If you've experienced something similar, this specific error looked like this:

```
processRequest:model:qos:qIndex:modelStringID:options:returnValue:error:: 
ANEProgramProcessRequestDirect() Failed with status=0xf : statusType=0x11 lModel=_ANEModel: ...
```