### PR TITLE
Widen swift-transformers constraint to allow >=1.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/huggingface/swift-transformers.git", .upToNextMinor(from: "1.1.6")),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.1.6"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ] + (isServerEnabled() ? [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.1"),


### PR DESCRIPTION
## Summary

Changes `.upToNextMinor(from: "1.1.6")` to `from: "1.1.6"` for the swift-transformers dependency.

## Problem

The current constraint resolves to `>=1.1.6, <1.2.0`, which conflicts with packages that require swift-transformers 1.2.0+ (e.g., FluidAudio). SPM cannot resolve both in the same dependency graph:

```
WhisperKit: swift-transformers .upToNextMinor(from: "1.1.6")  → <1.2.0
FluidAudio: swift-transformers from: "1.2.0"                  → >=1.2.0
```

## Fix

Widen to `from: "1.1.6"` which allows any version >=1.1.6, including 1.2.x. WhisperKit's code is compatible with swift-transformers 1.2.0 — tested in a production iOS app with both packages resolving to 1.2.0 successfully.

## Testing

- Built and archived an iOS app with both WhisperKit and FluidAudio 0.12.5
- SPM resolved swift-transformers to 1.2.0 satisfying both packages
- All WhisperKit functionality (transcribe, model download) works correctly