### PR TITLE
Mute-style input suppression without pausing AVAudioEngine

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -1011,12 +1011,7 @@ public extension AudioProcessor {
             }
 
             var newBufferArray = Self.convertBufferToArray(buffer: buffer)
-            if self.isInputSuppressed {
-                newBufferArray.withUnsafeMutableBufferPointer { ptr in
-                    guard let base = ptr.baseAddress else { return }
-                    vDSP_vclr(base, 1, vDSP_Length(ptr.count))
-                }
-            }
+            self.suppressInputIfNeeded(&newBufferArray)
             self.processBuffer(newBufferArray)
         }
 
@@ -1096,5 +1091,13 @@ public extension AudioProcessor {
         // Stop the audio engine
         audioEngine?.stop()
         audioEngine = nil
+    }
+
+    func suppressInputIfNeeded(_ buffer: inout [Float]) {
+        guard isInputSuppressed else { return }
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            guard let base = ptr.baseAddress else { return }
+            vDSP_vclr(base, 1, vDSP_Length(ptr.count))
+        }
     }
 }

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -213,6 +213,11 @@ open class AudioProcessor: NSObject, AudioProcessing {
 
     public var audioBufferCallback: (([Float]) -> Void)?
     public var minBufferLength = Int(Double(WhisperKit.sampleRate) * 0.1) // 0.1 second of audio at 16,000 Hz
+
+    /// Override to drop buffers without pausing the audio engine.
+    open func shouldAcceptBuffer(_ buffer: [Float]) -> Bool {
+        return true
+    }
     
     open func padOrTrim(fromArray audioArray: [Float], startAt startIndex: Int, toLength frameLength: Int) -> (any AudioProcessorOutputType)? {
         return AudioProcessor.padOrTrimAudio(fromArray: audioArray, startAt: startIndex, toLength: frameLength, saveSegment: false)
@@ -899,6 +904,7 @@ public extension AudioProcessor {
     /// We have a new buffer, process and store it.
     /// NOTE: Assumes audio is 16khz mono
     func processBuffer(_ buffer: [Float]) {
+        guard shouldAcceptBuffer(buffer) else { return }
         audioSamples.append(contentsOf: buffer)
 
         // Find the lowest average energy of the last 20 buffers ~2 seconds

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -1012,7 +1012,10 @@ public extension AudioProcessor {
 
             var newBufferArray = Self.convertBufferToArray(buffer: buffer)
             if self.isInputSuppressed {
-                newBufferArray = Array(repeating: 0, count: newBufferArray.count)
+                newBufferArray.withUnsafeMutableBufferPointer { ptr in
+                    guard let base = ptr.baseAddress else { return }
+                    vDSP_vclr(base, 1, vDSP_Length(ptr.count))
+                }
             }
             self.processBuffer(newBufferArray)
         }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -363,6 +363,22 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(paddedSamples.count, 1600, "Padded or trimmed samples count is not as expected")
     }
 
+    func testSuppressInputIfNeededMutesBuffer() {
+        let audioProcessor = AudioProcessor()
+        audioProcessor.setInputSuppressed(true)
+        var buffer: [Float] = [0.25, -0.5, 1.0]
+        audioProcessor.suppressInputIfNeeded(&buffer)
+        XCTAssertTrue(buffer.allSatisfy { $0 == 0.0 }, "Suppressed buffer should contain silence")
+    }
+
+    func testSuppressInputIfNeededNoopWhenDisabled() {
+        let audioProcessor = AudioProcessor()
+        audioProcessor.setInputSuppressed(false)
+        var buffer: [Float] = [0.25, -0.5, 1.0]
+        audioProcessor.suppressInputIfNeeded(&buffer)
+        XCTAssertEqual(buffer, [0.25, -0.5, 1.0], "Buffer should remain unchanged when suppression is disabled")
+    }
+
     func testAudioResample() throws {
         let audioFileURL = try XCTUnwrap(
             Bundle.current(for: self).url(forResource: "jfk", withExtension: "wav"),

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -379,6 +379,15 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(buffer, [0.25, -0.5, 1.0], "Buffer should remain unchanged when suppression is disabled")
     }
 
+    func testInputSuppressionToggleState() {
+        let audioProcessor = AudioProcessor()
+        XCTAssertFalse(audioProcessor.isInputSuppressed, "Suppression should be disabled by default")
+        audioProcessor.setInputSuppressed(true)
+        XCTAssertTrue(audioProcessor.isInputSuppressed, "Suppression should be enabled after setting true")
+        audioProcessor.setInputSuppressed(false)
+        XCTAssertFalse(audioProcessor.isInputSuppressed, "Suppression should be disabled after setting false")
+    }
+
     func testAudioResample() throws {
         let audioFileURL = try XCTUnwrap(
             Bundle.current(for: self).url(forResource: "jfk", withExtension: "wav"),


### PR DESCRIPTION
### Context
Some apps need to temporarily suppress input without pausing AVAudioEngine, since `pause()` can cause resume issues in certain iOS scenarios.

### Changes
Introduced simple mute-style switch (`isInputSuppressed`, `setInputSuppressed`) to AudioProcessor: when suppressed, we pass through silence so timing remains consistent.

Mute is implemented allocation-free by zeroing the samples in place (via Accelerate, which is already imported), to keep the tap path leaner.