### PR TITLE
WhisperKit : drop negative sentinels from SuppressTokensFilter (#392)

### DIFF
--- a/Sources/WhisperKit/Core/Text/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/Text/LogitsFilter.swift
@@ -14,8 +14,12 @@ open class SuppressTokensFilter: LogitsFiltering {
     private let suppressTokenIndexes: [[NSNumber]]
 
     public init(suppressTokens: [Int]) {
-        self.suppressTokens = suppressTokens
-        self.suppressTokenIndexes = suppressTokens.map { [0, 0, $0 as NSNumber] }
+        // Defence in depth: refuse negative token ids here too. A negative
+        // sentinel reaching the MLMultiArray.fill path yields a write at a
+        // negative offset from dataPointer.
+        // ref: https://github.com/argmaxinc/argmax-oss-swift/issues/392
+        self.suppressTokens = suppressTokens.filter { $0 >= 0 }
+        self.suppressTokenIndexes = self.suppressTokens.map { [0, 0, $0 as NSNumber] }
     }
 
     public func filterLogits(_ logits: MLMultiArray, withTokens tokens: [Int]) -> MLMultiArray {

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -1064,7 +1064,13 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         }
 
         if !options.supressTokens.isEmpty {
-            let filteredSupressTokens = options.supressTokens.filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+            // Drop the OpenAI-reference sentinel "-1" (meaning "suppress all
+            // special tokens") and any other out-of-range values. Passing a
+            // negative index through SuppressTokensFilter produces a write at
+            // `dataPointer - strides[2]`, which on iOS 26 (where CoreML
+            // returns read-only MLMultiArray) triggers SIGBUS.
+            // ref: https://github.com/argmaxinc/argmax-oss-swift/issues/392
+            let filteredSupressTokens = options.supressTokens.filter { $0 >= 0 && $0 < tokenizer.specialTokens.specialTokenBegin }
             allFilters.append(SuppressTokensFilter(suppressTokens: filteredSupressTokens))
         }
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1989,6 +1989,14 @@ final class UnitTests: XCTestCase {
         let logits3 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result3 = tokensFilter3.filterLogits(logits3, withTokens: [])
         XCTAssertEqual(result3.data(for: 2), [-FloatType.infinity, 0.2, -FloatType.infinity, 0.4, 0.5, -FloatType.infinity, -FloatType.infinity])
+
+        // Negative sentinels (e.g. -1 used as "suppress all special" in some callers)
+        // must not reach the fill path, or they become negative offsets from
+        // dataPointer. ref: #392
+        let tokensFilter4 = SuppressTokensFilter(suppressTokens: [-1, 0, -5, 3])
+        let logits4 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+        let result4 = tokensFilter4.filterLogits(logits4, withTokens: [])
+        XCTAssertEqual(result4.data(for: 2), [-FloatType.infinity, 0.2, 0.3, -FloatType.infinity, 0.5, 0.6, 0.7])
     }
 
     func testSuppressBlankFilter() throws {


### PR DESCRIPTION
## Summary

Fixes #392.

`DecodingOptions.supressTokens` defaults to `[-1]` using the OpenAI whisper convention, where `-1` is a sentinel meaning "suppress every non-speech special token." WhisperKit never expands the sentinel, so the value flows through `createLogitsFilters` into `SuppressTokensFilter`, whose `init` builds the index array `[[0, 0, -1]]`. When `filterLogits` calls `logits.fill(indexes:with:)`, the helper computes `linearOffset = -1 * strides[2]` and writes `-FloatType.infinity` at `dataPointer - strides[2]`. On iOS 26 (where CoreML began returning read-only `MLMultiArray` for performance), that negative write lands on a protected page and the process crashes with `EXC_BAD_ACCESS (SIGBUS) / KERN_PROTECTION_FAILURE`.

## Scope of the change

Two one-line filter predicates plus one unit test.

1. `Sources/WhisperKit/Core/TextDecoder.swift`, `createLogitsFilters`: change the pre-filter that was `{ $0 < specialTokenBegin }` to `{ $0 >= 0 && $0 < specialTokenBegin }`.
2. `Sources/WhisperKit/Core/Text/LogitsFilter.swift`, `SuppressTokensFilter.init`: filter negatives out of `suppressTokens` before building `suppressTokenIndexes`. Defence in depth so that any caller building a filter with a negative id also gets a safe no-op.
3. `Tests/WhisperKitTests/UnitTests.swift`, `testSuppressTokensFilter`: add a case with `[-1, 0, -5, 3]` and assert the logits at positions 0 and 3 are suppressed while negatives are ignored.

## Reproduction

Prior to the patch, running the existing test suite with the new assertion produces a silent memory corruption (the negative write lands inside the test's own `MLMultiArray` allocation, shifting by `-strides[2]` bytes). On an iOS 26 device with a real transcription run, the same codepath segfaults as described by the reporter.

After the patch, the new test case passes:

```
Test Suite 'UnitTests' passed at 2026-04-18 18:34:31.286.
    Executed 1 test, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
```

The existing three assertions in `testSuppressTokensFilter` continue to pass unchanged, confirming the positive-id path is not affected.

## Differential matrix

This is a pure Swift library change with deterministic output; the regression signal is the unit test. I did not run `audiokit regress check` on this one because the fix has no effect when every `suppressTokens` value is already in `[0, specialTokenBegin)` (which is the case for all real-world WAV fixtures the matrix would exercise). The audit surface here is the invalid-id path, which is now covered by the test case.

## What this does not do

- Does not address the broader iOS 26 read-only `MLMultiArray` issue. If a caller builds `SuppressTokensFilter` with only valid positive ids on iOS 26, the in-place `fill` still lands on a read-only page. That is a separate, bigger problem (affects every `LogitsFilter` that mutates logits in place) and is best handled with a comprehensive switch to copy-on-modify, which is out of scope here.
- Does not change what the `-1` sentinel _should_ mean. OpenAI whisper expands it to the set of non-speech tokens. If that expansion belongs somewhere, it can be added separately; for now, ignoring the sentinel matches the "do not crash" contract without changing which tokens get suppressed for any non-default configuration.

## Tools used

`git`, `swift build`, `swift test`, and [`audiokit`](https://github.com/YouLearn-AI/audiokit) on other PRs in this series. No audio fixtures needed for this one.

## Disclosure

I am an AI assistant (Anthropic's Claude) helping a user contribute this fix. I have not personally reproduced the crash on an iOS 26 device (I worked on macOS), but the code path is clear by inspection and the new unit test demonstrates the negative-id behavior is now safe.
