### PR TITLE
Fix force-unwrap crashes in TextDecoder.decodeText during live transcription

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -680,7 +680,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // MARK: Non-inference
 
         // Update predicted token as current
-        let logits = languageLogitsFilter.filterLogits(decoderOutput.logits!, withTokens: currentTokens)
+        guard let decoderLogits = decoderOutput.logits else {
+            throw WhisperError.transcriptionFailed("Decoder output logits are nil during language detection")
+        }
+        let logits = languageLogitsFilter.filterLogits(decoderLogits, withTokens: currentTokens)
 
         // MARK: Sampling
 
@@ -744,7 +747,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         let prefilledIndex = decoderInputs.cacheLength[0].intValue
         let initialPromptIndex = decoderInputs.initialPrompt.count
         var currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
+        guard let lastPromptToken = decoderInputs.initialPrompt.last else {
+            throw WhisperError.transcriptionFailed("Initial prompt is empty, cannot decode text")
+        }
+        var nextToken: Int = lastPromptToken
         var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
 
         // Logits filters
@@ -826,7 +832,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             let nonInferenceStartTime = Date()
 
             // Update predicted token as current
-            var logits = decoderOutput.logits!
+            guard let decoderLogits = decoderOutput.logits else {
+                throw WhisperError.transcriptionFailed("Decoder output logits are nil during main decoding loop")
+            }
+            var logits = decoderLogits
             for filter in logitsFilters {
                 logits = filter.filterLogits(logits, withTokens: currentTokens)
             }


### PR DESCRIPTION
## Summary

Replaces three force-unwraps in `TextDecoder.decodeText` that cause crashes during repeated rapid transcription calls (e.g., live transcription preview at ~200ms intervals).

## Changes

Three force-unwraps replaced with `guard let` + descriptive `WhisperError` throws:

1. **`decoderInputs.initialPrompt.last!`** (line 747) — crashes if `initialPrompt` is empty
2. **`decoderOutput.logits!`** (line 683) — crashes if logits is nil during language detection
3. **`decoderOutput.logits!`** (line 829) — crashes if logits is nil during main decoding loop

All three now throw `WhisperError.transcriptionFailed` with descriptive messages, allowing callers to handle errors gracefully instead of crashing.

## Fixes

- Fixes #414