### PR TITLE
Make public enums conform to Sendable

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -50,7 +50,7 @@ public extension WhisperMLModel {
 // MARK: - Whisper Models
 
 @frozen
-public enum ModelVariant: CustomStringConvertible, CaseIterable {
+public enum ModelVariant: CustomStringConvertible, CaseIterable, Sendable {
     case tiny
     case tinyEn
     case base
@@ -102,7 +102,7 @@ public enum ModelVariant: CustomStringConvertible, CaseIterable {
 }
 
 @frozen
-public enum ModelState: CustomStringConvertible {
+public enum ModelState: CustomStringConvertible, Sendable {
     case unloading
     case unloaded
     case loading
@@ -402,7 +402,7 @@ public struct DecodingCache {
 }
 
 @frozen
-public enum ChunkingStrategy: String, Codable, CaseIterable {
+public enum ChunkingStrategy: String, Codable, CaseIterable, Sendable {
     case none
     case vad
 }
@@ -743,7 +743,7 @@ public typealias TranscriptionStateCallback = (_ state: TranscriptionState) -> V
 
 /// Represents the different states of the transcription process.
 @frozen
-public enum TranscriptionState: CustomStringConvertible {
+public enum TranscriptionState: CustomStringConvertible, Sendable {
     /// The audio is being converted to the required format for transcription
     case convertingAudio
 

--- a/Sources/WhisperKit/Utilities/ModelUtilities.swift
+++ b/Sources/WhisperKit/Utilities/ModelUtilities.swift
@@ -5,10 +5,7 @@ import CoreML
 import Hub
 import Tokenizers
 
-public struct ModelUtilities {
-
-    private init() {}
-
+public enum ModelUtilities: Sendable {
     // MARK: Public
 
     public static func modelSupport(for deviceName: String, from config: ModelSupportConfig? = nil) -> ModelSupport {
@@ -207,22 +204,6 @@ public struct ModelUtilities {
     }
 
     static func getModelOutputDimention(_ model: MLModel?, named: String, position: Int) -> Int? {
-        guard let inputDescription = model?.modelDescription.outputDescriptionsByName[named] else { return nil }
-        guard inputDescription.type == .multiArray else { return nil }
-        guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }
-        let shape = shapeConstraint.shape.map { $0.intValue }
-        return shape[position]
-    }
-
-    func getModelInputDimention(_ model: MLModel?, named: String, position: Int) -> Int? {
-        guard let inputDescription = model?.modelDescription.inputDescriptionsByName[named] else { return nil }
-        guard inputDescription.type == .multiArray else { return nil }
-        guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }
-        let shape = shapeConstraint.shape.map { $0.intValue }
-        return shape[position]
-    }
-
-    func getModelOutputDimention(_ model: MLModel?, named: String, position: Int) -> Int? {
         guard let inputDescription = model?.modelDescription.outputDescriptionsByName[named] else { return nil }
         guard inputDescription.type == .multiArray else { return nil }
         guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }

--- a/Sources/WhisperKit/Utilities/TextUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TextUtilities.swift
@@ -4,10 +4,7 @@
 import Foundation
 
 /// A utility struct providing text compression and analysis functionality
-public struct TextUtilities {
-
-    private init() {}
-
+public enum TextUtilities: Sendable {
     /// Calculates the compression ratio of an array of text tokens using zlib compression
     /// - Parameter textTokens: Array of integer tokens to compress
     /// - Returns: The compression ratio (original size / compressed size). Returns infinity if compression fails

--- a/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
@@ -2,10 +2,7 @@
 //  Copyright © 2024 Argmax, Inc. All rights reserved.
 
 /// A utility struct providing transcription-related functionality for processing and manipulating transcription results
-public struct TranscriptionUtilities {
-
-    private init() {}
-
+public enum TranscriptionUtilities: Sendable {
     // MARK: Public
 
     /// Formats transcription segments into an array of strings, optionally including timestamps

--- a/Sources/WhisperKit/Utilities/WhisperError.swift
+++ b/Sources/WhisperKit/Utilities/WhisperError.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 @frozen
-public enum WhisperError: Error, LocalizedError, Equatable {
+public enum WhisperError: Error, LocalizedError, Equatable, Sendable {
     case tokenizerUnavailable(String = "Tokenizer is unavailable")
     case modelsUnavailable(String = "Models are unavailable")
     case prefillFailed(String = "Prefill failed")


### PR DESCRIPTION
Concurrency and safety improvements:

* Added the `Sendable` protocol conformance to several enums (`ModelVariant`, `ModelState`, `ChunkingStrategy`, `TranscriptionState`, and `WhisperError`) to ensure they can be safely used across threads in concurrent code. 

Code organization and utility refactoring:

* Refactored utility types (`ModelUtilities`, `TextUtilities`, and `TranscriptionUtilities`) from structs with private initializers to enums with only static methods, and made them conform to `Sendable`. This clarifies their intended usage as namespaces for static utilities and improves thread safety. 
* Removed unused or redundant instance-level methods from `ModelUtilities` to streamline the utility interface.