### PR TITLE
Upgrade swift-transformers & CI images

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -14,11 +14,12 @@ jobs:
       cancel-in-progress: true
     uses: ./.github/workflows/unit-tests.yml
     with:
-      ios-version: "18.6"
-      ios-device: "iPhone 16"
-      watchos-version: "11.5"
-      visionos-version: "2.5"
-      macos-runner: "macos-15"
+      ios-version: "26.1"
+      ios-device: "iPhone 17"
+      watchos-version: "26.1"
+      visionos-version: "26.1"
+      macos-runner: "macos-26"
+      xcode-version: "latest-stable"
 
   check-approvals:
     runs-on: ubuntu-latest
@@ -50,18 +51,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13-xlarge
-            ios-version: "17.2"
-            ios-device: "iPhone 14"
-            watchos-version: "10.2"
-            visionos-version: "1.0"
-            xcode-version: "15.2"
           - os: macos-14
             ios-version: "17.2"
             ios-device: "iPhone 15"
             watchos-version: "10.2"
             visionos-version: "1.0"
-            xcode-version: "15.2"
+            xcode-version: "16.1"
+          - os: macos-15
+            ios-version: "18.5"
+            ios-device: "iPhone 16"
+            watchos-version: "11.5"
+            visionos-version: "2.5"
+            xcode-version: "16.4"
     uses: ./.github/workflows/unit-tests.yml
     with:
       macos-runner: ${{ matrix.os }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -11,23 +11,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13-xlarge
-            ios-version: "17.2" # TODO: Download older simulators for macOS 13
-            ios-device: "iPhone 14"
-            watchos-version: "10.2"
-            visionos-version: "1.0"
-            xcode-version: "15.2"
           - os: macos-14
             ios-version: "17.5"
             ios-device: "iPhone 15"
             watchos-version: "10.2"
             visionos-version: "1.0"
-            xcode-version: "15.4"
+            xcode-version: "16.1"
           - os: macos-15
-            ios-version: "18.6" # Latest available version
+            ios-version: "18.5"
             ios-device: "iPhone 16"
             watchos-version: "11.5"
             visionos-version: "2.5"
+            xcode-version: "16.4"
+          - os: macos-26
+            ios-version: "26.1"
+            ios-device: "iPhone 17"
+            watchos-version: "26.1"
+            visionos-version: "26.1"
+            macos-runner: "macos-26"
             xcode-version: "latest-stable"
     uses: ./.github/workflows/unit-tests.yml
     with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,13 +43,13 @@ jobs:
             }
           - {
               name: "watchOS",
-              condition: "${{ inputs.macos-runner == 'macos-15' }}",
+              condition: "${{ inputs.macos-runner == 'macos-26' }}",
               clean-destination: "generic/platform=watchOS",
-              test-destination: "platform=watchOS Simulator,OS=${{ inputs.watchos-version }},name=Apple Watch Ultra 2 (49mm)",
+              test-destination: "platform=watchOS Simulator,OS=${{ inputs.watchos-version }},name=Apple Watch Ultra 3 (49mm)",
             }
           - {
               name: "visionOS",
-              condition: "${{ inputs.macos-runner == 'macos-15' }}",
+              condition: "${{ inputs.macos-runner == 'macos-26' }}",
               clean-destination: "generic/platform=visionOS",
               test-destination: "platform=visionOS Simulator,OS=${{ inputs.visionos-version }},name=Apple Vision Pro",
             }
@@ -83,7 +83,7 @@ jobs:
           echo "Destinations for testing:"
           xcodebuild test-without-building -testPlan UnitTestsPlan -scheme whisperkit-Package -showdestinations
       - name: Boot Simulator and Wait
-        if: ${{ matrix.run-config['condition'] == true }} && ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-15' }}
+        if: ${{ matrix.run-config['condition'] == true }} && ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-26' }}
         # Slower runners require some time to fully boot the simulator
         # Parse the simulator name from the destination string, boot it, and wait
         run: |

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,12 +10,30 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "38b7beeec5d968accd19a8a70c1882cc89979d1c",
+        "version" : "2.1.1"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "fc6543263e4caed9bf6107466d625cfae9357f08",
-        "version" : "0.1.8"
+        "revision" : "d363e83a77bafe144808a3d01556139fe67cd8bc",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", .upToNextMinor(from: "0.1.8")),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", .upToNextMinor(from: "1.1.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ] + (isServerEnabled() ? [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.1"),
@@ -36,19 +36,20 @@ let package = Package(
         .target(
             name: "WhisperKit",
             dependencies: [
-                .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "Hub", package: "swift-transformers"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
             ]
         ),
         .testTarget(
             name: "WhisperKitTests",
             dependencies: [
                 "WhisperKit",
-                .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "Hub", package: "swift-transformers"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
             ],
             path: "Tests",
             resources: [
                 .process("WhisperKitTests/Resources"),
-                .copy("Models/whisperkit-coreml"),
             ]
         ),
         .executableTarget(
@@ -64,9 +65,9 @@ let package = Package(
             path: "Sources/WhisperKitCLI",
             exclude: (isServerEnabled() ? [] : ["Server"]),
             swiftSettings: (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
-
         )
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )
 
 func isServerEnabled() -> Bool {

--- a/Sources/WhisperKit/Utilities/Extensions+Public.swift
+++ b/Sources/WhisperKit/Utilities/Extensions+Public.swift
@@ -57,15 +57,15 @@ public extension String {
 public extension MLMultiArray {
     convenience init(shape: [NSNumber], dataType: MLMultiArrayDataType, initialValue: Any) throws {
         switch dataType {
-        case .float16:
-            // IOSurface-backed arrays are implicitly float16. They can
-            // reduce buffer copies for some OS:compute unit combinations.
-            guard let pixelBuffer = Self.pixelBuffer(for: shape) else {
-                throw WhisperError.initializationError("MLMultiArray: Failed to initialize PixelBuffer")
-            }
-            self.init(pixelBuffer: pixelBuffer, shape: shape)
-        default:
-            try self.init(shape: shape, dataType: dataType)
+            case .float16:
+                // IOSurface-backed arrays are implicitly float16. They can
+                // reduce buffer copies for some OS:compute unit combinations.
+                guard let pixelBuffer = Self.pixelBuffer(for: shape) else {
+                    throw WhisperError.initializationError("MLMultiArray: Failed to initialize PixelBuffer")
+                }
+                self.init(pixelBuffer: pixelBuffer, shape: shape)
+            default:
+                try self.init(shape: shape, dataType: dataType)
         }
 
         switch dataType {
@@ -303,3 +303,4 @@ public extension WhisperKit {
         return ModelUtilities.formatModelFiles(modelFiles)
     }
 }
+


### PR DESCRIPTION
This change will bump the swift-transformers version to [1.1.2 ](https://github.com/huggingface/swift-transformers/releases/tag/1.1.2). In addition to the improvements in that release, WhisperKit will now be able to build alongside the latest MLX swift packages, which have a shared dependency.

This version requires swift-tools-version 6 to be available in Xcode, so we are deprecating support for Xcode 15.

Added:
- The latest swift-transformers should significantly improve download handling with resumable downloads, remote etag checks for changes, improved tokenization, and xet capability.
- macOS 26 images are now the main runner for unit tests on PRs

Removed:
- ⚠️ macOS 13 images are now [deprecated as github runners](https://github.com/actions/runner-images/blob/main/README.md), and will no longer be used for tests
- ⚠️ This also means Xcode 15 and below will be unsupported due to the swift 6 requirement.

Thanks to @naykutguven for kickstarting this effort in https://github.com/argmaxinc/WhisperKit/pull/361.

