### PR TITLE
Update Swift toolchain to 6.2 and build settings in Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,11 @@
 import PackageDescription
 import Foundation
 
+let approachableConcurrencySettings: [SwiftSetting] = [
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+]
+
 let package = Package(
     name: "whisperkit",
     platforms: [
@@ -37,7 +42,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Hub", package: "swift-transformers"),
                 .product(name: "Tokenizers", package: "swift-transformers"),
-            ]
+            ],
+            swiftSettings: approachableConcurrencySettings
         ),
         .testTarget(
             name: "WhisperKitTests",
@@ -49,7 +55,8 @@ let package = Package(
             path: "Tests",
             resources: [
                 .process("WhisperKitTests/Resources"),
-            ]
+            ],
+            swiftSettings: approachableConcurrencySettings
         ),
         .executableTarget(
             name: "WhisperKitCLI",
@@ -63,7 +70,7 @@ let package = Package(
             ] : []),
             path: "Sources/WhisperKitCLI",
             exclude: (isServerEnabled() ? [] : ["Server"]),
-            swiftSettings: (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
+            swiftSettings: approachableConcurrencySettings + (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
         )
     ],
     swiftLanguageModes: [.v5]


### PR DESCRIPTION
This pull request updates the Swift package configuration to adopt Swift 6.2 and enable upcoming concurrency features across all targets. The main changes involve updating the Swift tools version, introducing a shared set of concurrency-related Swift settings, and applying them consistently to all targets in the Package.swift file.

The language mode is still set to Swift 5 since the project doesn't fully compile in Swift 6 yet. Once the changes required for Swift 6 migration are complete, we can set it to Swift 6.