### PR TITLE
fix: replace force-unwraps in TextDecoder with guard statements

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -680,7 +680,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         // MARK: Non-inference
 
         // Update predicted token as current
-        let logits = languageLogitsFilter.filterLogits(decoderOutput.logits!, withTokens: currentTokens)
+        guard let decoderLogits = decoderOutput.logits else {
+            throw WhisperError.decodingLogitsFailed("Language detection failed: decoder output logits are nil")
+        }
+        let logits = languageLogitsFilter.filterLogits(decoderLogits, withTokens: currentTokens)
 
         // MARK: Sampling
 
@@ -744,7 +747,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         let prefilledIndex = decoderInputs.cacheLength[0].intValue
         let initialPromptIndex = decoderInputs.initialPrompt.count
         var currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
+        guard let lastPromptToken = decoderInputs.initialPrompt.last else {
+            throw WhisperError.decodingFailed("Initial prompt is empty, cannot begin decoding")
+        }
+        var nextToken: Int = lastPromptToken
         var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
 
         // Logits filters
@@ -826,7 +832,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             let nonInferenceStartTime = Date()
 
             // Update predicted token as current
-            var logits = decoderOutput.logits!
+            guard let decoderOutputLogits = decoderOutput.logits else {
+                throw WhisperError.decodingLogitsFailed("Decoder output logits are nil during token decoding")
+            }
+            var logits = decoderOutputLogits
             for filter in logitsFilters {
                 logits = filter.filterLogits(logits, withTokens: currentTokens)
             }


### PR DESCRIPTION
## Summary

Replaces three force-unwraps in `TextDecoder.decodeText` that cause `EXC_BREAKPOINT` crashes during rapid repeated transcription calls (e.g., live transcription preview at ~200ms intervals).

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line 747 | `decoderInputs.initialPrompt.last!` | `guard let` + `throw WhisperError.decodingFailed` |
| Line 683 | `decoderOutput.logits!` (language detection) | `guard let` + `throw WhisperError.decodingLogitsFailed` |
| Line 829 | `decoderOutput.logits!` (token decoding) | `guard let` + `throw WhisperError.decodingLogitsFailed` |

All three now throw descriptive `WhisperError` cases that already exist in the codebase, allowing callers to handle the error gracefully instead of crashing.

## Context

During sustained rapid transcription calls (5-10/sec for live preview), decoder state can degrade and hit these nil/empty conditions. The force-unwraps cause hard crashes instead of recoverable errors.

Fixes #414