### PR TITLE
Fix AudioProcessor Sendable capture

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -228,17 +228,11 @@ open class AudioProcessor: NSObject, AudioProcessing, @unchecked Sendable {
         }
     }
     public var audioSamples: ContiguousArray<Float> {
-        get {
-            stateLock.withLock {
-                audioSamplesStorage
-            }
-        }
-        set {
-            stateLock.withLock {
-                audioSamplesStorage = newValue
-            }
+        stateLock.withLock {
+            audioSamplesStorage
         }
     }
+
     public var audioEnergy: [(rel: Float, avg: Float, max: Float, min: Float)] {
         get {
             stateLock.withLock {
@@ -264,9 +258,10 @@ open class AudioProcessor: NSObject, AudioProcessing, @unchecked Sendable {
         }
     }
     public var relativeEnergy: [Float] {
-        stateLock.withLock {
-            audioEnergyStorage.map { $0.rel }
+        let energySnapshot = stateLock.withLock {
+            audioEnergyStorage
         }
+        return energySnapshot.map { $0.rel }
     }
 
     public private(set) var isInputSuppressed: Bool {
@@ -1006,9 +1001,10 @@ public extension AudioProcessor {
         stateLock.withLock {
             audioSamplesStorage.append(contentsOf: buffer)
 
-            // Find the lowest average energy of the last 20 buffers ~2 seconds
+            // Find the lowest average energy of the last 20 buffers ~2 seconds.
             let minAvgEnergy = audioEnergyStorage.suffix(20).reduce(Float.infinity) { min($0, $1.avg) }
-            let relativeEnergy = Self.calculateRelativeEnergy(of: buffer, relativeTo: minAvgEnergy)
+            let referenceEnergy = minAvgEnergy.isFinite ? minAvgEnergy : nil
+            let relativeEnergy = Self.calculateRelativeEnergy(of: buffer, relativeTo: referenceEnergy)
 
             // Update energy for buffers with valid data
             newEnergy = (relativeEnergy, signalEnergy.avg, signalEnergy.max, signalEnergy.min)
@@ -1171,9 +1167,15 @@ public extension AudioProcessor {
     func resumeRecordingLive(inputDeviceID: DeviceID? = nil, callback: (([Float]) -> Void)? = nil) throws {
         try? setupAudioSessionForDevice()
 
-        if stateLock.withLock({ inputDeviceID == lastInputDeviceStorage }) {
-            let engine = stateLock.withLock { audioEngineStorage }
-            try engine?.start()
+        let engine = stateLock.withLock { () -> AVAudioEngine? in
+            guard inputDeviceID == lastInputDeviceStorage else {
+                return nil
+            }
+            return audioEngineStorage
+        }
+
+        if let engine {
+            try engine.start()
         } else {
             let engine = try setupEngine(inputDeviceID: inputDeviceID)
             stateLock.withLock {

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -476,6 +476,18 @@ final class UnitTests: XCTestCase {
         let energyVeryLoud = AudioProcessor.calculateAverageEnergy(of: veryLoudNoise)
         XCTAssertGreaterThan(energyVeryLoud, energyLoud, "Audio energy is not very loud")
     }
+    
+    func testProcessBufferFirstBufferProducesFiniteNormalizedRelativeEnergy() throws {
+        let audioProcessor = AudioProcessor()
+        let firstBuffer = [Float](repeating: 0.05, count: 1600)
+        
+        audioProcessor.processBuffer(firstBuffer)
+        
+        let firstEnergy = try XCTUnwrap(audioProcessor.audioEnergy.first, "Expected processBuffer to store a first energy entry")
+        XCTAssertTrue(firstEnergy.rel.isFinite, "First relative energy should always be finite")
+        XCTAssertGreaterThanOrEqual(firstEnergy.rel, 0, "Relative energy should be clamped to the lower bound")
+        XCTAssertLessThanOrEqual(firstEnergy.rel, 1, "Relative energy should be clamped to the upper bound")
+    }
 
     // MARK: - Protocol Conformance Tests
 


### PR DESCRIPTION
This pull request makes significant improvements to the thread safety and concurrency handling of the `AudioProcessor` class in `AudioProcessor.swift`. The main change is the introduction of a lock (`stateLock`) to serialize access to internal state, making the class safe to use in concurrent contexts such as audio callbacks and async streams. Several properties and methods are updated to use this lock, and the class is marked as `@unchecked Sendable` to indicate intended concurrency use.

The most important changes include:

**Thread Safety and Concurrency Improvements**
- Added a private `UnfairLock` (`stateLock`) to serialize all mutations and accesses to internal state, ensuring thread safety when `AudioProcessor` is used across concurrent contexts. The class is now marked as `@unchecked Sendable`.
- All public and internal properties (`audioEngine`, `audioSamples`, `audioEnergy`, `relativeEnergyWindow`, `audioBufferCallback`, `minBufferLength`, and internal storage for these) are now accessed and mutated exclusively under the lock, preventing race conditions.

**Method Updates for Locking**
- Updated methods such as `processBuffer`, `purgeAudioSamples`, `startRecordingLive`, `resumeRecordingLive`, `pauseRecording`, and `stopRecording` to use the lock when accessing or mutating state, ensuring all state changes are thread-safe.
- Ensured that callbacks are invoked outside the lock to avoid potential deadlocks or re-entrant locking issues.

**Refactoring and Consistency**
- Refactored property storage to use private "Storage" variables, with public computed properties that use the lock for access.
- Updated code to consistently use the locked storage variables instead of direct property access throughout the class.

**Minor API Behavior Changes**
- When the async stream is terminated, now only stops recording (removes taps and stops the engine) instead of also clearing the callback, since the callback is now cleared in `stopRecording`.

These changes make `AudioProcessor` robust for use in multi-threaded and asynchronous scenarios, reducing the risk of data races and undefined behavior.