### PR TITLE
Fix thread safety errors in FunctionalTests

### DIFF
--- a/Tests/WhisperKitTests/FunctionalTests.swift
+++ b/Tests/WhisperKitTests/FunctionalTests.swift
@@ -251,7 +251,12 @@ private extension FunctionalTests {
 
             let waitResult = XCTWaiter.wait(for: [done], timeout: timeout)
             guard waitResult == .completed else {
+                // Cancel the in-flight task and then wait briefly for it to finish
+                // so that work from this iteration does not overlap with the next one.
                 task.cancel()
+
+                // Give the cancelled task a short grace period to clean up.
+                _ = XCTWaiter.wait(for: [done], timeout: 5)
                 XCTFail("Timed out waiting for measured async operation (\(waitResult))")
                 return
             }


### PR DESCRIPTION
This pull request refactors the `FunctionalTests` in `Tests/WhisperKitTests/FunctionalTests.swift` to modernize asynchronous test execution, improve code clarity, and remove outdated concurrency patterns. The main improvements include introducing a helper actor for running transcriptions, a reusable async measurement utility, and updating tests to use these new helpers instead of manual semaphore management.

**Async test execution and code simplification:**

* Introduced a private `TranscriptionRunner` actor to encapsulate and safely run asynchronous transcription operations, improving test concurrency safety and code readability.
* Added a `measureAsync` helper method to streamline asynchronous performance measurement in tests, replacing manual semaphore and task management with a more idiomatic async/await approach.

**Test modernization and cleanup:**

* Updated performance measurement tests to use `TranscriptionRunner` and `measureAsync`, removing legacy semaphore-based concurrency and making assertions on the result in a cleaner way. 
* Refactored `testBaseImplementation` to be an `async` test and removed unnecessary semaphore and task code, simplifying the test logic.