### PR TITLE
fix: replace force-unwraps with guards in TextDecoder.decodeText

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -744,7 +744,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         let prefilledIndex = decoderInputs.cacheLength[0].intValue
         let initialPromptIndex = decoderInputs.initialPrompt.count
         var currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
+        guard let firstToken = decoderInputs.initialPrompt.last else {
+            throw WhisperError.decodingFailed("initialPrompt is empty")
+        }
+        var nextToken: Int = firstToken
         var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
 
         // Logits filters
@@ -826,7 +829,10 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             let nonInferenceStartTime = Date()
 
             // Update predicted token as current
-            var logits = decoderOutput.logits!
+            guard let logits_ = decoderOutput.logits else {
+                throw WhisperError.decodingLogitsFailed("Decoder output logits are nil")
+            }
+            var logits = logits_
             for filter in logitsFilters {
                 logits = filter.filterLogits(logits, withTokens: currentTokens)
             }


### PR DESCRIPTION
Fixes #414

Two force-unwraps in `decodeText` crash the app when decoder state degrades during sustained rapid transcription calls (e.g., live transcription preview at ~5 calls/sec):

- **Line 747**: `decoderInputs.initialPrompt.last!` — crashes when `initialPrompt` is empty
- **Line 829**: `decoderOutput.logits!` — crashes when logits is nil

This PR replaces them with guard statements that throw descriptive errors, allowing callers to handle the failure gracefully instead of crashing the entire app.

### Minimal diff — no behavioral change for normal operation
The guard statements only trigger when the values are unexpectedly nil. Normal transcription flow is unaffected.