### PR TITLE
Backport BNNSScalar and MLShapedArrayScalar conformances of Float16 for older OS versions in Swift 6

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -14,9 +14,41 @@ public typealias FloatType = Float16
 public typealias FloatType = Float
 #endif
 
-#if (os(macOS) || targetEnvironment(macCatalyst)) && arch(arm64) && compiler(<6)
-extension Float16: BNNSScalar {}
-extension Float16: MLShapedArrayScalar {}
+#if (os(macOS) || targetEnvironment(macCatalyst)) && arch(arm64)
+
+// MARK: - Float16 BNNSScalar conformance for macOS
+#if os(macOS)
+
+// Available on macOS < 26, not visible on macOS 26+
+@available(macOS, obsoleted: 26.0)
+extension Float16: @retroactive BNNSScalar {
+    public static var bnnsDataType: BNNSDataType { .float16 }
+}
+
+// Available on macOS < 15, not visible on macOS 15+
+@available(macOS, obsoleted: 15.0)
+extension Float16: @retroactive MLShapedArrayScalar {
+    public static var multiArrayDataType: MLMultiArrayDataType { .float16 }
+}
+
+#endif
+
+// MARK: - Float16 BNNSScalar conformance for Mac Catalyst
+#if targetEnvironment(macCatalyst)
+
+// Catalyst uses its own availability domain.
+@available(macCatalyst, obsoleted: 26.0)
+extension Float16: @retroactive BNNSScalar {
+    public static var bnnsDataType: BNNSDataType { .float16 }
+}
+
+@available(macCatalyst, obsoleted: 15.0)
+extension Float16: @retroactive MLShapedArrayScalar {
+    public static var multiArrayDataType: MLMultiArrayDataType { .float16 }
+}
+
+#endif
+
 #endif
 
 // MARK: - CoreML


### PR DESCRIPTION
This PR adds an availability-gated backport of Apple’s Float16 conformances for older OS versions, avoiding duplicate conformance on newer OS and compiling cleanly under Swift 6.

Platform-specific protocol conformance improvements:

* Added `@available(..., obsoleted: ...)` annotations to the `Float16` extensions for `BNNSScalar` and `MLShapedArrayScalar` on macOS and Mac Catalyst, ensuring these conformances are only available on supported OS versions and not visible on newer versions. The official conformances of `Float16` implemented by Apple are available on macOS 26+ and macOS 15+, respectively.