### PR TITLE
Fix prompt tokens causing empty transcription output

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -764,7 +764,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
             let isPrefill = tokenIndex < initialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
             let isLastPrefillToken = tokenIndex == initialPromptIndex - 1
-            let isFirstToken = tokenIndex == prefilledIndex
+            let isInPrefillPhase = isPrefill || isLastPrefillToken // tokenIndex < initialPromptIndex
+            let isFirstToken = tokenIndex == max(prefilledIndex, initialPromptIndex) // First actually decoded token (after prompt)
 
             // Check if current index is part of the initial prompt
             if tokenIndex < initialPromptIndex {
@@ -854,8 +855,11 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 } else {
                     false
                 }
+            // During prefill phase (processing prompt tokens), skip early termination checks:
+            // - The model is being force-fed prompt tokens, so EOT predictions and low log probs are expected
+            // - Early stopping should only apply to actually decoded tokens after the prompt
             let isSegmentCompleted =
-                sampleResult.completed ||
+                (!isInPrefillPhase && sampleResult.completed) ||
                 currentTokens.count >= Constants.maxTokenContext - 1 ||
                 isFirstTokenLogProbTooLow
 


### PR DESCRIPTION
## Summary

When `promptTokens` are provided in `DecodingOptions` (e.g., via the `prompt` parameter in the OpenAI-compatible server API), transcription returns empty text.

**Root cause:** When `promptTokens` are set, the prefill KV cache is disabled ([known TODO on line 354](https://github.com/argmaxinc/WhisperKit/blob/664e1b5/Sources/WhisperKit/Core/TextDecoder.swift#L354)). This causes the decoding loop to start at `tokenIndex=0` with `startOfPreviousToken` as input. The model then either:
1. Predicts EOT → `sampleResult.completed = true` → loop breaks immediately
2. Produces a low-confidence prediction → `firstTokenLogProbThreshold` (-1.5 default) triggers → loop breaks

Both paths result in empty transcription output.

## Reproduction

```bash
# Start WhisperKit server with any model
whisperkit-cli serve --model-path <path> --port 8000

# Without prompt — works fine
curl -X POST http://localhost:8000/v1/audio/transcriptions \
  -F "file=@test.wav" -F "model=<model>" -F "language=ru"
# → {"text": "Привет, это тестовая запись..."}

# With prompt — returns empty text
curl -X POST http://localhost:8000/v1/audio/transcriptions \
  -F "file=@test.wav" -F "model=<model>" -F "language=ru" \
  -F "prompt=Kubernetes, Docker, RabbitMQ"
# → {"text": ""}
```

## Fix

Two changes in `TextDecoder.swift`:

1. **`isFirstToken`** now correctly points to the first actually decoded token after the prompt (`max(prefilledIndex, initialPromptIndex)`) instead of `tokenIndex == prefilledIndex` which fires at the first prompt token during prefill.

2. **`sampleResult.completed`** (EOT check) is skipped during the prefill phase. Since the model is being force-fed prompt tokens, its predictions during prefill are not meaningful for early stopping decisions.

## Test plan

- [x] Transcription without prompt still works correctly
- [x] Transcription with prompt now returns correct text (previously returned empty)
- [x] Tested with `whisper-large-v3-turbo` model via local server API