### PR TITLE
Use Int over NSNumber in logit filters and related extensions

### DIFF
--- a/Sources/WhisperKit/Core/Text/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/Text/LogitsFilter.swift
@@ -12,11 +12,11 @@ public protocol LogitsFiltering {
 
 open class SuppressTokensFilter: LogitsFiltering {
     let suppressTokens: [Int]
-    private let suppressTokenIndexes: [[NSNumber]]
+    private let suppressTokenIndexes: [[Int]]
 
     public init(suppressTokens: [Int]) {
         self.suppressTokens = suppressTokens
-        self.suppressTokenIndexes = suppressTokens.map { [0, 0, $0 as NSNumber] }
+        self.suppressTokenIndexes = suppressTokens.map { [0, 0, $0] }
     }
 
     public func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray {
@@ -28,7 +28,7 @@ open class SuppressTokensFilter: LogitsFiltering {
 open class SuppressBlankFilter: LogitsFiltering {
     let specialTokens: SpecialTokens
     let sampleBegin: Int
-    private let suppressTokenIndexes: [[NSNumber]]
+    private let suppressTokenIndexes: [[Int]]
 
     public init(
         specialTokens: SpecialTokens,
@@ -37,8 +37,8 @@ open class SuppressBlankFilter: LogitsFiltering {
         self.specialTokens = specialTokens
         self.sampleBegin = sampleBegin
         self.suppressTokenIndexes = [
-            [0, 0, specialTokens.whitespaceToken as NSNumber],
-            [0, 0, specialTokens.endToken as NSNumber],
+            [0, 0, specialTokens.whitespaceToken],
+            [0, 0, specialTokens.endToken],
         ]
     }
 
@@ -79,7 +79,7 @@ open class TimestampRulesFilter: LogitsFiltering {
         }
 
         // suppress <|notimestamps|> which is handled by `withoutTimestamps`
-        logits.fill(indexes: [[0, 0, specialTokens.noTimestampsToken as NSNumber]], with: -FloatType.infinity)
+        logits.fill(indexes: [[0, 0, specialTokens.noTimestampsToken]], with: -FloatType.infinity)
 
         if tokens.count > sampleBegin {
             // timestamps have to appear in pairs, except directly before EOT; mask logits accordingly
@@ -143,7 +143,7 @@ open class TimestampRulesFilter: LogitsFiltering {
     }
 
     private func sumOfProbabilityOverTimestampsIsAboveAnyOtherToken(logits: MLMultiArray, timeTokenBegin: Int) -> Bool {
-        let timeTokenBeginOffset = logits.linearOffset(for: [0, 0, timeTokenBegin as NSNumber])
+        let timeTokenBeginOffset = logits.linearOffset(for: [0, 0, timeTokenBegin])
 
         let logprobsInputPointer = UnsafeMutableRawBufferPointer(
             start: logits.dataPointer,
@@ -247,7 +247,7 @@ open class LanguageLogitsFilter: LogitsFiltering {
     let allLanguageTokens: Set<Int>
     let logitsDim: Int
     let sampleBegin: Int
-    let nonLanguageTokenIndexes: [[NSNumber]]
+    let nonLanguageTokenIndexes: [[Int]]
 
     public init(allLanguageTokens: Set<Int>, logitsDim: Int, sampleBegin: Int) {
         self.allLanguageTokens = allLanguageTokens
@@ -265,11 +265,11 @@ open class LanguageLogitsFilter: LogitsFiltering {
         return logits
     }
 
-    private static func getNonLanguageTokenIndexes(logitsDim: Int, allLanguageTokens: Set<Int>) -> [[NSNumber]] {
-        var indexes: [[NSNumber]] = []
+    private static func getNonLanguageTokenIndexes(logitsDim: Int, allLanguageTokens: Set<Int>) -> [[Int]] {
+        var indexes: [[Int]] = []
         for i in 0..<logitsDim {
             if !allLanguageTokens.contains(i) {
-                indexes.append([0, 0, i as NSNumber])
+                indexes.append([0, 0, i])
             }
         }
         return indexes

--- a/Sources/WhisperKit/Utilities/Extensions+Public.swift
+++ b/Sources/WhisperKit/Utilities/Extensions+Public.swift
@@ -100,13 +100,19 @@ public extension MLMultiArray {
     ///  - index: The index of the element
     ///  - strides: The precomputed strides of the multi-array, if not provided, it will be computed. It's a performance optimization to avoid recomputing the strides every time when accessing the multi-array with multiple indexes.
     @inline(__always)
-    func linearOffset(for index: [NSNumber], strides strideInts: [Int]? = nil) -> Int {
+    func linearOffset(for index: [Int], strides strideInts: [Int]? = nil) -> Int {
         var linearOffset = 0
         let strideInts = strideInts ?? strides.map { $0.intValue }
         for (dimension, stride) in zip(index, strideInts) {
-            linearOffset += dimension.intValue * stride
+            linearOffset += dimension * stride
         }
         return linearOffset
+    }
+
+    @available(*, deprecated, message: "Use linearOffset(for: [Int], strides:) instead.")
+    @inline(__always)
+    func linearOffset(for index: [NSNumber], strides strideInts: [Int]? = nil) -> Int {
+        linearOffset(for: index.map(\.intValue), strides: strideInts)
     }
 
     func fillLastDimension(indexes: Range<Int>, with value: FloatType) {
@@ -118,13 +124,18 @@ public extension MLMultiArray {
         }
     }
 
-    func fill<Value>(indexes: [[NSNumber]], with value: Value) {
+    func fill<Value>(indexes: [[Int]], with value: Value) {
         let pointer = UnsafeMutablePointer<Value>(OpaquePointer(dataPointer))
         let strideInts = strides.map { $0.intValue }
         for index in indexes {
             let linearOffset = linearOffset(for: index, strides: strideInts)
             pointer[linearOffset] = value
         }
+    }
+
+    @available(*, deprecated, message: "Use fill(indexes: [[Int]], with:) instead.")
+    func fill<Value>(indexes: [[NSNumber]], with value: Value) {
+        fill(indexes: indexes.map { $0.map(\.intValue) }, with: value)
     }
 
     private class func pixelBuffer(for shape: [NSNumber]) -> CVPixelBuffer? {
@@ -303,4 +314,3 @@ public extension WhisperKit {
         return ModelUtilities.formatModelFiles(modelFiles)
     }
 }
-

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -114,7 +114,7 @@ extension MLMultiArray {
         let logits = try MLMultiArray(shape: [1, 1, arr.count] as [NSNumber], dataType: .float16)
         let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(logits.dataPointer))
         for (index, value) in arr.enumerated() {
-            let linearOffset = logits.linearOffset(for: [0, 0, index as NSNumber])
+            let linearOffset = logits.linearOffset(for: [0, 0, index])
             ptr[linearOffset] = value
         }
         return logits
@@ -123,11 +123,11 @@ extension MLMultiArray {
     /// Get the data from `MLMultiArray` for given dimension
     func data(for dimension: Int) -> [FloatType] {
         let count = shape[dimension].intValue
-        let indexes = stride(from: 0, to: count, by: 1).map { [0, 0, $0 as NSNumber] }
+        let indexes = stride(from: 0, to: count, by: 1).map { [0, 0, $0] }
         var result = [FloatType]()
         let ptr = UnsafeMutablePointer<FloatType>(OpaquePointer(dataPointer))
         for index in indexes {
-            let linearOffset = linearOffset(for: index as [NSNumber])
+            let linearOffset = linearOffset(for: index)
             result.append(ptr[linearOffset])
         }
         return result

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1874,11 +1874,11 @@ final class UnitTests: XCTestCase {
 
     func testFillIndexesWithValue() throws {
         let logits = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
-        logits.fill(indexes: [] as [[NSNumber]], with: -FloatType.infinity)
+        logits.fill(indexes: [] as [[Int]], with: -FloatType.infinity)
         XCTAssertEqual(logits.data(for: 2), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
 
         let logits2 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
-        let indexes2: [[NSNumber]] = [[0, 0, 0], [0, 0, 1], [0, 0, 5]]
+        let indexes2: [[Int]] = [[0, 0, 0], [0, 0, 1], [0, 0, 5]]
         logits2.fill(indexes: indexes2, with: -FloatType.infinity)
         XCTAssertEqual(logits2.data(for: 2), [-.infinity, -.infinity, 0.3, 0.4, 0.5, -.infinity, 0.7])
 
@@ -2319,7 +2319,7 @@ final class UnitTests: XCTestCase {
         let ptr = UnsafeMutablePointer<Double>(OpaquePointer(mlMatrix.dataPointer))
         for (i, row) in matrix.enumerated() {
             for (j, value) in row.enumerated() {
-                let linearOffset = mlMatrix.linearOffset(for: [i, j] as [NSNumber])
+                let linearOffset = mlMatrix.linearOffset(for: [i, j])
                 ptr[linearOffset] = value
             }
         }


### PR DESCRIPTION
This pull request refactors the handling of multi-dimensional array indices throughout the codebase, standardizing on the use of `[Int]` instead of `[NSNumber]` for improved type safety and performance. The changes affect both the main implementation and the test suite, updating method signatures, internal logic, and usage sites. Deprecated methods are introduced for backward compatibility.

**Core API and Implementation Updates:**

* Updated the `MLMultiArray` extension methods (`linearOffset(for:)` and `fill(indexes:with:)`) to use `[Int]` instead of `[NSNumber]`, and added deprecated overloads to maintain backward compatibility.
* Refactored all logits filter classes (`SuppressTokensFilter`, `SuppressBlankFilter`, `TimestampRulesFilter`, `LanguageLogitsFilter`) to use `[[Int]]` for index arrays instead of `[[NSNumber]]`.

**Test Suite Adjustments:**

* Updated test utility methods and test cases to use `[Int]` and `[[Int]]` for indices, aligning with the new API.

These changes modernize the codebase, simplify type handling, and reduce unnecessary type conversions, while ensuring backward compatibility for existing code.