### PR TITLE
Update setup for min deployment targets in CI workflows

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-15.6
+          - os: macos-15
             ios-version: "18.5"
             ios-device: "iPhone 16"
             watchos-version: "11.5"

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-15.6
+          - os: macos-15
             ios-version: "18.5"
             ios-device: "iPhone 16"
             watchos-version: "11.5"


### PR DESCRIPTION
This pull request updates the macOS and Xcode versions used in both the development and release test GitHub Actions workflows to ensure compatibility with newer Apple platforms and tooling.

Platform and tooling updates:

* Updated the test matrix in `.github/workflows/development-tests.yml` to use `macos-15.6` and Xcode `26.0`, along with the latest corresponding iOS, watchOS, and visionOS versions.
* Updated the test matrix in `.github/workflows/release-tests.yml` to use `macos-15.6` and Xcode `26.0`, and removed older macOS and Xcode versions from the matrix.