### PR TITLE
Tokenizer and punctuation fixes, better remote config handling

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -6,10 +6,6 @@ on:
     types: [submitted]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
-
 jobs:
   build-and-test:
     name: "Build and Test"

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -17,6 +17,8 @@ jobs:
     with:
       ios-version: "18.6"
       ios-device: "iPhone 16"
+      watchos-version: "11.5"
+      visionos-version: "2.5"
       macos-runner: "macos-15"
 
   check-approvals:
@@ -49,14 +51,20 @@ jobs:
           - os: macos-13-xlarge
             ios-version: "17.2"
             ios-device: "iPhone 14"
+            watchos-version: "10.2"
+            visionos-version: "1.0"
             xcode-version: "15.2"
           - os: macos-14
             ios-version: "17.2"
             ios-device: "iPhone 15"
+            watchos-version: "10.2"
+            visionos-version: "1.0"
             xcode-version: "15.2"
     uses: ./.github/workflows/unit-tests.yml
     with:
       macos-runner: ${{ matrix.os }}
       ios-version: ${{ matrix.ios-version }}
       ios-device: ${{ matrix.ios-device }}
+      watchos-version: ${{ matrix.watchos-version }}
+      visionos-version: ${{ matrix.visionos-version }}
       xcode-version: ${{ matrix.xcode-version }}

--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-test:
     name: "Build and Test"
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-build-and-test
+      cancel-in-progress: true
     uses: ./.github/workflows/unit-tests.yml
     with:
       ios-version: "18.6"
@@ -41,6 +44,9 @@ jobs:
     name: "Pre-merge Tests"
     needs: [check-approvals]
     if: needs.check-approvals.outputs.reviews == 'APPROVED' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ matrix.os }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,18 +14,26 @@ jobs:
           - os: macos-13-xlarge
             ios-version: "17.2" # TODO: Download older simulators for macOS 13
             ios-device: "iPhone 14"
+            watchos-version: "10.2"
+            visionos-version: "1.0"
             xcode-version: "15.2"
           - os: macos-14
             ios-version: "17.5"
             ios-device: "iPhone 15"
+            watchos-version: "10.2"
+            visionos-version: "1.0"
             xcode-version: "15.4"
           - os: macos-15
-            ios-version: "18.5" # Latest available version
+            ios-version: "18.6" # Latest available version
             ios-device: "iPhone 16"
+            watchos-version: "11.5"
+            visionos-version: "2.5"
             xcode-version: "latest-stable"
     uses: ./.github/workflows/unit-tests.yml
     with:
       macos-runner: ${{ matrix.os }}
       ios-version: ${{ matrix.ios-version }}
       ios-device: ${{ matrix.ios-device }}
+      watchos-version: ${{ matrix.watchos-version }}
+      visionos-version: ${{ matrix.visionos-version }}
       xcode-version: ${{ matrix.xcode-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,9 @@ jobs:
   unit-tests:
     name: "${{ matrix.run-config['name'] }} on ${{ inputs.macos-runner }}"
     runs-on: ${{ inputs.macos-runner }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.macos-runner }}
+      cancel-in-progress: true
     strategy:
       matrix:
         run-config:
@@ -53,7 +56,7 @@ jobs:
               clean-destination: "generic/platform=visionOS",
               test-destination: "platform=visionOS Simulator,OS=${{ inputs.visionos-version }},name=Apple Vision Pro",
             }
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.run-config['name'] == 'visionOS' && 60 || 30 }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,12 @@ on:
       ios-device:
         required: true
         type: string
+      watchos-version:
+        required: true
+        type: string
+      visionos-version:
+          required: true
+          type: string
       macos-runner:
         required: true
         type: string
@@ -39,13 +45,13 @@ jobs:
               name: "watchOS",
               condition: "${{ inputs.macos-runner == 'macos-15' }}",
               clean-destination: "generic/platform=watchOS",
-              test-destination: "platform=watchOS Simulator,name=Apple Watch Ultra 2 (49mm)",
+              test-destination: "platform=watchOS Simulator,OS=${{ inputs.watchos-version }},name=Apple Watch Ultra 2 (49mm)",
             }
           - {
               name: "visionOS",
               condition: "${{ inputs.macos-runner == 'macos-15' }}",
               clean-destination: "generic/platform=visionOS",
-              test-destination: "platform=visionOS Simulator,name=Apple Vision Pro",
+              test-destination: "platform=visionOS Simulator,OS=${{ inputs.visionos-version }},name=Apple Vision Pro",
             }
     timeout-minutes: 30
     steps:
@@ -77,7 +83,7 @@ jobs:
           echo "Runtimes for testing:"
           xcrun simctl list runtimes
           echo "Destinations for testing:"
-          xcodebuild test-without-building -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -showdestinations
+          xcodebuild test-without-building -testPlan UnitTestsPlan -scheme whisperkit-Package -showdestinations
       - name: Boot Simulator and Wait
         if: ${{ matrix.run-config['condition'] == true }} && ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-15' }}
         # Slower runners require some time to fully boot the simulator
@@ -92,7 +98,7 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild clean build-for-testing -scheme whisperkit-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcpretty
-          xcodebuild test -only-testing WhisperKitTests/UnitTests -scheme whisperkit-Package -destination '${{ matrix.run-config['test-destination'] }}'
+          xcodebuild test -testPlan UnitTestsPlan -scheme whisperkit-Package -destination '${{ matrix.run-config['test-destination'] }}'
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,9 +26,6 @@ jobs:
   unit-tests:
     name: "${{ matrix.run-config['name'] }} on ${{ inputs.macos-runner }}"
     runs-on: ${{ inputs.macos-runner }}
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ inputs.macos-runner }}
-      cancel-in-progress: true
     strategy:
       matrix:
         run-config:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/whisperkit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/whisperkit-Package.xcscheme
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WhisperKit"
+               BuildableName = "WhisperKit"
+               BlueprintName = "WhisperKit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WhisperKitTests"
+               BuildableName = "WhisperKitTests"
+               BlueprintName = "WhisperKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "whisperkit-cli"
+               BuildableName = "whisperkit-cli"
+               BlueprintName = "whisperkit-cli"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/WhisperKitTests/UnitTestsPlan.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WhisperKitTests"
+               BuildableName = "WhisperKitTests"
+               BlueprintName = "WhisperKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "whisperkit-cli"
+            BuildableName = "whisperkit-cli"
+            BlueprintName = "whisperkit-cli"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "whisperkit-cli"
+            BuildableName = "whisperkit-cli"
+            BlueprintName = "whisperkit-cli"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/WhisperKit/Core/Text/SegmentSeeker.swift
+++ b/Sources/WhisperKit/Core/Text/SegmentSeeker.swift
@@ -285,11 +285,14 @@ open class SegmentSeeker: SegmentSeeking {
         prepended: String = Constants.defaultPrependPunctuations,
         appended: String = Constants.defaultAppendPunctuations
     ) -> [WordTiming] {
+        guard !alignment.isEmpty else {
+            return []
+        }
         var prependedAlignment = [WordTiming]()
         var appendedAlignment = [WordTiming]()
 
         // Include the first word if it's not a prepended punctuation
-        if !alignment.isEmpty && !prepended.contains(alignment[0].word.trimmingCharacters(in: .whitespaces)) {
+        if !prepended.contains(alignment[0].word.trimmingCharacters(in: .whitespaces)) {
             prependedAlignment.append(alignment[0])
         }
 
@@ -304,7 +307,11 @@ open class SegmentSeeker: SegmentSeeking {
             {
                 currentWord.word = previousWord.word + currentWord.word
                 currentWord.tokens = previousWord.tokens + currentWord.tokens
-                prependedAlignment[prependedAlignment.count - 1] = currentWord
+                if prependedAlignment.isEmpty {
+                    prependedAlignment.append(currentWord)
+                } else {
+                    prependedAlignment[prependedAlignment.count - 1] = currentWord
+                }
             } else {
                 prependedAlignment.append(currentWord)
             }

--- a/Sources/WhisperKit/Utilities/Extensions+Public.swift
+++ b/Sources/WhisperKit/Utilities/Extensions+Public.swift
@@ -297,3 +297,12 @@ public extension FileManager {
 public func resolveAbsolutePath(_ inputPath: String) -> String {
     return FileManager.resolveAbsolutePath(inputPath)
 }
+
+
+@available(*, deprecated, message: "Subject to removal in a future version. Use `ModelUtilities.formatModelFiles(_:)` instead.")
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+public extension WhisperKit {
+    static func formatModelFiles(_ modelFiles: [String]) -> [String] {
+        return ModelUtilities.formatModelFiles(modelFiles)
+    }
+}

--- a/Tests/WhisperKitTests/Resources/config-v04.json
+++ b/Tests/WhisperKitTests/Resources/config-v04.json
@@ -1,0 +1,218 @@
+{
+    "name": "whisperkit-coreml",
+    "version": "0.4",
+    "device_support": [
+        {
+            "chips": "A12, A13, S9, S10",
+            "identifiers": [
+                "iPhone11",
+                "iPhone12",
+                "iPad12,1",
+                "iPad12,2",
+                "Watch7",
+                "Watch8"
+            ],
+            "models": {
+                "default": "openai_whisper-tiny",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en"
+                ]
+            }
+        },
+        {
+            "chips": "A16, A17 Pro, A18",
+            "identifiers": [
+                "iPhone15",
+                "iPhone16",
+                "iPhone17",
+                "iPad15,7",
+                "iPad15,8",
+                "iPad16,1",
+                "iPad16,2"
+            ],
+            "models": {
+                "default": "openai_whisper-base",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v2_turbo_955MB",
+                    "openai_whisper-large-v3_947MB",
+                    "openai_whisper-large-v3_turbo_954MB",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "distil-whisper_distil-large-v3_turbo_600MB",
+                    "openai_whisper-large-v3-v20240930_626MB",
+                    "openai_whisper-large-v3-v20240930_turbo_632MB"
+                ]
+            }
+        },
+        {
+            "chips": "M1",
+            "identifiers": [
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "MacBookAir10,1",
+                "Macmini9,1",
+                "iMac21,1",
+                "iMac21,2",
+                "Mac13",
+                "iPad13,4",
+                "iPad13,5",
+                "iPad13,6",
+                "iPad13,7",
+                "iPad13,8",
+                "iPad13,9",
+                "iPad13,10",
+                "iPad13,11",
+                "iPad13,16",
+                "iPad13,17"
+            ],
+            "models": {
+                "default": "openai_whisper-large-v3-v20240930_626MB",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v3",
+                    "openai_whisper-large-v3_947MB",
+                    "distil-whisper_distil-large-v3",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "openai_whisper-large-v3-v20240930_626MB"
+                ]
+            }
+        },
+        {
+            "chips": "M2, M3, M4",
+            "identifiers": [
+                "Mac14",
+                "Mac15",
+                "Mac16",
+                "iPad14,3",
+                "iPad14,4",
+                "iPad14,5",
+                "iPad14,6",
+                "iPad14,8",
+                "iPad14,9",
+                "iPad14,10",
+                "iPad14,11",
+                "iPad15",
+                "iPad16"
+            ],
+            "models": {
+                "default": "openai_whisper-large-v3-v20240930",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v2_turbo",
+                    "openai_whisper-large-v2_turbo_955MB",
+                    "openai_whisper-large-v3",
+                    "openai_whisper-large-v3_947MB",
+                    "openai_whisper-large-v3_turbo",
+                    "openai_whisper-large-v3_turbo_954MB",
+                    "distil-whisper_distil-large-v3",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "distil-whisper_distil-large-v3_turbo",
+                    "distil-whisper_distil-large-v3_turbo_600MB",
+                    "openai_whisper-large-v3-v20240930",
+                    "openai_whisper-large-v3-v20240930_turbo",
+                    "openai_whisper-large-v3-v20240930_626MB",
+                    "openai_whisper-large-v3-v20240930_turbo_632MB"
+                ]
+            }
+        },
+        {
+            "chips": "A14",
+            "identifiers": [
+                "iPhone13",
+                "iPad13,1",
+                "iPad13,2",
+                "iPad13,18",
+                "iPad13,19"
+            ],
+            "models": {
+                "default": "openai_whisper-base",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en"
+                ]
+            }
+        },
+        {
+            "chips": "A15",
+            "identifiers": [
+                "iPhone14",
+                "iPad14,1",
+                "iPad14,2"
+            ],
+            "models": {
+                "default": "openai_whisper-base",
+                "supported": [
+                    "openai_whisper-tiny",
+                    "openai_whisper-tiny.en",
+                    "openai_whisper-base",
+                    "openai_whisper-base.en",
+                    "openai_whisper-small",
+                    "openai_whisper-small.en",
+                    "openai_whisper-large-v2_949MB",
+                    "openai_whisper-large-v2_turbo_955MB",
+                    "openai_whisper-large-v3_947MB",
+                    "openai_whisper-large-v3_turbo_954MB",
+                    "distil-whisper_distil-large-v3_594MB",
+                    "distil-whisper_distil-large-v3_turbo_600MB",
+                    "openai_whisper-large-v3-v20240930_626MB",
+                    "openai_whisper-large-v3-v20240930_turbo_632MB"
+                ]
+            }
+        }
+    ],
+    "model_checksums": {
+        "distil-whisper_distil-large-v3": "9cd8271143b919402ae776c30b479565",
+        "distil-whisper_distil-large-v3_594MB": "ca532f45ddbf8a3d241132cc5cf41639",
+        "distil-whisper_distil-large-v3_turbo": "b8638452c6568dfe33a33bfcc2bc6aca",
+        "distil-whisper_distil-large-v3_turbo_600MB": "81746b4b1afbbb01a8ae9ea452460d88",
+        "openai_whisper-base.en": "fbcfd586f15e2952251b1d3257f18471",
+        "openai_whisper-base": "36e60501ad0f01c1a5719e83a1f63f20",
+        "openai_whisper-large-v2": "21b86c07318aeeef54598f15b7903979",
+        "openai_whisper-large-v2_949MB": "71bad4e1566749d1060eda42308d9fb4",
+        "openai_whisper-large-v2_turbo": "7734959b6550e7b5c2d732bf2b7acd23",
+        "openai_whisper-large-v2_turbo_955MB": "cb6411862a48ec75325572081f01e5b5",
+        "openai_whisper-large-v3-v20240930": "17ebd78ff7edfa59001b554e9cc4c021",
+        "openai_whisper-large-v3-v20240930_547MB": "c945dad68449ac3c78ecb2d561ac189d",
+        "openai_whisper-large-v3-v20240930_626MB": "578fe5a07f4eb7e4187c920bca571aa5",
+        "openai_whisper-large-v3-v20240930_turbo": "dfbf09ab741af1d5400ddbd07bb37dad",
+        "openai_whisper-large-v3-v20240930_turbo_632MB": "33954440dbd785ca1828afe25514f5a5",
+        "openai_whisper-large-v3": "a6f24dc72785722e9cea89e227856dfe",
+        "openai_whisper-large-v3_947MB": "ef6b0e9622a046ce2361b4c72307877f",
+        "openai_whisper-large-v3_turbo": "c550fbdea70c5784d322c0a427f8b5cd",
+        "openai_whisper-large-v3_turbo_954MB": "e639c4bb98d905064ef5dd38757dd9d1",
+        "openai_whisper-small.en": "38efe6a00706bbdb995795c67a836e5e",
+        "openai_whisper-small": "f1d21adb950bc9be5d5343bcdeccd23b",
+        "openai_whisper-tiny.en": "e1183fd55448923b1ce43a2da67aa21f",
+        "openai_whisper-tiny": "7147518a3d68ddbea0691e04cfffa4ff"
+    }
+}

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -2249,8 +2249,12 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(audioChunks.count, 3)
     }
 
-    #if !os(watchOS) // FIXME: These tests are flaky out on watchOS
+    #if !os(watchOS) // FIXME: These tests are flaky
     func testVADAudioChunkerAccuracy() async throws {
+        guard #available(macOS 15, iOS 18, watchOS 11, visionOS 2, *) else {
+            throw XCTSkip("Disabled on macOS 14 and below due to swift concurrency flakiness")
+        }
+        
         let options = DecodingOptions(temperatureFallbackCount: 0, chunkingStrategy: .vad)
 
         let chunkedResult = try await XCTUnwrapAsync(

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1785,7 +1785,7 @@ final class UnitTests: XCTestCase {
             // Assert that more tokens are returned in the callback with waiting
             XCTAssertGreaterThanOrEqual(tokenCountWithWait, 30, "Tokens for callback with wait should contain the full audio file")
 
-            #if os(watchOS) || os(iOS) // FIXME: Some OS ignore the priority here on github action runners for some reason
+            #if !os(macOS) // FIXME: Some OS ignore the priority here on github action runners for some reason
             XCTAssertGreaterThanOrEqual(tokenCountWithWait, tokenCountWithEarlyStop, "More tokens should be returned in the callback with waiting (early stop: \(tokenCountWithEarlyStop), with wait: \(tokenCountWithWait))")
             #else
             XCTAssertGreaterThan(tokenCountWithWait, tokenCountWithEarlyStop, "More tokens should be returned in the callback with waiting (early stop: \(tokenCountWithEarlyStop), with wait: \(tokenCountWithWait))")

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -37,7 +37,7 @@ final class UnitTests: XCTestCase {
     func testModelSupportConfigFallback() {
         let fallbackRepoConfig = Constants.fallbackModelSupportConfig
         XCTAssertEqual(fallbackRepoConfig.repoName, "whisperkit-coreml-fallback")
-        XCTAssertEqual(fallbackRepoConfig.repoVersion, "0.3")
+        XCTAssertEqual(fallbackRepoConfig.repoVersion, "0.4")
         XCTAssertGreaterThanOrEqual(fallbackRepoConfig.deviceSupports.count, 5)
 
         // Test that all device supports have their disabled models set except devices that should support all known models
@@ -72,7 +72,7 @@ final class UnitTests: XCTestCase {
         // Support from same repo should be merged
         XCTAssertEqual(sameRepoConfig.repoName, "whisperkit-coreml")
         XCTAssertEqual(sameRepoConfig.repoVersion, "0.3")
-        XCTAssertEqual(sameRepoConfig.deviceSupports.count, 6)
+        XCTAssertEqual(sameRepoConfig.deviceSupports.count, 7)
 
         let differentRepoConfig = ModelSupportConfig(
             repoName: "whisperkit-somerepo",
@@ -91,38 +91,10 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(differentRepoConfig.repoVersion, "0.3")
         XCTAssertEqual(differentRepoConfig.deviceSupports.count, 1)
     }
-
-    func testModelSupportConfigv02FromJson() throws {
+    
+    func testModelSupportConfigFromJson() throws {
         let configFilePath = try XCTUnwrap(
-            Bundle.current(for: self).path(forResource: "config-v02", ofType: "json"),
-            "Config file not found"
-        )
-
-        let jsonData = try Data(contentsOf: URL(fileURLWithPath: configFilePath))
-        let decoder = JSONDecoder()
-        let loadedConfig = try decoder.decode(ModelSupportConfig.self, from: jsonData)
-
-        // Compare loaded config with fallback config
-        XCTAssertEqual(loadedConfig.repoName, "whisperkit-coreml")
-        XCTAssertLessThan(loadedConfig.repoVersion, Constants.fallbackModelSupportConfig.repoVersion)
-        XCTAssertEqual(loadedConfig.deviceSupports.count, Constants.fallbackModelSupportConfig.deviceSupports.count)
-
-        // Compare device supports
-        for (loadedDeviceSupport, fallbackDeviceSupport) in zip(loadedConfig.deviceSupports, Constants.fallbackModelSupportConfig.deviceSupports) {
-            let loadedSupport = Set(loadedDeviceSupport.models.supported)
-            let fallbackSupport = Set(fallbackDeviceSupport.models.supported)
-            let loadedDisabled = Set(loadedDeviceSupport.models.disabled)
-            let fallbackDisabled = Set(fallbackDeviceSupport.models.disabled)
-            XCTAssertTrue(loadedSupport.isSubset(of: fallbackSupport),
-                          "Supported models should be a subset of fallback models for \(loadedDeviceSupport.identifiers), found missing model(s): \(loadedSupport.subtracting(fallbackSupport))")
-            XCTAssertTrue(loadedDisabled.isSubset(of: fallbackDisabled),
-                          "Disabled models should be a subset of fallback models for \(loadedDeviceSupport.identifiers), found missing model(s): \(loadedDisabled.subtracting(fallbackDisabled))")
-        }
-    }
-
-    func testModelSupportConfigv03FromJson() throws {
-        let configFilePath = try XCTUnwrap(
-            Bundle.current(for: self).path(forResource: "config-v03", ofType: "json"),
+            Bundle.current(for: self).path(forResource: "config-v04", ofType: "json"),
             "Config file not found"
         )
 
@@ -883,6 +855,373 @@ final class UnitTests: XCTestCase {
     }
 
     // MARK: - Tokenizer Tests
+    
+    func testTokenizerFolderFromConfig() async throws {
+        // Default case, no tokenizer folder specified - should download from Hub
+        let configWithNoTokenizerFolder = WhisperKitConfig(
+            model: "tiny",
+            load: false,
+            download: false
+        )
+        
+        let whisperKitDefault = try await WhisperKit(configWithNoTokenizerFolder)
+        XCTAssertNil(whisperKitDefault.tokenizerFolder, "tokenizerFolder should be nil when not specified and no downloadBase provided")
+        
+        // Tokenizer folder specified without model folder
+        let tempDir = FileManager.default.temporaryDirectory
+        let tokenizerFolder = tempDir.appendingPathComponent("tokenizer_folder_\(UUID().uuidString)")
+        let configWithTokenizerFolder = WhisperKitConfig(
+            model: "tiny",
+            tokenizerFolder: tokenizerFolder,
+            load: false,
+            download: false
+        )
+        
+        let whisperKitWithTokenizerFolder = try await WhisperKit(configWithTokenizerFolder)
+        XCTAssertEqual(whisperKitWithTokenizerFolder.tokenizerFolder?.path, tokenizerFolder.path, "tokenizerFolder should exactly match specified folder path")
+        
+        // Tokenizer folder and model folder specified
+        let modelFolder = tempDir.appendingPathComponent("model_folder_\(UUID().uuidString)")
+        let tokenizerFolderWithModelFolder = tempDir.appendingPathComponent("tokenizer_folder_\(UUID().uuidString)")
+        
+        let configWithTokenizerAndModelFolder = WhisperKitConfig(
+            model: "tiny",
+            modelFolder: modelFolder.path,
+            tokenizerFolder: tokenizerFolderWithModelFolder,
+            load: false,
+            download: false
+        )
+        
+        let whisperKitWithBothFolders = try await WhisperKit(configWithTokenizerAndModelFolder)
+        XCTAssertEqual(whisperKitWithBothFolders.tokenizerFolder?.path, tokenizerFolderWithModelFolder.path, "tokenizerFolder should exactly match specified folder, not model folder")
+        XCTAssertNotEqual(whisperKitWithBothFolders.tokenizerFolder?.path, modelFolder.path, "tokenizerFolder should not be the same as model folder")
+        
+        // Model folder specified without tokenizer folder
+        let modelFolderOnly = tempDir.appendingPathComponent("model_folder_\(UUID().uuidString)")
+        
+        let configWithModelFolderOnly = WhisperKitConfig(
+            model: "tiny",
+            modelFolder: modelFolderOnly.path,
+            load: false,
+            download: false
+        )
+        
+        let whisperKitWithModelFolderOnly = try await WhisperKit(configWithModelFolderOnly)
+        XCTAssertNil(whisperKitWithModelFolderOnly.tokenizerFolder, "tokenizerFolder should be nil when only model folder specified without downloadBase")
+        
+        // Model folder and download base specified
+        let downloadBase = tempDir.appendingPathComponent("download_base_\(UUID().uuidString)")
+        let modelFolderWithDownloadBase = tempDir.appendingPathComponent("model_folder_\(UUID().uuidString)")
+        
+        let configWithModelFolderAndDownloadBase = WhisperKitConfig(
+            model: "tiny",
+            downloadBase: downloadBase,
+            modelFolder: modelFolderWithDownloadBase.path,
+            load: false,
+            download: false
+        )
+        
+        let whisperKitWithModelFolderAndDownloadBase = try await WhisperKit(configWithModelFolderAndDownloadBase)
+        XCTAssertEqual(whisperKitWithModelFolderAndDownloadBase.tokenizerFolder?.path, downloadBase.path, "tokenizerFolder should exactly match downloadBase path")
+        XCTAssertNotEqual(whisperKitWithModelFolderAndDownloadBase.tokenizerFolder?.path, modelFolderWithDownloadBase.path, "tokenizerFolder should not be the same as model folder")
+        
+        // Download base specified only
+        let downloadBaseOnly = tempDir.appendingPathComponent("download_base_\(UUID().uuidString)")
+        
+        let configWithDownloadBaseOnly = WhisperKitConfig(
+            model: "tiny",
+            downloadBase: downloadBaseOnly,
+            load: false,
+            download: false
+        )
+        
+        let whisperKitWithDownloadBaseOnly = try await WhisperKit(configWithDownloadBaseOnly)
+        XCTAssertEqual(whisperKitWithDownloadBaseOnly.tokenizerFolder?.path, downloadBaseOnly.path, "tokenizerFolder should fall back to downloadBase when not explicitly set")
+    }
+    
+    func testTokenizerLoadingPriority() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("tokenizer_loading_test_folder_\(UUID().uuidString)")
+        
+        // Test tokenizer folder resolution priority
+        let repoStyleDir = tempDir.appendingPathComponent("models")
+            .appendingPathComponent("openai")
+            .appendingPathComponent("whisper-tiny")
+        
+        // Download the tokenizer first
+        let repoTokenizer = try await ModelUtilities.loadTokenizer(
+            for: .tiny,
+            tokenizerFolder: tempDir,
+            useBackgroundSession: false
+        ) as! WhisperTokenizerWrapper
+        XCTAssertEqual(repoTokenizer.tokenizerFolder?.path, repoStyleDir.path, "tokenizerFolder should exactly match repoStyleDir path")
+        
+        // Check that direct loading from the top level of the directory is prioritized when no repo style exists (tokenizer already exists here)
+        let tokenizer = try await ModelUtilities.loadTokenizer(
+            for: .tiny,
+            tokenizerFolder: repoStyleDir,
+            useBackgroundSession: false
+        ) as! WhisperTokenizerWrapper
+        XCTAssertEqual(tokenizer.tokenizerFolder?.path, repoStyleDir.path, "tokenizerFolder should exactly match repoStyleDir path")
+        
+        // Move the tokenizer files to the top level
+        let repoContents = try FileManager.default.contentsOfDirectory(at: repoStyleDir, includingPropertiesForKeys: nil)
+        for item in repoContents {
+            let destination = tempDir.appendingPathComponent(item.lastPathComponent)
+            try FileManager.default.copyItem(at: item, to: destination)
+        }
+        
+        // Check that when the tokenizer is both at the top level and in the repo style location, the repo style is prioritized
+        // Loading from the top level is considered a fallback and simplifies offline use cases
+        let tokenizerAtTopLevel = try await ModelUtilities.loadTokenizer(
+            for: .tiny,
+            tokenizerFolder: tempDir,
+            useBackgroundSession: false
+        ) as! WhisperTokenizerWrapper
+        XCTAssertEqual(tokenizerAtTopLevel.tokenizerFolder?.path, repoStyleDir.path, "tokenizerFolder should exactly match repoStyleDir path")
+    }
+    
+        func testTokenizerLoadingFromDifferentVariants() async throws {
+        // Test that different model variants resolve to correct tokenizer names
+        for variant in ModelVariant.allCases {
+            let expectedName = "openai/whisper-\(variant.description)"
+            let tokenizer = try await ModelUtilities.loadTokenizer(
+                for: variant,
+                tokenizerFolder: nil,
+                useBackgroundSession: false
+            ) as! WhisperTokenizerWrapper
+            XCTAssertNotNil(tokenizer, "Should load tokenizer for variant \(variant)")
+            XCTAssertTrue(tokenizer.tokenizerFolder!.path.contains(expectedName), "Tokenizer folder should contain \(expectedName)")
+            
+            // Test that the tokenizer has expected properties
+            XCTAssertGreaterThan(tokenizer.specialTokens.specialTokenBegin, 0, "Special token begin should be set")
+            XCTAssertNotNil(tokenizer.encode(text: "test"), "Should be able to encode text")
+            XCTAssertNotNil(tokenizer.decode(tokens: [1, 2, 3]), "Should be able to decode tokens")
+        }
+    }
+        
+    func testTokenizerLoadingFromWhisperKit() async throws {
+        // Test that tokenizer is properly loaded and assigned during WhisperKit model loading
+        let config = WhisperKitConfig(
+            model: "tiny",
+            verbose: true,
+            logLevel: .debug,
+            load: true
+        )
+        
+        let whisperKit = try await WhisperKit(config)
+        
+        // Verify tokenizer was loaded
+        XCTAssertNotNil(whisperKit.tokenizer, "Tokenizer should be loaded after model loading")
+        XCTAssertNotNil(whisperKit.textDecoder.tokenizer, "TextDecoder should have tokenizer assigned")
+        
+        // Load a tokenizer that should match
+        let tokenizer = try await ModelUtilities.loadTokenizer(
+            for: .tiny
+        ) as! WhisperTokenizerWrapper
+        
+        // Verify tokenizer location
+        XCTAssertEqual((whisperKit.tokenizer as! WhisperTokenizerWrapper).tokenizerFolder!.path, tokenizer.tokenizerFolder!.path)
+        
+        // Verify tokenizer functionality
+        if let tokenizer = whisperKit.tokenizer {
+            let testText = "Hello world"
+            let encoded = tokenizer.encode(text: testText)
+            XCTAssertFalse(encoded.isEmpty, "Should encode text to tokens")
+            
+            let decoded = tokenizer.decode(tokens: encoded)
+            XCTAssertFalse(decoded.isEmpty, "Should decode tokens back to text")
+            
+            // Test special token access
+            XCTAssertGreaterThan(tokenizer.specialTokens.endToken, 0, "End token should be valid")
+            XCTAssertGreaterThan(tokenizer.specialTokens.startOfTranscriptToken, 0, "Start of transcript token should be valid")
+            
+            // Test token conversion
+            let startToken = "<|startoftranscript|>"
+            if let tokenId = tokenizer.convertTokenToId(startToken) {
+                let convertedBack = tokenizer.convertIdToToken(tokenId)
+                XCTAssertEqual(convertedBack, startToken, "Token conversion should be reversible")
+            }
+        }
+    }
+    
+    func testTokenizerFallbackToHubWhenLocalFails() async throws {
+        // Test scenario where local tokenizer loading fails and falls back to Hub
+        let tempDir = FileManager.default.temporaryDirectory
+        let corruptedTokenizerDir = tempDir.appendingPathComponent("corrupted_tokenizer")
+        
+        try FileManager.default.createDirectory(at: corruptedTokenizerDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: corruptedTokenizerDir)
+        }
+        
+        // Create a corrupted tokenizer.json file
+        let corruptedJson = "{ invalid json content"
+        let tokenizerFile = corruptedTokenizerDir.appendingPathComponent("tokenizer.json")
+        try corruptedJson.write(to: tokenizerFile, atomically: true, encoding: .utf8)
+        let configFile = corruptedTokenizerDir.appendingPathComponent("config.json")
+        try corruptedJson.write(to: configFile, atomically: true, encoding: .utf8)
+        
+        // This should fail to load locally and fall back to Hub
+        do {
+            let tokenizer = try await ModelUtilities.loadTokenizer(
+                for: .tiny,
+                tokenizerFolder: corruptedTokenizerDir,
+                useBackgroundSession: false
+            )
+            XCTAssertNotNil(tokenizer, "Should successfully fall back to Hub when local loading fails")
+        } catch {
+            // If Hub download also fails, that's acceptable in test environment
+            Logging.debug("Both local and Hub loading failed: \(error)")
+        }
+    }
+    
+    func testTokenizerModelVariantDetection() async throws {
+        // Test that model variant detection works correctly for tokenizer selection
+        let testDimensions: [(logitsDim: Int, encoderDim: Int, expectedVariant: ModelVariant)] = [
+            (51865, 384, .tiny),      // Multilingual tiny
+            (51864, 384, .tinyEn),    // English tiny
+            (51865, 512, .base),      // Multilingual base
+            (51864, 512, .baseEn),    // English base
+            (51865, 768, .small),     // Multilingual small
+            (51864, 768, .smallEn),   // English small
+            (51865, 1024, .medium),   // Multilingual medium
+            (51864, 1024, .mediumEn), // English medium
+            (51865, 1280, .largev2),  // Large v2
+            (51866, 1280, .largev3)   // Large v3 (has extra language token)
+        ]
+        
+        for (logitsDim, encoderDim, expectedVariant) in testDimensions {
+            let detectedVariant = ModelUtilities.detectVariant(logitsDim: logitsDim, encoderDim: encoderDim)
+            XCTAssertEqual(detectedVariant, expectedVariant, 
+                          "Should detect \(expectedVariant) for logitsDim: \(logitsDim), encoderDim: \(encoderDim)")
+            
+            let isMultilingual = ModelUtilities.isModelMultilingual(logitsDim: logitsDim)
+            XCTAssertEqual(isMultilingual, expectedVariant.isMultilingual, 
+                          "Multilingual detection should match variant for \(expectedVariant)")
+        }
+    }
+    
+    func testTokenizerLoadingThroughModelLoading() async throws {
+        // Test tokenizer loading through WhisperKit model loading process
+        let config = WhisperKitConfig(
+            model: "tiny",
+            verbose: true,
+            logLevel: .debug,
+            load: true,
+            download: true
+        )
+        
+        let whisperKit = try await WhisperKit(config)
+        
+        // Verify tokenizer was loaded through model loading
+        XCTAssertNotNil(whisperKit.tokenizer, "Tokenizer should be loaded after calling loadModels")
+        XCTAssertNotNil(whisperKit.textDecoder.tokenizer, "TextDecoder should have tokenizer assigned")
+        XCTAssertEqual(whisperKit.modelVariant, .tiny, "Model variant should be detected as tiny")
+        
+        // Verify tokenizer properties specific to tiny model
+        guard let tokenizer = whisperKit.tokenizer else {
+            XCTFail("Tokenizer should not be nil")
+            return
+        }
+        
+        // Test that the tokenizer works with the loaded model
+        let testEncoding = tokenizer.encode(text: "Hello world")
+        XCTAssertFalse(testEncoding.isEmpty, "Should be able to encode text")
+        
+        let testDecoding = tokenizer.decode(tokens: testEncoding)
+        XCTAssertFalse(testDecoding.isEmpty, "Should be able to decode tokens")
+        
+        // Test special tokens are properly configured
+        XCTAssertGreaterThan(tokenizer.specialTokens.specialTokenBegin, 50000, "Special tokens should start after vocab")
+        XCTAssertEqual(tokenizer.specialTokens.endToken, 50257, "End token should match expected value for tiny model")
+        
+        // Test that model dimensions match tokenizer expectations
+        XCTAssertEqual(whisperKit.textDecoder.isModelMultilingual, true, "Tiny model should be detected as multilingual")
+        XCTAssertFalse(tokenizer.allLanguageTokens.isEmpty, "Multilingual model should have language tokens")
+    }
+    
+    func testTokenizerLoadingWithCustomTokenizerFolder() async throws {
+        // Test tokenizer loading with custom tokenizer folder at model load time
+        let modelPath = try await tinyModelPath()
+        let modelURL = URL(filePath: modelPath)
+        
+        // Create a different directory for tokenizer to ensure it's not defaulting to model folder
+        let tempDir = FileManager.default.temporaryDirectory
+        let customTokenizerDir = tempDir.appendingPathComponent("custom_tokenizer_test_\(UUID().uuidString)")
+        
+        let config = WhisperKitConfig(
+            modelFolder: modelPath,
+            tokenizerFolder: customTokenizerDir,
+            verbose: true,
+            logLevel: .debug,
+            load: true,
+            download: false
+        )
+        
+        let whisperKit = try await WhisperKit(config)
+        
+        // Verify tokenizer folder was set to our custom directory
+        XCTAssertEqual(whisperKit.tokenizerFolder?.path, customTokenizerDir.path, "Tokenizer folder should exactly match custom configured folder")
+        XCTAssertNotEqual(whisperKit.tokenizerFolder?.path, modelURL.path, "Tokenizer folder should NOT be the same as model folder")
+        XCTAssertEqual(whisperKit.modelFolder?.path, modelPath, "Model folder should match the specified model path")
+        
+        // Verify tokenizer was loaded (will fall back to hub download since custom dir doesn't exist)
+        XCTAssertNotNil(whisperKit.tokenizer, "Tokenizer should be loaded even with custom folder (fallback to hub download)")
+        
+        // Check the actual path used by the tokenizer wrapper
+        if let wrapper = whisperKit.tokenizer as? WhisperTokenizerWrapper {
+            XCTAssertNotNil(wrapper.tokenizerFolder, "Tokenizer wrapper should record the folder path used")
+            
+            // The wrapper should record the Hub path that was actually used
+            let expectedHubPath = customTokenizerDir.appendingPathComponent("models/openai/whisper-tiny")
+            XCTAssertEqual(wrapper.tokenizerFolder?.path, expectedHubPath.path,
+                          "Tokenizer wrapper should record the exact Hub path based on custom directory")
+        }
+        
+        // Test that the tokenizer works correctly
+        if let tokenizer = whisperKit.tokenizer {
+            let encoded = tokenizer.encode(text: "Test text")
+            let decoded = tokenizer.decode(tokens: encoded)
+            XCTAssertFalse(encoded.isEmpty, "Should encode text")
+            XCTAssertFalse(decoded.isEmpty, "Should decode tokens")
+        }
+    }
+    
+    func testTokenizerLoadingWithModelDimensionDetection() async throws {
+        // Test that tokenizer is selected based on actual model dimensions
+        let modelPath = try await tinyModelPath()
+        
+        let config = WhisperKitConfig(
+            modelFolder: modelPath,
+            verbose: true,
+            logLevel: .debug,
+            load: true,
+            download: false
+        )
+        
+        let whisperKit = try await WhisperKit(config)
+        
+        // Verify model variant was detected from loaded model dimensions
+        XCTAssertEqual(whisperKit.modelVariant, .tiny, "Should detect tiny variant from model dimensions")
+        
+        // Verify tokenizer matches detected variant
+        XCTAssertNotNil(whisperKit.tokenizer, "Tokenizer should be loaded based on detected variant")
+        
+        // Verify the TextDecoder has correct multilingual setting
+        XCTAssertTrue(whisperKit.textDecoder.isModelMultilingual, "Tiny model should be multilingual")
+        
+        // Test that tokenizer special tokens match the model expectations
+        if let tokenizer = whisperKit.textDecoder.tokenizer {
+            // Test some specific tokens that should exist in tiny model
+            let transcribeToken = tokenizer.convertTokenToId("<|transcribe|>")
+            let englishToken = tokenizer.convertTokenToId("<|en|>")
+            
+            XCTAssertNotNil(transcribeToken, "Should have transcribe token")
+            XCTAssertNotNil(englishToken, "Should have English language token")
+            XCTAssertTrue(tokenizer.allLanguageTokens.contains(englishToken!), "English token should be in language tokens set")
+        }
+    }
 
     func testDecoderTokenizer() async throws {
         // This token index does not change with v3
@@ -1416,7 +1755,9 @@ final class UnitTests: XCTestCase {
             let earlyStopTokenCount = 10
             let continuationCallback: TranscriptionCallback = { (progress: TranscriptionProgress) -> Bool? in
                 // Stop after only 10 tokens (full test audio contains ~30)
-                progress.tokens.count <= earlyStopTokenCount
+                let shouldContinue = progress.tokens.count <= earlyStopTokenCount
+                Logging.debug("\(shouldContinue ? "Continuing" : "Early stopping") after \(progress.tokens.count) tokens")
+                return shouldContinue
             }
 
             let result = try await whisperKit.transcribe(audioPath: audioFilePath, callback: continuationCallback).first!
@@ -1908,6 +2249,7 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(audioChunks.count, 3)
     }
 
+    #if !os(watchOS) // FIXME: These tests are flaky out on watchOS
     func testVADAudioChunkerAccuracy() async throws {
         let options = DecodingOptions(temperatureFallbackCount: 0, chunkingStrategy: .vad)
 
@@ -1936,7 +2278,6 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(wer, 0.0, "Transcripts should match with a WER of 0, found \(wer). Full diff: \(diffDescription)")
     }
 
-    #if !os(watchOS) // FIXME: This test times out on watchOS when run on low compute runners
     func testVADProgress() async throws {
         let pipe = try await WhisperKit(WhisperKitConfig(model: "tiny.en"))
 

--- a/Tests/WhisperKitTests/UnitTestsPlan.xctestplan
+++ b/Tests/WhisperKitTests/UnitTestsPlan.xctestplan
@@ -1,0 +1,46 @@
+{
+  "configurations" : [
+    {
+      "id" : "427C492D-C19B-4C99-A90A-F4AEF0EC4B54",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "maximumTestRepetitions" : 3,
+    "testRepetitionMode" : "retryOnFailure",
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "FunctionalTests",
+        "FunctionalTests\/testAsyncImplementation()",
+        "FunctionalTests\/testBaseImplementation()",
+        "FunctionalTests\/testBatchTranscribeAudioArrays()",
+        "FunctionalTests\/testBatchTranscribeAudioPaths()",
+        "FunctionalTests\/testBatchTranscribeAudioPathsWithErrors()",
+        "FunctionalTests\/testInitLarge()",
+        "FunctionalTests\/testModelSearchPathLarge()",
+        "FunctionalTests\/testRealTimeFactorLarge()",
+        "FunctionalTests\/testRealTimeFactorTiny()",
+        "RegressionTests",
+        "RegressionTests\/testHirschberg()",
+        "RegressionTests\/testInMemoryAndDiskUsage()",
+        "RegressionTests\/testLargeWER()",
+        "RegressionTests\/testLevenshtein()",
+        "RegressionTests\/testModelPerformance()",
+        "RegressionTests\/testModelPerformanceWithDebugConfig()",
+        "RegressionTests\/testNormalizer()"
+      ],
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "WhisperKitTests",
+        "name" : "WhisperKitTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
This PR includes the following fixes and improvements:

- CI now uses pinned os versions for more devices as well as a test plan to retry flakey tests
- Default device support config has been update to match latest from remote
- Remote config and model endpoints now accept `remoteConfigName` as well as `endpoint` parameters 
- Tokenizer loading improvements:
    - The tokenizer loader will now search in more locations locally before attempting to download from huggingface, including the model path. 
    - There was a bug in the previous release which downloaded the tokenizer to the model path only, this fix will search for that location for backwards compatibility, but respect the `tokenizerFolder` if provided in the `WhisperKitConfig`, and downloadBase by default for downloading if needed.
- Fixed a bug in prepended punctuation merging if there was no initial value in cases where the input alignment words didn't start with a special token.