### PR TITLE
Move `decodeWithFallback` outside the enclosing method

### DIFF
--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -177,7 +177,6 @@ open class TranscribeTask {
                     decodingOptions: options,
                     decoderInputs: &decoderInputs,
                     detectedLanguage: &detectedLanguage,
-                    fallbackCount: &fallbackCount,
                     prefilledCacheSize: prefilledCacheSize,
                     callback: decodingCallback
                 )
@@ -329,7 +328,6 @@ open class TranscribeTask {
         decodingOptions options: DecodingOptions,
         decoderInputs: inout any DecodingInputsType,
         detectedLanguage: inout String?,
-        fallbackCount: inout Int,
         prefilledCacheSize: Int,
         callback: TranscriptionCallback? = nil
     ) async throws -> DecodingResult {
@@ -406,14 +404,13 @@ open class TranscribeTask {
 
             if let fallback = decodingResult?.fallback, fallback.needsFallback {
                 // Reset decoder inputs for fallback
-                fallbackCount = i
                 timings.decodingFallback += Date().timeIntervalSince(decodeWithFallbackStart)
-                timings.totalDecodingFallbacks = Double(fallbackCount)
+                timings.totalDecodingFallbacks = Double(i)
                 decoderInputs.reset(
                     prefilledCacheSize: prefilledCacheSize,
                     maxTokenContext: options.sampleLength
                 )
-                Logging.info("Fallback #\(fallbackCount + 1) (\(fallback.fallbackReason))")
+                Logging.info("Fallback #\(i + 1) (\(fallback.fallbackReason))")
             } else {
                 break
             }


### PR DESCRIPTION
This pull request refactors `decodeWithFallback` method and move it outside the enclosing function to fix concurrency errors. The logic remains the same.

### Decoding fallback logic

* Refactored the `decodeWithFallback` method to accept explicit references to `decoderInputs`, `detectedLanguage`, and `fallbackCount`, rather than relying on implicit state. This makes the fallback mechanism clearer and easier to maintain.
* Fixes the following Swift Concurrency errors:
  * `Sending task-isolated 'decoderInputs' to @concurrent local function 'decodeWithFallback(encoderSegment:decodingOptions:callback:)' risks causing data races between @concurrent and task-isolated uses`
  * `Sending task-isolated 'encoderOutput' to @concurrent local function 'decodeWithFallback(encoderSegment:decodingOptions:callback:)' risks causing data races between @concurrent and task-isolated uses`
  * `Sending task-isolated 'self' to @concurrent local function 'decodeWithFallback(encoderSegment:decodingOptions:callback:)' risks causing data races between @concurrent and task-isolated uses`