### PR TITLE
Add download-tokenizer(s) targets for model tokenizer downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,23 +75,51 @@ setup-model-repo:
 	fi
 
 
+# Download a specific tokenizer
+download-tokenizer: setup-model-repo
+	@if [ -z "$(MODEL)" ]; then \
+		echo "Error: MODEL is not set. Usage: make download-tokenizer MODEL=base"; \
+		exit 1; \
+	fi
+	@if echo "$(MODEL)" | grep -q "^distil-"; then \
+		dest="$(MODEL_REPO_DIR)/distil-whisper_$(MODEL)"; \
+		base_model=$$(echo "$(MODEL)" | sed 's/_[0-9]*MB$$//' | sed 's/_turbo$$//' | sed 's/-v[0-9]\{8\}$$//'); \
+		repo="distil-whisper/$$base_model"; \
+	else \
+		dest="$(MODEL_REPO_DIR)/openai_whisper-$(MODEL)"; \
+		base_model=$$(echo "$(MODEL)" | sed 's/_[0-9]*MB$$//' | sed 's/_turbo$$//' | sed 's/-v[0-9]\{8\}$$//'); \
+		repo="openai/whisper-$$base_model"; \
+	fi; \
+	echo "Downloading tokenizer for $(MODEL) from $$repo into $$dest..."; \
+	curl -fL -o "$$dest/tokenizer.json" "https://huggingface.co/$$repo/resolve/main/tokenizer.json?download=true"; \
+	curl -fL -o "$$dest/tokenizer_config.json" "https://huggingface.co/$$repo/resolve/main/tokenizer_config.json?download=true"
+
+
+# Download tokenizers for all models
+download-tokenizers: setup-model-repo
+	@echo "Downloading tokenizers for models found in $(MODEL_REPO_DIR)..."
+	@cd $(MODEL_REPO_DIR) && \
+	for d in openai_whisper-* distil-whisper_*; do \
+	  [ -d "$$d" ] || continue; \
+	  if echo "$$d" | grep -q "^openai_whisper-"; then \
+	    model=$$(echo "$$d" | sed 's/openai_whisper-//'); \
+	    base_model=$$(echo "$$model" | sed 's/_[0-9]*MB$$//' | sed 's/_turbo$$//' | sed 's/-v[0-9]\{8\}$$//'); \
+	    repo="openai/whisper-$$base_model"; \
+	  elif echo "$$d" | grep -q "^distil-whisper_"; then \
+	    base_model=$$(echo "$$d" | sed 's/distil-whisper_//' | sed 's/_[0-9]*MB$$//' | sed 's/_turbo$$//' | sed 's/-v[0-9]\{8\}$$//'); \
+	    repo="distil-whisper/$$base_model"; \
+	  fi; \
+	  echo "Downloading tokenizer for $$d from $$repo..."; \
+	  curl -fL -o "$$d/tokenizer.json" "https://huggingface.co/$$repo/resolve/main/tokenizer.json?download=true"; \
+	  curl -fL -o "$$d/tokenizer_config.json" "https://huggingface.co/$$repo/resolve/main/tokenizer_config.json?download=true"; \
+	done
+
+
 # Download all models
 download-models: setup-model-repo
 	@echo "Downloading all models..."
 	@cd $(MODEL_REPO_DIR) && \
 	git lfs pull
-
-download-tokenizers:
-	@echo "Downloading tokenizers for models found in $(MODEL_REPO_DIR)..."
-	@cd $(MODEL_REPO_DIR) && \
-	for d in openai_whisper-*; do \
-		[ -e "$$d" ] || { echo "No models matching openai_whisper-* found in $(MODEL_REPO_DIR)."; break; }; \
-		model=$$(basename $$d | sed 's/openai_whisper-//'); \
-		file="https://huggingface.co/openai/whisper-$$model/resolve/main/tokenizer.json?download=true"; \
-		dest="./$$d"; \
-		echo "Downloading tokenizer for model $$model into $$dest"; \
-		curl -fL -o "$$dest/tokenizer.json" "$$file"; \
-	done
 
 # Download a specific model
 download-model:


### PR DESCRIPTION
This PR adds two new Makefile targets to download tokenizers from the respective OpenAI Whisper repositories.                                                                                                                                    
                                                                                                                                                                                                                                 This could be useful when using a local model folder with WhisperKit, the tokenizer is not automatically downloaded even if the model files are present. These targets allow fetching the `tokenizer.json` separately.