### PR TITLE
Use default checkout setting in CI script for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,8 +56,6 @@ jobs:
     timeout-minutes: ${{ matrix.run-config['name'] == 'visionOS' && 60 || 30 }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ inputs.xcode-version || 'latest-stable' }}


### PR DESCRIPTION
This pull request makes a minor update to the unit test workflow configuration. The change removes the explicit checkout of the pull request head ref, simplifying the workflow setup.