### PR TITLE
Sortable segment discovery during VAD chunking

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1661,6 +1661,7 @@ struct ContentView: View {
                 Logging.debug("Discovered segment: \(segment.id) (\(segment.seek))): \(segment.start) -> \(segment.end)")
             }
         }
+
         whisperKit.segmentDiscoveryCallback = segmentCallback
 
         let streamingAudio = samples

--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1423,6 +1423,15 @@ struct ContentView: View {
             return nil
         }
 
+        let segmentCallback: SegmentDiscoveryCallback = { segments in
+            // Log segments as they are discovered from the segment discovery callback
+            for segment in segments {
+                Logging.debug("Discovered segment: \(segment.id) (\(segment.seek))): \(segment.start) -> \(segment.end) \(segment.text)")
+            }
+        }
+
+        whisperKit.segmentDiscoveryCallback = segmentCallback
+
         let transcriptionResults: [TranscriptionResult] = try await whisperKit.transcribe(
             audioArray: samples,
             decodeOptions: options,
@@ -1645,6 +1654,14 @@ struct ContentView: View {
         }
 
         Logging.info("[EagerMode] \(lastAgreedSeconds)-\(Double(samples.count) / 16000.0) seconds")
+
+        let segmentCallback: SegmentDiscoveryCallback = { segments in
+            // Log segments as they are discovered from the segment discovery callback
+            for segment in segments {
+                Logging.debug("Discovered segment: \(segment.id) (\(segment.seek))): \(segment.start) -> \(segment.end)")
+            }
+        }
+        whisperKit.segmentDiscoveryCallback = segmentCallback
 
         let streamingAudio = samples
         var streamOptions = options

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -716,9 +716,8 @@ open class WhisperKit {
                     }
 
                     // Setup segment callback to track chunk seek positions for segment discovery
-                    var batchedSegmentCallback: SegmentDiscoveryCallback? = self.segmentDiscoveryCallback
-                    if let seekOffsets {
-                        batchedSegmentCallback = { segments in
+                    let batchedSegmentCallback: SegmentDiscoveryCallback? = if let seekOffsets {
+                        { segments in
                             let windowId = audioIndex + batchIndex * audioArrayBatch.count
                             let seekOffset = seekOffsets[windowId]
                             var adjustedSegments = segments
@@ -727,6 +726,8 @@ open class WhisperKit {
                             }
                             self.segmentDiscoveryCallback?(adjustedSegments)
                         }
+                    } else {
+                        self.segmentDiscoveryCallback
                     }
 
                     // Setup decoding options for the current audio array


### PR DESCRIPTION
This PR provides information to the segment discovery callback that can be used to sort incoming segments as they are discovered during VAD chunking (asynchronous) transcription. Previously these segments had a 0 seek time until adjusted at the end of the transcription run.

It does this by keeping track of the seek time for each chunk and updates the resulting segments sent to the discovery callback mid-transcription.

Example:
```swift
    whisperKit.segmentDiscoveryCallback = { segments in
        // Add new segments to an array as they are discovered
        discoveredSegments.append(contentsOf: segments)
        
        // Sorted array of results that can be surfaced to the UI
        discoveredSegments.sort { $0.seek < $1.seek }
    }
```