### PR TITLE
fix: skip firstTokenLogProbThreshold when promptTokens are set

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -850,7 +850,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             timings.decodingSampling += samplingTime
 
             isFirstTokenLogProbTooLow =
-                if isFirstToken, let firstTokenLogProbThreshold = options.firstTokenLogProbThreshold, nextTokenLogProb < firstTokenLogProbThreshold {
+                if isFirstToken, options.promptTokens == nil, let firstTokenLogProbThreshold = options.firstTokenLogProbThreshold, nextTokenLogProb < firstTokenLogProbThreshold {
                     true
                 } else {
                     false

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1702,6 +1702,39 @@ final class UnitTests: XCTestCase {
         XCTAssertFalse(result.text.contains(promptText), "Prompt text should not be present in the result")
     }
 
+    func testPromptTokensWithStrictFirstTokenThreshold() async throws {
+        // Regression test for https://github.com/argmaxinc/WhisperKit/issues/372
+        //
+        // promptTokens shift the decoder's first content token logprob downward.
+        // Measured on tiny model + jfk.wav:
+        //   - Without prompt: firstToken logprob ≈ -0.087
+        //   - With CJK prompt: firstToken logprob ≈ -0.578
+        //
+        // On larger/turbo models with longer audio, this shift is amplified
+        // enough to breach the default threshold (-1.5), causing empty output.
+        // We use -0.5 here to reliably reproduce the issue on the tiny model,
+        // simulating the larger shift seen on turbo variants.
+        let config = WhisperKitConfig(model: "tiny", verbose: true, logLevel: .debug, load: true)
+        let whisperKit = try await WhisperKit(config)
+        let tokenizer = try XCTUnwrap(whisperKit.tokenizer)
+
+        let promptText = "繁體中文語音轉錄。"
+        let promptTokens = tokenizer.encode(text: promptText)
+
+        let options = DecodingOptions(
+            skipSpecialTokens: true,
+            promptTokens: promptTokens,
+            firstTokenLogProbThreshold: -0.5
+        )
+
+        let result = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: options),
+            "Failed to transcribe"
+        )
+
+        XCTAssertFalse(result.text.isEmpty, "Transcription should not be empty when promptTokens are set, even with a strict firstTokenLogProbThreshold")
+    }
+
     func testPrefixTokens() async throws {
         let config = WhisperKitConfig(model: "tiny", verbose: true, logLevel: .debug, load: true)
         let whisperKit = try await WhisperKit(config)


### PR DESCRIPTION
## Problem

Using `promptTokens` in `DecodingOptions` causes intermittent empty transcription results, particularly with distilled/turbo model variants (e.g. `large-v3-turbo`). This is the root cause of #372.

### Root Cause Analysis

When `promptTokens` are provided, the decoder input sequence becomes:

```
[<|startofprev|>] + [prompt_tokens...] + [<|sot|>] + [lang] + [task] + [notimestamps]
```

The prompt tokens shift the decoder's KV cache state, causing the **first content token's logprob** to occasionally drop below `firstTokenLogProbThreshold` (default: `-1.5`). When this happens:

1. `isFirstTokenLogProbTooLow` is set to `true`
2. The decoding loop **immediately breaks** — producing zero content tokens
3. `avgLogProb` computes to `0.000` (no real tokens to average over)
4. `DecodingFallback` triggers with reason `"firstTokenLogProbThreshold"`
5. Temperature is increased and decoding retries, but the first token may still fail the threshold
6. After exhausting all fallback attempts, the final result is empty

### Why this only affects WhisperKit

`firstTokenLogProbThreshold` is a **WhisperKit-specific quality gate** — it does not exist in:
- **OpenAI's original Whisper** (`whisper/decoding.py`) — only uses `logprob_threshold` (avg over full segment), `no_speech_threshold`, and `compression_ratio_threshold`
- **whisper.cpp** — faithfully ports the original three thresholds without adding a first-token check

The original Whisper design lets the decoder run to completion and evaluates quality over the **entire segment** via `avgLogprob`. This is robust to prompt-induced shifts in the first token's distribution because subsequent tokens compensate. WhisperKit's early abort on the first token prevents this self-correction.

### Why it's intermittent

The first token logprob depends on the interaction between prompt token content and audio content. For certain audio segments, the prompt conditioning pushes the first token just below `-1.5`; for others it stays above. This creates a non-deterministic failure pattern.

### Why turbo models are more affected

Distilled/turbo variants (e.g. `large-v3-v20240930`) have fewer decoder layers, making them more sensitive to changes in the conditioning context. The reduced decoder capacity has less room to absorb the distributional shift from prompt tokens.

## Fix

Skip the `firstTokenLogProbThreshold` check when `promptTokens` are present (`options.promptTokens == nil` guard). This is a one-line change in `TextDecoder.swift`.

**Safety**: The existing `logProbThreshold` (avg over full segment, default `-1.0`) and `compressionRatioThreshold` remain active as quality gates, matching the original Whisper behavior. Truly bad segments will still be caught and retried via temperature fallback.

## Related

- Fixes #372