### PR TITLE
Add `Sendable` conformance to public structs

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -14,7 +14,7 @@ public typealias DeviceID = String
 #endif
 public typealias ChannelMode = AudioInputConfig.ChannelMode
 
-public struct AudioDevice: Identifiable, Hashable {
+public struct AudioDevice: Identifiable, Hashable, Sendable {
     public let id: DeviceID
     public let name: String
 
@@ -25,9 +25,9 @@ public struct AudioDevice: Identifiable, Hashable {
 }
 
 /// Configuration for audio input including device selection and channel processing options.
-public struct AudioInputConfig {
+public struct AudioInputConfig: Sendable {
     /// Specifies how to handle audio channels when processing multi-channel audio.
-    public enum ChannelMode: Hashable, Codable {
+    public enum ChannelMode: Hashable, Codable, Sendable {
         /// Selects a single specific channel by index.
         /// - Parameter index: The zero-based index of the channel to use.
         ///                    0 selects the first channel, 1 selects the second, etc.

--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -127,7 +127,7 @@ open class WhisperKitConfig {
 ///   - noSpeechThreshold: If the no speech probability is higher than this value AND the average log
 ///                        probability over sampled tokens is below `logProbThreshold`, consider the segment as silent.
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public struct DecodingOptions: Codable {
+public struct DecodingOptions: Codable, Sendable {
     public var verbose: Bool
     public var task: DecodingTask
     public var language: String?

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -135,7 +135,7 @@ public enum ModelState: CustomStringConvertible {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public struct ModelComputeOptions {
+public struct ModelComputeOptions: Sendable {
     public var melCompute: MLComputeUnits
     public var audioEncoderCompute: MLComputeUnits
     public var textDecoderCompute: MLComputeUnits
@@ -167,7 +167,7 @@ public struct ModelComputeOptions {
     }
 }
 
-public struct ModelSupport: Codable, Equatable {
+public struct ModelSupport: Codable, Equatable, Sendable {
     public let `default`: String
     public let supported: [String]
     /// Computed on init of ModelRepoConfig
@@ -188,7 +188,7 @@ public struct ModelSupport: Codable, Equatable {
     }
 }
 
-public struct DeviceSupport: Codable {
+public struct DeviceSupport: Codable, Sendable {
     /// Optional chip name string, intended for annotation only, e.g. "A16, A17"
     public let chips: String?
     /// Device identifiers, e.g. ["iPhone15,2", "iPhone15,3"]
@@ -203,7 +203,7 @@ public struct DeviceSupport: Codable {
     }
 }
 
-public struct ModelSupportConfig: Codable {
+public struct ModelSupportConfig: Codable, Sendable {
     public let repoName: String
     public let repoVersion: String
     public var deviceSupports: [DeviceSupport]
@@ -312,7 +312,7 @@ public struct ModelSupportConfig: Codable {
 
 // MARK: - Chunking
 
-public struct AudioChunk {
+public struct AudioChunk: Sendable {
     public var seekOffsetIndex: Int
     public var audioSamples: [Float]
 
@@ -325,7 +325,7 @@ public struct AudioChunk {
 // MARK: - Decoding
 
 @frozen
-public enum DecodingTask: Codable, CustomStringConvertible, CaseIterable {
+public enum DecodingTask: Codable, CustomStringConvertible, CaseIterable, Sendable {
     case transcribe
     case translate
 
@@ -410,7 +410,7 @@ public enum ChunkingStrategy: String, Codable, CaseIterable {
 }
 
 @available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-public struct DecodingFallback {
+public struct DecodingFallback: Sendable {
     public var needsFallback: Bool
     public var fallbackReason: String
 
@@ -508,7 +508,7 @@ public struct DecodingResult {
 
 // Structs
 
-public struct TranscriptionResult: Codable {
+public struct TranscriptionResult: Codable, Sendable {
     public var text: String
     public var segments: [TranscriptionSegment]
     public var language: String
@@ -611,7 +611,7 @@ public extension TranscriptionResult {
     }
 }
 
-public struct TranscriptionSegment: Hashable, Codable {
+public struct TranscriptionSegment: Hashable, Codable, Sendable {
     public var id: Int
     public var seek: Int
     public var start: Float
@@ -659,7 +659,7 @@ public struct TranscriptionSegment: Hashable, Codable {
     }
 }
 
-public struct WordTiming: Hashable, Codable {
+public struct WordTiming: Hashable, Codable, Sendable {
     public var word: String
     public var tokens: [Int]
     public var start: Float
@@ -680,7 +680,7 @@ public struct WordTiming: Hashable, Codable {
     }
 }
 
-public struct TranscriptionProgress {
+public struct TranscriptionProgress: Sendable {
     public var timings: TranscriptionTimings
     public var text: String
     public var tokens: [Int]
@@ -754,7 +754,7 @@ public enum TranscriptionState: CustomStringConvertible {
 /// - Note: This callback should be lightweight and return as quickly as possible to avoid extra decoding loops
 public typealias TranscriptionCallback = ((TranscriptionProgress) -> Bool?)?
 
-public struct TranscriptionTimings: Codable {
+public struct TranscriptionTimings: Codable, Sendable {
     public var pipelineStart: CFAbsoluteTime
     public var firstTokenTime: CFAbsoluteTime
     public var inputAudioSeconds: TimeInterval
@@ -1223,7 +1223,7 @@ public class TextDecoderCachePrefillOutput: MLFeatureProvider {
 
 // MARK: SpecialTokens
 
-public struct SpecialTokens {
+public struct SpecialTokens: Sendable {
     public let endToken: Int
     public let englishToken: Int
     public let noSpeechToken: Int

--- a/Sources/WhisperKit/Core/Text/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/Text/TokenSampler.swift
@@ -10,7 +10,7 @@ public protocol TokenSampling {
     func finalize(tokens: [Int], logProbs: [Float]) -> SamplingResult
 }
 
-public struct SamplingResult {
+public struct SamplingResult: Sendable {
     public var tokens: [Int]
     public var logProbs: [Float]
     public var completed: Bool


### PR DESCRIPTION
This pull request adds the `Sendable` protocol conformance to a number of core data structures throughout the WhisperKit codebase. This update improves the safety and correctness of concurrent code by ensuring these types can be safely passed across threads, which is particularly important for Swift Concurrency. No other functional changes are introduced.

Concurrency and thread safety improvements:

* Added `Sendable` conformance to key structs and enums related to audio processing, configuration, model support, and transcription, such as `AudioDevice`, `AudioInputConfig`, `DecodingOptions`, `ModelComputeOptions`, `ModelSupport`, `DeviceSupport`, `ModelSupportConfig`, `AudioChunk`, `DecodingTask`, `DecodingFallback`, `TranscriptionResult`, `TranscriptionSegment`, `WordTiming`, `TranscriptionProgress`, `TranscriptionTimings`, `SpecialTokens`, and `SamplingResult`.