### PR TITLE
AudioProcessor: fix teardown to avoid StartIO/thread warnings on some Bluetooth devices

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -1078,14 +1078,22 @@ public extension AudioProcessor {
     func stopRecording() {
         guard let engine = audioEngine else { return }
 
-        // Remove the tap from the input node first; other nodes are secondary.
+        // Remove tap from the input node explicitly.
         engine.inputNode.removeTap(onBus: 0)
+
         engine.attachedNodes.forEach { node in
             node.removeTap(onBus: 0)
         }
 
+        // Disconnect the input to force the engine graph to fully tear down.
+        // This helps prevent lingering input connections across repeated start/stop cycles.
+        engine.disconnectNodeInput(engine.inputNode)
+
         engine.stop()
+
+        // Reset clears the engine/node state so a subsequent start builds a fresh graph.
         engine.reset()
+
         audioEngine = nil
     }
 }

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -1076,13 +1076,16 @@ public extension AudioProcessor {
     }
 
     func stopRecording() {
-        // Remove the tap on any attached node
-        audioEngine?.attachedNodes.forEach { node in
+        guard let engine = audioEngine else { return }
+
+        // Remove the tap from the input node first; other nodes are secondary.
+        engine.inputNode.removeTap(onBus: 0)
+        engine.attachedNodes.forEach { node in
             node.removeTap(onBus: 0)
         }
 
-        // Stop the audio engine
-        audioEngine?.stop()
+        engine.stop()
+        engine.reset()
         audioEngine = nil
     }
 }


### PR DESCRIPTION
On some Bluetooth devices (e.g. Sony WH-1000XM5), restarting recording may fail to start audio capture.
**Fix:** Strengthen AVAudioEngine teardown to fully release the input node and avoid stale audio graph state.

### Changes

- Remove tap from `inputNode` first (not only `attachedNodes`)
- Disconnect input node (`disconnectNodeInput`)
- `reset()` engine before releasing
