### PR TITLE
fix: replace force-unwraps in TextDecoder with safe error handling

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -680,7 +680,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // MARK: Non-inference
 
         // Update predicted token as current
-        let logits = languageLogitsFilter.filterLogits(decoderOutput.logits!, withTokens: currentTokens)
+        guard let outputLogits = decoderOutput.logits else {
+            throw WhisperError.decodingLogitsFailed("Logits unavailable in language detection output")
+        }
+        let logits = languageLogitsFilter.filterLogits(outputLogits, withTokens: currentTokens)
 
         // MARK: Sampling
 
@@ -688,7 +691,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
         let sampleResult = tokenSampler.update(tokens: currentTokens, logits: logits, logProbs: logProbs)
 
-        nextToken = sampleResult.tokens.last!
+        guard let sampledToken = sampleResult.tokens.last else {
+            throw WhisperError.decodingFailed("Language detection sampler returned empty tokens")
+        }
+        nextToken = sampledToken
         logProbs = sampleResult.logProbs
 
         let samplingTime = Date().timeIntervalSince(samplingStartTime)
@@ -744,7 +750,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         let prefilledIndex = decoderInputs.cacheLength[0].intValue
         let initialPromptIndex = decoderInputs.initialPrompt.count
         var currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
+        guard let lastPromptToken = decoderInputs.initialPrompt.last else {
+            throw WhisperError.prepareDecoderInputsFailed("Initial prompt is empty")
+        }
+        var nextToken: Int = lastPromptToken
         var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
 
         // Logits filters
@@ -826,7 +835,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             let nonInferenceStartTime = Date()
 
             // Update predicted token as current
-            var logits = decoderOutput.logits!
+            guard let outputLogits = decoderOutput.logits else {
+                throw WhisperError.decodingLogitsFailed("Logits unavailable in decoder output")
+            }
+            var logits = outputLogits
             for filter in logitsFilters {
                 logits = filter.filterLogits(logits, withTokens: currentTokens)
             }
@@ -840,8 +852,14 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
             let sampleResult = tokenSampler.update(tokens: currentTokens, logits: logits, logProbs: logProbs)
 
-            nextToken = sampleResult.tokens.last!
-            let nextTokenLogProb = sampleResult.logProbs.last!
+            guard let sampledToken = sampleResult.tokens.last else {
+                throw WhisperError.decodingFailed("Token sampler returned empty tokens")
+            }
+            guard let sampledLogProb = sampleResult.logProbs.last else {
+                throw WhisperError.decodingFailed("Token sampler returned empty logProbs")
+            }
+            nextToken = sampledToken
+            let nextTokenLogProb = sampledLogProb
 
             Logging.debug("Predicted next tokenIndex: \(tokenIndex + 1), token: \(nextToken), text: \(tokenizer.decode(tokens: [nextToken]))")
 


### PR DESCRIPTION
## Summary

- Replace 6 force-unwrap operations in `TextDecoder.swift` that crash during sustained rapid transcription
- `decoderOutput.logits!` → `guard let` with `WhisperError.decodingLogitsFailed` (2 sites: `detectLanguage` and `decodeText`)
- `decoderInputs.initialPrompt.last!` → `guard let` with `WhisperError.prepareDecoderInputsFailed`
- `sampleResult.tokens.last!` → `guard let` with `WhisperError.decodingFailed` (2 sites)
- `sampleResult.logProbs.last!` → `guard let` with `WhisperError.decodingFailed`

All replacements use existing `WhisperError` cases so callers can catch and handle errors gracefully instead of crashing the app.

## Test plan

- [ ] Verify existing tests pass (no behavioral change for valid inputs)
- [ ] Confirm live transcription use case from #414 no longer crashes

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)