### PR TITLE
Fix SpeakerKit tests on iOS 17

### DIFF
--- a/Sources/SpeakerKit/PyannoteConfig.swift
+++ b/Sources/SpeakerKit/PyannoteConfig.swift
@@ -10,11 +10,17 @@ import ArgmaxCore
 public extension ModelInfo {
     static func segmenter(version: String? = nil, variant: String? = nil, computeUnits: MLComputeUnits = .cpuOnly) -> ModelInfo {
         let variant = variant ?? {
+            #if targetEnvironment(simulator)
+            if #available(iOS 18, macOS 15, *) {
+                return "W8A16"
+            }
+            #else
             if #available(iOS 17, macOS 14, *) {
                 return "W8A16"
-            } else {
-                return "W32A32"
             }
+            #endif
+
+            return "W32A32"
         }()
         return ModelInfo(version: version ?? "pyannote-v3", variant: variant, name: "speaker_segmenter", computeUnits: computeUnits)
     }


### PR DESCRIPTION
The W8A16 model variant was being selected for all iOS 17+ targets, including the simulator. However, on the simulator, W8A16 requires iOS 18 / macOS 15 or later.

This fix adds a #if targetEnvironment(simulator) check so that the simulator path gates on iOS 18+, while physical devices continue to use W8A16 from iOS 17+. Devices and simulators below those thresholds fall back to W32A32.