### PR TITLE
Mark public callbacks Sendable

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -1370,7 +1370,7 @@ struct ContentView: View {
         )
 
         // Early stopping checks
-        let decodingCallback: ((TranscriptionProgress) -> Bool?) = { (progress: TranscriptionProgress) in
+        let decodingCallback: TranscriptionCallback = { (progress: TranscriptionProgress) in
             DispatchQueue.main.async {
                 let fallbacks = Int(progress.timings.totalDecodingFallbacks)
                 let chunkId = isStreamMode ? 0 : progress.windowId
@@ -1620,7 +1620,7 @@ struct ContentView: View {
         )
 
         // Early stopping checks
-        let decodingCallback: ((TranscriptionProgress) -> Bool?) = { progress in
+        let decodingCallback: TranscriptionCallback = { progress in
             DispatchQueue.main.async {
                 let fallbacks = Int(progress.timings.totalDecodingFallbacks)
                 if progress.text.count < currentText.count {

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -505,7 +505,7 @@ struct WhisperAXWatchView: View {
         )
 
         // Early stopping checks
-        let decodingCallback: ((TranscriptionProgress) -> Bool?) = { progress in
+        let decodingCallback: TranscriptionCallback = { progress in
             DispatchQueue.main.async {
                 let fallbacks = Int(progress.timings.totalDecodingFallbacks)
                 if progress.text.count < currentText.count {

--- a/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
@@ -17,7 +17,10 @@ public extension AudioStreamTranscriber {
     }
 }
 
-public typealias AudioStreamTranscriberCallback = (AudioStreamTranscriber.State, AudioStreamTranscriber.State) -> Void
+public typealias AudioStreamTranscriberCallback = @Sendable (
+    AudioStreamTranscriber.State,
+    AudioStreamTranscriber.State
+) -> Void
 
 /// Responsible for streaming audio from the microphone, processing it, and transcribing it in real-time.
 public actor AudioStreamTranscriber {

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -729,17 +729,20 @@ public struct TranscriptionProgress: Sendable {
 /// A callback that provides transcription segments as they are discovered.
 /// - Parameters:
 ///   - segments: An array of `TranscriptionSegment` objects representing the transcribed segments
-public typealias SegmentDiscoveryCallback = (_ segments: [TranscriptionSegment]) -> Void
+public typealias SegmentDiscoveryCallback = @Sendable (_ segments: [TranscriptionSegment]) -> Void
 
 /// A callback that reports changes in the model's state.
 /// - Parameters:
 ///   - oldState: The previous state of the model, if any
 ///   - newState: The current state of the model
-public typealias ModelStateCallback = (_ oldState: ModelState?, _ newState: ModelState) -> Void
+public typealias ModelStateCallback = @Sendable (
+    _ oldState: ModelState?,
+    _ newState: ModelState
+) -> Void
 
 /// A callback that reports changes in the transcription process.
 /// - Parameter state: The current `TranscriptionState` of the transcription process
-public typealias TranscriptionStateCallback = (_ state: TranscriptionState) -> Void
+public typealias TranscriptionStateCallback = @Sendable (_ state: TranscriptionState) -> Void
 
 /// Represents the different states of the transcription process.
 @frozen
@@ -776,7 +779,7 @@ public enum TranscriptionState: CustomStringConvertible {
 ///   - `false`: Stop the transcription process early.
 ///   - `nil`: Continue the transcription process (equivalent to returning `true`).
 /// - Note: This callback should be lightweight and return as quickly as possible to avoid extra decoding loops
-public typealias TranscriptionCallback = ((TranscriptionProgress) -> Bool?)?
+public typealias TranscriptionCallback = @Sendable (TranscriptionProgress) -> Bool?
 
 public struct TranscriptionTimings: Codable, Sendable {
     public var pipelineStart: CFAbsoluteTime

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -90,7 +90,7 @@ public protocol TextDecoding {
         using decoderInputs: any DecodingInputsType,
         sampler tokenSampler: TokenSampling,
         options decoderOptions: DecodingOptions,
-        callback: ((TranscriptionProgress) -> Bool?)?
+        callback: TranscriptionCallback?
     ) async throws -> DecodingResult
 
     @available(*, deprecated, message: "Subject to removal in a future version. Use `decodeText(from:using:sampler:options:callback:) async throws -> DecodingResult` instead.")
@@ -100,7 +100,7 @@ public protocol TextDecoding {
         using decoderInputs: DecodingInputs,
         sampler tokenSampler: TokenSampling,
         options decoderOptions: DecodingOptions,
-        callback: ((TranscriptionProgress) -> Bool?)?
+        callback: TranscriptionCallback?
     ) async throws -> [DecodingResult]
 
     func detectLanguage(
@@ -137,7 +137,7 @@ public extension TextDecoding {
         using decoderInputs: DecodingInputs,
         sampler tokenSampler: TokenSampling,
         options decoderOptions: DecodingOptions,
-        callback: ((TranscriptionProgress) -> Bool?)?
+        callback: TranscriptionCallback?
     ) async throws -> [DecodingResult] {
         let result: DecodingResult = try await decodeText(
             from: encoderOutput,
@@ -155,7 +155,7 @@ public extension TextDecoding {
         using decoderInputs: any DecodingInputsType,
         sampler tokenSampler: TokenSampling,
         options decoderOptions: DecodingOptions,
-        callback: ((TranscriptionProgress) -> Bool?)?
+        callback: TranscriptionCallback?
     ) async throws -> DecodingResult {
         let result: DecodingResult = try await decodeText(
             from: encoderOutput,
@@ -173,7 +173,7 @@ public extension TextDecoding {
         using decoderInputs: DecodingInputs,
         sampler tokenSampler: TokenSampling,
         options decoderOptions: DecodingOptions,
-        callback: ((TranscriptionProgress) -> Bool?)?
+        callback: TranscriptionCallback?
     ) async throws -> DecodingResult {
         let result: DecodingResult = try await decodeText(
             from: encoderOutput,
@@ -732,7 +732,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         using decoderInputs: any DecodingInputsType,
         sampler tokenSampler: TokenSampling,
         options: DecodingOptions,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async throws -> DecodingResult {
         guard let tokenizer else {
             // Tokenizer required for decoding

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -57,7 +57,7 @@ open class TranscribeTask {
     public func run(
         audioArray: [Float],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async throws -> TranscriptionResult {
         let interval = Logging.beginSignpost("TranscribeAudio", signposter: Logging.TranscribeTask.signposter)
         defer { Logging.endSignpost("TranscribeAudio", interval: interval, signposter: Logging.TranscribeTask.signposter) }
@@ -163,7 +163,7 @@ open class TranscribeTask {
                 Logging.info("Decoding \(Logging.formatTimestamp(timeOffset))s - \(Logging.formatTimestamp(timeOffsetEnd))s")
 
                 // Overload progress callback to include windowId
-                let decodingCallback: ((TranscriptionProgress) -> Bool?) = { [weak self] progress in
+                let decodingCallback: TranscriptionCallback = { [weak self] progress in
                     guard let self = self, let callback = callback else { return nil }
                     var windowProgress = progress
                     windowProgress.windowId = Int(self.timings.totalDecodingWindows - self.timings.totalDecodingFallbacks)
@@ -289,7 +289,7 @@ open class TranscribeTask {
         func decodeWithFallback(
             encoderSegment encoderOutput: any AudioEncoderOutputType,
             decodingOptions options: DecodingOptions,
-            callback: TranscriptionCallback = nil
+            callback: TranscriptionCallback? = nil
         ) async throws -> DecodingResult {
             let interval = Logging.beginSignpost("Decode", signposter: Logging.TranscribeTask.signposter)
             defer { Logging.endSignpost("Decode", interval: interval, signposter: Logging.TranscribeTask.signposter) }

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -596,7 +596,7 @@ open class WhisperKit {
     open func transcribe(
         audioPaths: [String],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async -> [[TranscriptionResult]?] {
         let transcribeResults = await transcribeWithResults(
             audioPaths: audioPaths,
@@ -621,7 +621,7 @@ open class WhisperKit {
     open func transcribeWithResults(
         audioPaths: [String],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async -> [Result<[TranscriptionResult], Swift.Error>] {
         transcriptionStateCallback?(.convertingAudio)
 
@@ -676,7 +676,7 @@ open class WhisperKit {
     open func transcribe(
         audioArrays: [[Float]],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async -> [[TranscriptionResult]?] {
         let transcribeResults = await transcribeWithResults(
             audioArrays: audioArrays,
@@ -702,7 +702,7 @@ open class WhisperKit {
     open func transcribeWithResults(
         audioArrays: [[Float]],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async -> [Result<[TranscriptionResult], Swift.Error>] {
         // Create an array of decoding options with the same value for each audio array
         let decodeOptionsArray = Array(repeating: decodeOptions, count: audioArrays.count)
@@ -726,7 +726,7 @@ open class WhisperKit {
         audioArrays: [[Float]],
         decodeOptionsArray: [DecodingOptions?] = [nil],
         seekOffsets: [Int]? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async -> [Result<[TranscriptionResult], Swift.Error>] {
         var result = [Result<[TranscriptionResult], Swift.Error>]()
 
@@ -752,7 +752,7 @@ open class WhisperKit {
             let partialResult = await withTaskGroup(of: [(index: Int, result: Result<[TranscriptionResult], Swift.Error>)].self) { taskGroup -> [Result<[TranscriptionResult], Swift.Error>] in
                 for (audioIndex, audioArray) in audioArrayBatch.enumerated() {
                     // Setup callback to keep track of batches and chunks
-                    let batchedAudioCallback: ((TranscriptionProgress) -> Bool?) = { progress in
+                    let batchedAudioCallback: TranscriptionCallback = { progress in
                         var batchedProgress = progress
                         batchedProgress.windowId = audioIndex + batchIndex * audioArrayBatch.count
                         return callback?(batchedProgress)
@@ -821,7 +821,7 @@ open class WhisperKit {
     open func transcribe(
         audioPath: String,
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async throws -> TranscriptionResult? {
         let result: [TranscriptionResult] = try await transcribe(audioPath: audioPath, decodeOptions: decodeOptions, callback: callback)
         return result.first
@@ -837,7 +837,7 @@ open class WhisperKit {
     open func transcribe(
         audioPath: String,
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async throws -> [TranscriptionResult] {
         transcriptionStateCallback?(.convertingAudio)
 
@@ -876,7 +876,7 @@ open class WhisperKit {
     open func transcribe(
         audioArray: [Float],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil
+        callback: TranscriptionCallback? = nil
     ) async throws -> TranscriptionResult? {
         let result: [TranscriptionResult] = try await transcribe(audioArray: audioArray, decodeOptions: decodeOptions, callback: callback)
         return result.first
@@ -893,7 +893,7 @@ open class WhisperKit {
     open func transcribe(
         audioArray: [Float],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil,
+        callback: TranscriptionCallback? = nil,
         segmentCallback: SegmentDiscoveryCallback? = nil
     ) async throws -> [TranscriptionResult] {
         var transcribeResults = [TranscriptionResult]()
@@ -985,7 +985,7 @@ open class WhisperKit {
     open func runTranscribeTask(
         audioArray: [Float],
         decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback = nil,
+        callback: TranscriptionCallback? = nil,
         segmentCallback: SegmentDiscoveryCallback? = nil
     ) async throws -> [TranscriptionResult] {
         if modelState != .loaded {

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -138,7 +138,7 @@ extension XCTestCase {
     func transcribe(
         with variant: ModelVariant,
         options: DecodingOptions,
-        callback: TranscriptionCallback = nil,
+        callback: TranscriptionCallback? = nil,
         audioFile: String = "jfk.wav",
         file: StaticString = #file,
         line: UInt = #line


### PR DESCRIPTION
This pull request refactors the callback type signatures throughout the WhisperKit codebase to improve thread safety and clarity. The main change is the consistent use of the `@Sendable` attribute for callback typealiases (such as `TranscriptionCallback`, `SegmentDiscoveryCallback`, and others), ensuring they are safe to use in concurrent contexts. Additionally, the code updates function and method signatures to expect optional `TranscriptionCallback?` parameters instead of non-optional defaults, and updates all usages accordingly.

**Concurrency and Callback Improvements**

* Added `@Sendable` to all major callback typealiases, including `TranscriptionCallback`, `AudioStreamTranscriberCallback`, `SegmentDiscoveryCallback`, `ModelStateCallback`, and `TranscriptionStateCallback`, making them safe for use in concurrent Swift contexts. 
* Updated `TranscriptionCallback` to be non-optional in its typealias, and changed method and function signatures across the codebase to accept `TranscriptionCallback?` (i.e., optional) parameters, improving clarity and flexibility. 

**Code Consistency and Usage Updates**

* Replaced all inline callback type definitions (e.g., `(TranscriptionProgress) -> Bool?`) with the new `TranscriptionCallback` typealias in function parameters and local variables, ensuring consistency across the codebase.

These changes help make the codebase safer for concurrency, easier to maintain, and more consistent.