### PR TITLE
fix: the issue where filenames containing dots are not handled correctly when  generating the report path

### DIFF
--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -345,7 +345,7 @@ struct TranscribeCLI: AsyncParsableCommand {
         transcribeResult: TranscriptionResult?
     ) {
         let audioFile = URL(fileURLWithPath: audioPath).lastPathComponent
-        let audioFileName = audioFile.components(separatedBy: ".").first!
+        let audioFileName = URL(fileURLWithPath: audioPath).deletingPathExtension().lastPathComponent
         let transcription = transcribeResult?.text ?? "Transcription failed"
 
         if cliArguments.report, let result = transcribeResult {


### PR DESCRIPTION
**Reproduce steps:**

transcribe a filename contains `.`
 `swift run whisperkit-cli transcribe --audio-path "~/Downloads/1.video.mp4" --verbose --word-timestamps --report --report-path ~/Downloads`

**Expected result:** `~/Downloads/1.video.json`

**actual result:** `~/Downloads/1.json`