### PR TITLE
Pass logitfilters to textdecoder, improve tokenizer loading

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -16,11 +16,11 @@ jobs:
             ios-device: "iPhone 14"
             xcode-version: "15.2"
           - os: macos-14
-            ios-version: "17.2"
+            ios-version: "17.5"
             ios-device: "iPhone 15"
-            xcode-version: "15.2"
+            xcode-version: "15.4"
           - os: macos-15
-            ios-version: "18.2" # Latest available version
+            ios-version: "18.5" # Latest available version
             ios-device: "iPhone 16"
             xcode-version: "latest-stable"
     uses: ./.github/workflows/unit-tests.yml

--- a/Sources/WhisperKit/Core/Text/SegmentSeeker.swift
+++ b/Sources/WhisperKit/Core/Text/SegmentSeeker.swift
@@ -395,7 +395,7 @@ open class SegmentSeeker: SegmentSeeking {
                 tokens: wordTokenArray,
                 start: wordStartTime,
                 end: wordEndTime,
-                probability: pow(10, probability)
+                probability: exp(probability)
             )
             wordTimings.append(wordTiming)
         }

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -440,7 +440,7 @@ open class WhisperKit {
 
             let tokenizer = try await ModelUtilities.loadTokenizer(
                 for: modelVariant,
-                tokenizerFolder: path.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+                tokenizerFolder: path,
                 useBackgroundSession: useBackgroundDownloadSession
             )
             currentTimings.tokenizerLoadTime = CFAbsoluteTimeGetCurrent() - tokenizerLoadStart

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -28,7 +28,6 @@ open class WhisperKit {
     public var featureExtractor: any FeatureExtracting
     public var audioEncoder: any AudioEncoding
     public var textDecoder: any TextDecoding
-    public var logitsFilters: [any LogitsFiltering]
     public var segmentSeeker: any SegmentSeeking
     public var voiceActivityDetector: VoiceActivityDetector?
 
@@ -58,10 +57,13 @@ open class WhisperKit {
         featureExtractor = config.featureExtractor ?? FeatureExtractor()
         audioEncoder = config.audioEncoder ?? AudioEncoder()
         textDecoder = config.textDecoder ?? TextDecoder()
-        logitsFilters = config.logitsFilters ?? []
+        if let logitsFilters = config.logitsFilters {
+            textDecoder.logitsFilters = logitsFilters
+        }
+        
         segmentSeeker = config.segmentSeeker ?? SegmentSeeker()
         voiceActivityDetector = config.voiceActivityDetector
-        tokenizerFolder = config.tokenizerFolder
+        tokenizerFolder = config.tokenizerFolder ?? config.downloadBase
         useBackgroundDownloadSession = config.useBackgroundDownloadSession
         currentTimings = TranscriptionTimings()
         Logging.shared.logLevel = config.verbose ? config.logLevel : .none
@@ -421,25 +423,32 @@ open class WhisperKit {
             return
         }
 
-        // Check model dimensions to assign appropriate tokenizer
-        guard let logitsDim = textDecoder.logitsSize, let encoderDim = audioEncoder.embedSize else {
-            throw WhisperError.tokenizerUnavailable()
+        // Only load tokenizer if not already set
+        if let tokenizer {
+            Logging.debug("Tokenizer already loaded, skipping tokenizer loading")
+            textDecoder.tokenizer = tokenizer
+        } else {
+            // Check model dimensions to assign appropriate tokenizer
+            guard let logitsDim = textDecoder.logitsSize, let encoderDim = audioEncoder.embedSize else {
+                throw WhisperError.tokenizerUnavailable()
+            }
+            textDecoder.isModelMultilingual = ModelUtilities.isModelMultilingual(logitsDim: logitsDim)
+            modelVariant = ModelUtilities.detectVariant(logitsDim: logitsDim, encoderDim: encoderDim)
+            
+            Logging.debug("Loading tokenizer for \(modelVariant)")
+            let tokenizerLoadStart = CFAbsoluteTimeGetCurrent()
+
+            let tokenizer = try await ModelUtilities.loadTokenizer(
+                for: modelVariant,
+                tokenizerFolder: path.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+                useBackgroundSession: useBackgroundDownloadSession
+            )
+            currentTimings.tokenizerLoadTime = CFAbsoluteTimeGetCurrent() - tokenizerLoadStart
+
+            self.tokenizer = tokenizer
+            textDecoder.tokenizer = tokenizer
+            Logging.debug("Loaded tokenizer in \(String(format: "%.2f", currentTimings.tokenizerLoadTime))s")
         }
-        textDecoder.isModelMultilingual = ModelUtilities.isModelMultilingual(logitsDim: logitsDim)
-        modelVariant = ModelUtilities.detectVariant(logitsDim: logitsDim, encoderDim: encoderDim)
-        Logging.debug("Loading tokenizer for \(modelVariant)")
-        let tokenizerLoadStart = CFAbsoluteTimeGetCurrent()
-
-        let tokenizer = try await ModelUtilities.loadTokenizer(
-            for: modelVariant,
-            tokenizerFolder: tokenizerFolder,
-            useBackgroundSession: useBackgroundDownloadSession
-        )
-        currentTimings.tokenizerLoadTime = CFAbsoluteTimeGetCurrent() - tokenizerLoadStart
-
-        self.tokenizer = tokenizer
-        textDecoder.tokenizer = tokenizer
-        Logging.debug("Loaded tokenizer in \(String(format: "%.2f", currentTimings.tokenizerLoadTime))s")
 
         modelState = .loaded
 

--- a/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
@@ -160,17 +160,17 @@ public struct TranscriptionUtilities {
     }
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionSegment.formatSegments(_:withTimestamps:)` instead.")
+@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.formatSegments(_:withTimestamps:)` instead.")
 public func formatSegments(_ segments: [TranscriptionSegment], withTimestamps: Bool = true) -> [String] {
     return TranscriptionUtilities.formatSegments(segments, withTimestamps: withTimestamps)
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionSegment.findLongestCommonPrefix(_:_:)` instead.")
+@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.findLongestCommonPrefix(_:_:)` instead.")
 public func findLongestCommonPrefix(_ words1: [WordTiming], _ words2: [WordTiming]) -> [WordTiming] {
     return TranscriptionUtilities.findLongestCommonPrefix(words1, words2)
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionSegment.findLongestDifferentSuffix(_:_:)` instead.")
+@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.findLongestDifferentSuffix(_:_:)` instead.")
 public func findLongestDifferentSuffix(_ words1: [WordTiming], _ words2: [WordTiming]) -> [WordTiming] {
     TranscriptionUtilities.findLongestDifferentSuffix(words1, words2)
 }

--- a/Sources/WhisperKitCLI/TranscribeCLI.swift
+++ b/Sources/WhisperKitCLI/TranscribeCLI.swift
@@ -419,6 +419,9 @@ struct TranscribeCLI: AsyncParsableCommand {
         let downloadTokenizerFolder: URL? =
             if let filePath = cliArguments.downloadTokenizerPath {
                 URL(filePath: filePath)
+            } else if let modelPath = cliArguments.modelPath {
+                // If no tokenizer path is provided, use the model path if it exists
+                URL(filePath: modelPath)
             } else {
                 nil
             }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1394,6 +1394,10 @@ final class UnitTests: XCTestCase {
     }
 
     func testCallbackWithEarlyStopping() async throws {
+        guard #available(macOS 14, iOS 17, watchOS 10, visionOS 1, *) else {
+            throw XCTSkip("Disabled on macOS 13 due to swift concurrency flakiness")
+        }
+        
         let callbackTestTask = Task(priority: .userInitiated) {
             let config = WhisperKitConfig(
                 model: "tiny",

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -2047,7 +2047,21 @@ final class UnitTests: XCTestCase {
 
         // Populate the matrix with some non-linear data
         let matrix = try MLMultiArray(shape: [numberOfRows, numberOfColumns], dataType: .float16)
-        let tokenProbs = Array(repeating: 0.0, count: numberOfRows.intValue).map { _ in Float.random(in: -1..<0) }
+        
+        // Use specific known log probabilities to test the exp() calculation
+        let knownLogProbs: [Float] = [
+            -0.5,  // exp(-0.5) ≈ 0.6065
+            -1.0,  // exp(-1.0) ≈ 0.3679
+            -2.0,  // exp(-2.0) ≈ 0.1353
+            -0.1,  // exp(-0.1) ≈ 0.9048
+            -0.3,  // exp(-0.3) ≈ 0.7408
+        ]
+        
+        // Create tokenProbs array with known values, cycling through knownLogProbs
+        let tokenProbs = (0..<numberOfRows.intValue).map { index in
+            knownLogProbs[index % knownLogProbs.count]
+        }
+        
         for i in 0..<numberOfRows.intValue {
             for j in 0..<numberOfColumns.intValue {
                 matrix[i * numberOfColumns.intValue + j] = NSNumber(value: Double.random(in: 0...1))
@@ -2067,16 +2081,27 @@ final class UnitTests: XCTestCase {
         XCTAssertFalse(result.isEmpty, "Result should not be empty.")
 
         var previousEndTime: Float = -1.0
+        var currentTokenIndex = 0
+        
         for wordTiming in result {
             XCTAssertFalse(wordTiming.word.isEmpty, "Word should not be empty.")
             XCTAssertFalse(wordTiming.tokens.isEmpty, "Tokens should not be empty.")
             XCTAssert(wordTiming.tokens.allSatisfy { $0 >= 0 }, "All token IDs should be non-negative.")
             XCTAssertLessThanOrEqual(wordTiming.start, wordTiming.end, "Start should be less than or equal to end.")
             XCTAssertGreaterThanOrEqual(wordTiming.start, previousEndTime, "Start time should not be earlier than the previous end time.")
-            XCTAssertGreaterThanOrEqual(wordTiming.probability, 0.0, "Probability should not be negative.")
-            XCTAssertLessThanOrEqual(wordTiming.probability, 1.0, "Probability should not be greater than 1.")
+
+            // Test the specific probability calculation: exp(average of log probabilities)
+            let startIndex = currentTokenIndex
+            let endIndex = currentTokenIndex + wordTiming.tokens.count
+            let wordLogProbs = Array(tokenProbs[startIndex..<endIndex])
+            let averageLogProb = wordLogProbs.reduce(0, +) / Float(wordLogProbs.count)
+            let expectedProbability = exp(averageLogProb)
+            
+            XCTAssertEqual(wordTiming.probability, expectedProbability, accuracy: 0.0001, 
+                          "Probability should be exp(average log prob). Expected: \(expectedProbability), Got: \(wordTiming.probability)")
 
             previousEndTime = wordTiming.end
+            currentTokenIndex = endIndex
         }
     }
 
@@ -2677,5 +2702,191 @@ final class UnitTests: XCTestCase {
             }
             previousTime = time
         }
+    }
+
+    // MARK: - TextDecoder Logits Filter Tests
+
+    func testCreateLogitsFiltersOnlyCustomFilters() async throws {
+        let customFilter = PlusOneFilter()
+        let decoder = TextDecoder()
+        decoder.logitsFilters = [customFilter]
+        let tokenizer = try await ModelUtilities.loadTokenizer(for: .tiny)
+
+        let options = DecodingOptions(
+            withoutTimestamps: true,
+            suppressBlank: false,
+            supressTokens: []
+        )
+
+        let allFilters = decoder.createLogitsFilters(
+            options: options,
+            prefilledIndex: 0,
+            initialPromptIndex: 1,
+            tokenizer: tokenizer
+        )
+
+        // Should only contain the custom filter
+        XCTAssertEqual(allFilters.count, 1)
+        XCTAssertTrue(allFilters[0] is PlusOneFilter)
+    }
+
+    func testCreateLogitsFiltersWithSuppressBlank() async throws {
+        let decoder = TextDecoder()
+        let tokenizer = try await ModelUtilities.loadTokenizer(for: .tiny)
+
+        let options = DecodingOptions(
+            withoutTimestamps: true,
+            suppressBlank: true,
+            supressTokens: []
+        )
+
+        let allFilters = decoder.createLogitsFilters(
+            options: options,
+            prefilledIndex: 0,
+            initialPromptIndex: 1,
+            tokenizer: tokenizer
+        )
+
+        // Should contain only SuppressBlankFilter
+        XCTAssertEqual(allFilters.count, 1)
+        XCTAssertTrue(allFilters[0] is SuppressBlankFilter)
+    }
+
+    func testCreateLogitsFiltersWithSuppressTokens() async throws {
+        let decoder = TextDecoder()
+        let tokenizer = CustomTokenizer(specialTokenBegin: 10)
+
+        let options = DecodingOptions(
+            withoutTimestamps: true,
+            suppressBlank: false,
+            supressTokens: [0, 2, 11, 15]  // Mix of tokens < 10 and >= 10
+        )
+
+        let allFilters = decoder.createLogitsFilters(
+            options: options,
+            prefilledIndex: 0,
+            initialPromptIndex: 1,
+            tokenizer: tokenizer
+        )
+
+        // Should contain only SuppressTokensFilter
+        XCTAssertEqual(allFilters.count, 1)
+        XCTAssertTrue(allFilters[0] is SuppressTokensFilter)
+
+        let suppressFilter = allFilters[0] as! SuppressTokensFilter
+        XCTAssertEqual(suppressFilter.suppressTokens, [0, 2])  // Only tokens < 10
+    }
+
+    func testCreateLogitsFiltersWithTimestamps() async throws {
+        let decoder = TextDecoder()
+        let tokenizer = try await ModelUtilities.loadTokenizer(for: .tiny)
+
+        let options = DecodingOptions(
+            withoutTimestamps: false,
+            suppressBlank: false,
+            supressTokens: []
+        )
+
+        let allFilters = decoder.createLogitsFilters(
+            options: options,
+            prefilledIndex: 0,
+            initialPromptIndex: 1,
+            tokenizer: tokenizer
+        )
+
+        // Should contain only TimestampRulesFilter
+        XCTAssertEqual(allFilters.count, 1)
+        XCTAssertTrue(allFilters[0] is TimestampRulesFilter)
+    }
+
+    func testCreateLogitsFiltersAllFiltersEnabled() async throws {
+        let customFilter = PlusOneFilter()
+        let decoder = TextDecoder()
+        decoder.logitsFilters = [customFilter]
+        let tokenizer = CustomTokenizer(specialTokenBegin: 10)
+
+        let options = DecodingOptions(
+            withoutTimestamps: false,
+            suppressBlank: true,
+            supressTokens: [0, 2, 11, 15]  // Mix of tokens < 10 and >= 10
+        )
+
+        let allFilters = decoder.createLogitsFilters(
+            options: options,
+            prefilledIndex: 0,
+            initialPromptIndex: 1,
+            tokenizer: tokenizer
+        )
+
+        // Should contain all 4 filter types: custom, blank, suppress, timestamp
+        XCTAssertEqual(allFilters.count, 4)
+        XCTAssertTrue(allFilters[0] is PlusOneFilter)
+        XCTAssertTrue(allFilters[1] is SuppressBlankFilter)
+        XCTAssertTrue(allFilters[2] is SuppressTokensFilter)
+        XCTAssertTrue(allFilters[3] is TimestampRulesFilter)
+    }
+
+}
+
+// MARK: - Mock Types for Testing
+
+class PlusOneFilter: LogitsFiltering {
+    var filterCallCount = 0
+
+    func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray {
+        filterCallCount += 1
+
+        guard let modifiedLogits = try? MLMultiArray(shape: logits.shape, dataType: logits.dataType) else {
+            return logits
+        }
+
+        for i in 0..<logits.count {
+            let originalValue = logits[i].floatValue
+            modifiedLogits[i] = NSNumber(value: originalValue + 1.0)
+        }
+
+        return modifiedLogits
+    }
+}
+
+class CustomTokenizer: WhisperTokenizer {
+    let specialTokens: SpecialTokens
+    let allLanguageTokens: Set<Int>
+
+    init(specialTokenBegin: Int) {
+        self.specialTokens = SpecialTokens(
+            endToken: 1,
+            englishToken: 2,
+            noSpeechToken: 3,
+            noTimestampsToken: 4,
+            specialTokenBegin: specialTokenBegin,
+            startOfPreviousToken: 5,
+            startOfTranscriptToken: 6,
+            timeTokenBegin: 7,
+            transcribeToken: 8,
+            translateToken: 9,
+            whitespaceToken: 10
+        )
+        self.allLanguageTokens = Set<Int>()
+    }
+
+    func encode(text: String) -> [Int] {
+        return [1, 2, 3]
+    }
+
+    func decode(tokens: [Int]) -> String {
+        return "mock text"
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        return nil
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        return "token_\(id)"
+    }
+
+    func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
+        return (["mock"], [[1, 2, 3]])
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1394,7 +1394,7 @@ final class UnitTests: XCTestCase {
     }
 
     func testCallbackWithEarlyStopping() async throws {
-        guard #available(macOS 14, iOS 17, watchOS 10, visionOS 1, *) else {
+        guard #available(macOS 15, iOS 18, watchOS 11, visionOS 2, *) else {
             throw XCTSkip("Disabled on macOS 13 due to swift concurrency flakiness")
         }
         

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1395,7 +1395,7 @@ final class UnitTests: XCTestCase {
 
     func testCallbackWithEarlyStopping() async throws {
         guard #available(macOS 15, iOS 18, watchOS 11, visionOS 2, *) else {
-            throw XCTSkip("Disabled on macOS 13 due to swift concurrency flakiness")
+            throw XCTSkip("Disabled on macOS 14 and below due to swift concurrency flakiness")
         }
         
         let callbackTestTask = Task(priority: .userInitiated) {


### PR DESCRIPTION
Wire logitsfilter to `TextDecoder`
- Resolves an issue where logits filters passed into WhisperKitConfig were not being passed into the text decoder

Only load tokenizer if null, respect downloadBase as default for tokenizer folder
- The new logic will do a couple things:
    1. If the tokenizer is not nil before calling loadModels, it will skip any tokenizer handling and just pass it to the TextDecoder
    2. If the tokenizerFolder is nil when loading the tokenizer is needed, it will default to the downloadBase value if set
    3. If the tokenizerFolder contains a tokenizer.json at the top level of the URL, it will look there as well if not found in the repo location (e.g. huggingface/models/openai/tiny/tokenizer.json and huggingface/models/tokenizer.json are both search paths). This is done to match modelFolder behavior if the tokenizer is bundled with the app, but give the flexibility to also use the swift-transformers structure if downloading is needed.
- Resolves https://github.com/argmaxinc/WhisperKit/issues/339
- Resolves https://github.com/argmaxinc/WhisperKit/issues/340
