### PR TITLE
Fix swift-transformers compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", .upToNextMinor(from: "0.1.8")),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ] + (isServerEnabled() ? [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.1"),

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -6,7 +6,6 @@ import AVFoundation
 import CoreML
 import Foundation
 import Hub
-import TensorUtils
 import Tokenizers
 
 open class WhisperKit {


### PR DESCRIPTION
Changes:
- Remove unused TensorUtils import from WhisperKit.swift TensorUtils was imported but never actually used in the codebase
- Update swift-transformers dependency from 0.1.8 to branch: main This resolves version conflicts with mlx-swift-examples

These changes make WhisperKit compatible with swift-transformers 1.0.0+ while maintaining all existing functionality.