### PR TITLE
Prepare for new swift-transformers, add TranscribeTask hooks

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,4 +1,4 @@
-name: Pre-Release Tests
+name: Release Tests
 
 on:
   push:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo "Simulators on runner:"
           xcrun simctl list
-          if [[ "${{ matrix.run-config['name'] }}" != "macOS" ]]; then
+          if [[ "${{ matrix.run-config['name'] }}" == "visionOS" ]]; then
             xcodebuild -downloadPlatform ${{ matrix.run-config['name'] }}
           fi
           echo "Runtimes for testing:"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # WhisperKit
 
-[![Tests](https://github.com/argmaxinc/whisperkit/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/argmaxinc/whisperkit/actions/workflows/pre-release-tests.yml)
+[![Tests](https://github.com/argmaxinc/whisperkit/actions/workflows/release-tests.yml/badge.svg)](https://github.com/argmaxinc/whisperkit/actions/workflows/release-tests.yml)
 [![License](https://img.shields.io/github/license/argmaxinc/whisperkit?logo=github&logoColor=969da4&label=License&labelColor=353a41&color=32d058)](LICENSE.md)
 [![Supported Swift Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fargmaxinc%2FWhisperKit%2Fbadge%3Ftype%3Dswift-versions&labelColor=353a41&color=32d058)](https://swiftpackageindex.com/argmaxinc/WhisperKit) [![Supported Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fargmaxinc%2FWhisperKit%2Fbadge%3Ftype%3Dplatforms&labelColor=353a41&color=32d058)](https://swiftpackageindex.com/argmaxinc/WhisperKit)
 [![Discord](https://img.shields.io/discord/1171912382512115722?style=flat&logo=discord&logoColor=969da4&label=Discord&labelColor=353a41&color=32d058&link=https%3A%2F%2Fdiscord.gg%2FG5F5GZGecC)](https://discord.gg/G5F5GZGecC)

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -355,8 +355,8 @@ public extension TextDecoding {
         {
             // Prefilling kv cache data requires non-nil task and language tokens, set defaults if not provided
             // Task tokens are remapped to 0->transcribe and 1->translate for the prefill lookup table
-            let task = MLMultiArray.from([taskToken == tokenizer.specialTokens.transcribeToken ? 0 : 1])
-            let lang = MLMultiArray.from([languageToken])
+            let task = try MLMultiArray.from([taskToken == tokenizer.specialTokens.transcribeToken ? 0 : 1])
+            let lang = try MLMultiArray.from([languageToken])
             guard let prefillOutput = try await self.prefillKVCache(withTask: task, andLanguage: lang) else {
                 Logging.error("Unable to prefill cache")
                 return prefilledDecoderInputs

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -6,7 +6,6 @@ import AVFoundation
 import CoreML
 import Foundation
 import Hub
-import TensorUtils
 import Tokenizers
 
 open class WhisperKit {
@@ -957,6 +956,29 @@ open class WhisperKit {
         return transcribeResults
     }
 
+    /// Setup the `TranscribeTask` used for decoding. Subclasses may override to provide custom behavior.
+    open func setupTranscribeTask(
+        currentTimings: TranscriptionTimings,
+        progress: Progress,
+        audioProcessor: any AudioProcessing,
+        audioEncoder: any AudioEncoding,
+        featureExtractor: any FeatureExtracting,
+        segmentSeeker: any SegmentSeeking,
+        textDecoder: any TextDecoding,
+        tokenizer: any WhisperTokenizer
+    ) -> TranscribeTask {
+        TranscribeTask(
+            currentTimings: currentTimings,
+            progress: progress,
+            audioProcessor: audioProcessor,
+            audioEncoder: audioEncoder,
+            featureExtractor: featureExtractor,
+            segmentSeeker: segmentSeeker,
+            textDecoder: textDecoder,
+            tokenizer: tokenizer
+        )
+    }
+
     /// Runs the transcription task on a single audio sample array asynchronously with custom segment callback.
     /// - Returns: An array of `TranscriptionResult`.
     /// - Throws: An error if the transcription fails or if the tokenizer is unavailable.
@@ -983,7 +1005,7 @@ open class WhisperKit {
             progress.totalUnitCount = max(1, progress.totalUnitCount)
             progress.addChild(childProgress, withPendingUnitCount: 1)
 
-            let transcribeTask = TranscribeTask(
+            let transcribeTask = setupTranscribeTask(
                 currentTimings: currentTimings,
                 progress: childProgress,
                 audioProcessor: audioProcessor,

--- a/Sources/WhisperKit/Utilities/Extensions+Internal.swift
+++ b/Sources/WhisperKit/Utilities/Extensions+Internal.swift
@@ -4,6 +4,24 @@
 import AVFoundation
 import CoreML
 
+extension MLMultiArray {
+    /// All values will be stored in the last dimension of the MLMultiArray (default is dims=1)
+    static func from(_ array: [Int], dims: Int = 1) throws -> MLMultiArray {
+        var shape = Array(repeating: 1, count: dims)
+        shape[shape.count - 1] = array.count
+        /// Examples:
+        /// dims=1 : [arr.count]
+        /// dims=2 : [1, arr.count]
+        ///
+        let output = try MLMultiArray(shape: shape as [NSNumber], dataType: .int32)
+        let pointer = UnsafeMutablePointer<Int32>(OpaquePointer(output.dataPointer))
+        for (i, item) in array.enumerated() {
+            pointer[i] = Int32(item)
+        }
+        return output
+    }
+}
+
 extension Array {
     func batched(into size: Int) -> [[Element]] {
         return stride(from: 0, to: count, by: size).map {
@@ -32,6 +50,26 @@ extension Array where Element: Hashable {
                 return true
             }
         }
+    }
+}
+
+extension String {
+    /// Reference: https://github.com/huggingface/swift-transformers/blob/94610577e4af9bbc267060af1e25e977604dd796/Sources/Tokenizers/Decoder.swift#L267-L275
+    func trimmingFromEnd(character: Character = " ", upto: Int) -> String {
+        var result = self
+        var trimmed = 0
+        while trimmed < upto && result.last == character {
+            result.removeLast()
+            trimmed += 1
+        }
+        return result
+    }
+}
+
+extension [String] {
+    /// Reference: https://github.com/huggingface/swift-transformers/blob/94610577e4af9bbc267060af1e25e977604dd796/Sources/Hub/HubApi.swift#L983-L987
+    func matching(glob: String) -> [String] {
+        filter { fnmatch(glob, $0, 0) == 0 }
     }
 }
 


### PR DESCRIPTION
This PR includes some extensions from swift-transformers > 1.0.0 that were being used and are now private, which will help when upgrading in the near future. 

It also makes `TranscribeTask` overrideable and includes a couple new functions that may be useful for running logic on a single window alongside the transcribe process.
⚠️ These hooks will await for the logic to complete if not wrapped in a detached task, which could block the transcription process, so use with caution - intended for advanced use cases.

Additionally, minor changes to improve the test CI further.