### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: read
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - name: Check Approvals
         id: reviews
         env:

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -15,14 +15,14 @@ jobs:
       GH_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
     steps:
         - name: Checkout whisper-kit-expo
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4.3.1
           with:
             repository: seb-sep/whisper-kit-expo
             token: ${{ secrets.COMMITTER_TOKEN }}
             ref: main
         
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
           with:
             node-version: '20.x'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
             }
     timeout-minutes: ${{ matrix.run-config['name'] == 'visionOS' && 60 || 30 }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ inputs.xcode-version || '26.4.1' }}
@@ -63,7 +63,7 @@ jobs:
         run: make setup
       - name: Setup Cache
         id: model-cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
         with:
           path: Models
           key: ${{ runner.os }}-models
@@ -99,7 +99,7 @@ jobs:
           xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}'
       - name: Upload Test Results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: test-results-${{ matrix.run-config['name']}}-on-${{ inputs.macos-runner }}
           path: |


### PR DESCRIPTION
This PR pins GitHub Actions to exact commit SHAs for more reproducible builds.

## Why pin to commit SHAs?

Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability.

Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/unit-tests.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/expo-update.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/expo-update.yml`
- Pinned `actions/upload-artifact` from `v4` to `ea165f8` in `.github/workflows/unit-tests.yml`
- Pinned `actions/cache` from `v4` to `0057852` in `.github/workflows/unit-tests.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/development-tests.yml`
