### PR TITLE
Fix isolation error in MLModel load

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -29,11 +29,9 @@ public protocol WhisperMLModel: AnyObject {
 
 public extension WhisperMLModel {
     func loadModel(at modelPath: URL, computeUnits: MLComputeUnits, prewarmMode: Bool = false) async throws {
-        let loadedModel = try await Task {
-            let modelConfig = MLModelConfiguration()
-            modelConfig.computeUnits = computeUnits
-            return try await MLModel.load(contentsOf: modelPath, configuration: modelConfig)
-        }.value
+        let modelConfig = MLModelConfiguration()
+        modelConfig.computeUnits = computeUnits
+        let loadedModel = try await MLModel.load(contentsOf: modelPath, configuration: modelConfig)
 
         model = prewarmMode ? nil : loadedModel
     }


### PR DESCRIPTION
This pull request simplifies the asynchronous model loading logic in the `WhisperMLModel` protocol extension. The change removes an unnecessary use of `Task` when loading the model, making the code more straightforward and easier to follow.

- Simplified model loading by removing the extra `Task` wrapper and directly awaiting the result of `MLModel.load` in the `loadModel` method of `WhisperMLModel` (`Sources/WhisperKit/Core/Models.swift`).