### PR TITLE
Remove deprecated APIs

### DIFF
--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -312,7 +312,7 @@ struct WhisperAXWatchView: View {
             }
         }
 
-        localModels = WhisperKit.formatModelFiles(localModels)
+        localModels = ModelUtilities.formatModelFiles(localModels)
         for model in localModels {
             if !availableModels.contains(model),
                !disabledModels.contains(model)
@@ -523,7 +523,7 @@ struct WhisperAXWatchView: View {
             let checkWindow = Int(compressionCheckWindow)
             if currentTokens.count > checkWindow {
                 let checkTokens: [Int] = currentTokens.suffix(checkWindow)
-                let compressionRatio = compressionRatio(of: checkTokens)
+                let compressionRatio = TextUtilities.compressionRatio(of: checkTokens)
                 if compressionRatio > options.compressionRatioThreshold! {
                     return false
                 }

--- a/Sources/ArgmaxCore/Logging.swift
+++ b/Sources/ArgmaxCore/Logging.swift
@@ -218,12 +218,3 @@ public extension Logging {
     }
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `Logging.logCurrentMemoryUsage(_:)` instead.")
-public func logCurrentMemoryUsage(_ message: String) {
-    Logging.logCurrentMemoryUsage(message)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `Logging.getMemoryUsage()` instead.")
-public func getMemoryUsage() -> UInt64 {
-    return Logging.getMemoryUsage()
-}

--- a/Sources/ArgmaxCore/ModelUtilities.swift
+++ b/Sources/ArgmaxCore/ModelUtilities.swift
@@ -27,16 +27,6 @@ public struct ModelUtilities {
         return shape[position]
     }
 
-    @available(*, deprecated, renamed: "getModelInputDimension")
-    public static func getModelInputDimention(_ model: MLModel?, named: String, position: Int) -> Int? {
-        getModelInputDimension(model, named: named, position: position)
-    }
-
-    @available(*, deprecated, renamed: "getModelOutputDimension")
-    public static func getModelOutputDimention(_ model: MLModel?, named: String, position: Int) -> Int? {
-        getModelOutputDimension(model, named: named, position: position)
-    }
-
     // MARK: - Model URL Detection
 
     /// Recursively searches a directory tree for a named CoreML model bundle.

--- a/Sources/SpeakerKit/SpeakerKit.swift
+++ b/Sources/SpeakerKit/SpeakerKit.swift
@@ -37,16 +37,6 @@ open class SpeakerKit: @unchecked Sendable {
             try await diarizer.loadModels()
         }
     }
-    
-    /// Use ``init(_:)`` instead with a ``PyannoteConfig``.
-    @available(*, unavailable, renamed: "init(_:)")
-    public convenience init(models: some SpeakerKitModels) async throws { fatalError() }
-    
-    /// Deprecated: For backward compatibility with code using `SpeakerKitDiarizer` protocol.
-    @available(*, unavailable, message: "Conform to Diarizer protocol instead of SpeakerKitDiarizer")
-    public convenience init(diarizer: SpeakerKitDiarizer?) {
-        fatalError("SpeakerKitDiarizer-based init is no longer supported. Use Diarizer protocol instead.")
-    }
 
     // MARK: - Diarization
 

--- a/Sources/SpeakerKit/SpeakerKitDiarizer.swift
+++ b/Sources/SpeakerKit/SpeakerKitDiarizer.swift
@@ -52,13 +52,3 @@ public class SpeakerKitDiarizer: ModelManager, Diarizer, @unchecked Sendable {
         return try await diarize(audioArray, options, progressCallback)
     }
 }
-
-// MARK: - Deprecated
-
-/// Deprecated: Use ``SpeakerKitDiarizer/pyannote(config:segmenterModelInfo:embedderModelInfo:pldaModelInfo:downloader:)``
-/// to create a Pyannote-backed manager, then inject it via ``SpeakerKitConfig/diarizer`` or pass a config to ``SpeakerKit/init(_:)``.
-@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
-@available(*, deprecated, renamed: "SpeakerKitDiarizer",
-    message: "Use SpeakerKitDiarizer.pyannote(config:) and SpeakerKit(_ config:) instead.")
-public typealias SpeakerKitModelManager = SpeakerKitDiarizer
-

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -93,16 +93,6 @@ public protocol TextDecoding {
         callback: TranscriptionCallback?
     ) async throws -> DecodingResult
 
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `decodeText(from:using:sampler:options:callback:) async throws -> DecodingResult` instead.")
-    @_disfavoredOverload
-    func decodeText(
-        from encoderOutput: MLMultiArray,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options decoderOptions: DecodingOptions,
-        callback: TranscriptionCallback?
-    ) async throws -> [DecodingResult]
-
     func detectLanguage(
         from encoderOutput: any AudioEncoderOutputType,
         using decoderInputs: any DecodingInputsType,
@@ -110,16 +100,6 @@ public protocol TextDecoding {
         options: DecodingOptions,
         temperature: FloatType
     ) async throws -> DecodingResult
-
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `detectLanguage(from:using:sampler:options:temperature:) async throws -> DecodingResult` instead.")
-    @_disfavoredOverload
-    func detectLanguage(
-        from encoderOutput: MLMultiArray,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options: DecodingOptions,
-        temperature: FloatType
-    ) async throws -> [DecodingResult]
 
     static func updateKVCache(
         keyTensor: MLMultiArray,
@@ -131,112 +111,6 @@ public protocol TextDecoding {
 }
 
 public extension TextDecoding {
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `decodeText(from:using:sampler:options:callback:) async throws -> DecodingResult` instead.")
-    func decodeText(
-        from encoderOutput: MLMultiArray,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options decoderOptions: DecodingOptions,
-        callback: TranscriptionCallback?
-    ) async throws -> [DecodingResult] {
-        let result: DecodingResult = try await decodeText(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: decoderOptions,
-            callback: callback
-        )
-        return [result]
-    }
-
-    // Add default conformance for protocol
-    func decodeText(
-        from encoderOutput: any AudioEncoderOutputType,
-        using decoderInputs: any DecodingInputsType,
-        sampler tokenSampler: TokenSampling,
-        options decoderOptions: DecodingOptions,
-        callback: TranscriptionCallback?
-    ) async throws -> DecodingResult {
-        let result: DecodingResult = try await decodeText(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: decoderOptions,
-            callback: callback
-        )
-        return result
-    }
-
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `decodeText(from:using:sampler:options:callback:) async throws -> DecodingResult` instead.")
-    func decodeText(
-        from encoderOutput: any AudioEncoderOutputType,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options decoderOptions: DecodingOptions,
-        callback: TranscriptionCallback?
-    ) async throws -> DecodingResult {
-        let result: DecodingResult = try await decodeText(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: decoderOptions,
-            callback: callback
-        )
-        return result
-    }
-
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `detectLanguage(from:using:sampler:options:temperature:) async throws -> DecodingResult` instead.")
-    func detectLanguage(
-        from encoderOutput: any AudioEncoderOutputType,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options: DecodingOptions,
-        temperature: FloatType
-    ) async throws -> DecodingResult {
-        let result: DecodingResult = try await detectLanguage(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: options,
-            temperature: temperature
-        )
-        return result
-    }
-
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `detectLanguage(from:using:sampler:options:temperature:) async throws -> DecodingResult` instead.")
-    func detectLanguage(
-        from encoderOutput: MLMultiArray,
-        using decoderInputs: DecodingInputs,
-        sampler tokenSampler: TokenSampling,
-        options: DecodingOptions,
-        temperature: FloatType
-    ) async throws -> [DecodingResult] {
-        let result: DecodingResult = try await detectLanguage(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: options,
-            temperature: temperature
-        )
-        return [result]
-    }
-
-    func detectLanguage(
-        from encoderOutput: any AudioEncoderOutputType,
-        using decoderInputs: any DecodingInputsType,
-        sampler tokenSampler: TokenSampling,
-        options: DecodingOptions,
-        temperature: FloatType
-    ) async throws -> DecodingResult {
-        let result: DecodingResult = try await detectLanguage(
-            from: encoderOutput,
-            using: decoderInputs,
-            sampler: tokenSampler,
-            options: options,
-            temperature: temperature
-        )
-        return result
-    }
 
     func prepareDecoderInputs(withPrompt initialPrompt: [Int]) throws -> any DecodingInputsType {
         let tokenShape = [NSNumber(value: 1), NSNumber(value: initialPrompt.count)]
@@ -508,27 +382,27 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
     public init() {}
 
     public var supportsWordTimestamps: Bool {
-        return ModelUtilities.getModelOutputDimention(model, named: "alignment_heads_weights", position: 0) != nil
+        return ModelUtilities.getModelOutputDimension(model, named: "alignment_heads_weights", position: 0) != nil
     }
 
     public var logitsSize: Int? {
-        return ModelUtilities.getModelOutputDimention(model, named: "logits", position: 2)
+        return ModelUtilities.getModelOutputDimension(model, named: "logits", position: 2)
     }
 
     public var kvCacheEmbedDim: Int? {
-        return ModelUtilities.getModelInputDimention(model, named: "key_cache", position: 1)
+        return ModelUtilities.getModelInputDimension(model, named: "key_cache", position: 1)
     }
 
     public var kvCacheMaxSequenceLength: Int? {
-        return ModelUtilities.getModelInputDimention(model, named: "key_cache", position: 3)
+        return ModelUtilities.getModelInputDimension(model, named: "key_cache", position: 3)
     }
 
     public var windowSize: Int? {
-        return ModelUtilities.getModelInputDimention(model, named: "encoder_output_embeds", position: 3)
+        return ModelUtilities.getModelInputDimension(model, named: "encoder_output_embeds", position: 3)
     }
 
     public var embedSize: Int? {
-        return ModelUtilities.getModelInputDimention(model, named: "encoder_output_embeds", position: 1)
+        return ModelUtilities.getModelInputDimension(model, named: "encoder_output_embeds", position: 1)
     }
 
     /// Override default so we an unload the prefill data as well

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -825,17 +825,6 @@ open class WhisperKit {
 
     // MARK: - Transcribe single audio file
 
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `transcribe(audioPath:decodeOptions:callback:) async throws -> [TranscriptionResult]` instead.")
-    @_disfavoredOverload
-    open func transcribe(
-        audioPath: String,
-        decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback? = nil
-    ) async throws -> TranscriptionResult? {
-        let result: [TranscriptionResult] = try await transcribe(audioPath: audioPath, decodeOptions: decodeOptions, callback: callback)
-        return result.first
-    }
-
     /// Transcribes an audio file from the given path asynchronously.
     /// - Parameters:
     ///   - audioPath: The file path to the audio file to be transcribed.
@@ -878,18 +867,6 @@ open class WhisperKit {
     }
 
     // MARK: - Transcribe single audio sample array
-
-    /// Deprecated
-    @available(*, deprecated, message: "Subject to removal in a future version. Use `transcribe(audioArray:decodeOptions:callback:) async throws -> [TranscriptionResult]` instead.")
-    @_disfavoredOverload
-    open func transcribe(
-        audioArray: [Float],
-        decodeOptions: DecodingOptions? = nil,
-        callback: TranscriptionCallback? = nil
-    ) async throws -> TranscriptionResult? {
-        let result: [TranscriptionResult] = try await transcribe(audioArray: audioArray, decodeOptions: decodeOptions, callback: callback)
-        return result.first
-    }
 
     /// Main entry point for transcribing audio
     /// - Parameters:

--- a/Sources/WhisperKit/Utilities/Extensions+Public.swift
+++ b/Sources/WhisperKit/Utilities/Extensions+Public.swift
@@ -44,16 +44,3 @@ public extension String {
         trimmingCharacters(in: Constants.specialTokenCharacters)
     }
 }
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `FileManager.resolveAbsolutePath(_:)` instead.")
-public func resolveAbsolutePath(_ inputPath: String) -> String {
-    return FileManager.resolveAbsolutePath(inputPath)
-}
-
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `ModelUtilities.formatModelFiles(_:)` instead.")
-public extension WhisperKit {
-    static func formatModelFiles(_ modelFiles: [String]) -> [String] {
-        return ModelUtilities.formatModelFiles(modelFiles)
-    }
-}

--- a/Sources/WhisperKit/Utilities/ModelUtilities.swift
+++ b/Sources/WhisperKit/Utilities/ModelUtilities.swift
@@ -203,29 +203,3 @@ extension ModelUtilities {
     }
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `ModelUtilities.loadTokenizer(for:pretrained:tokenizerFolder:useBackgroundSession:)` instead.")
-public func loadTokenizer(
-    for pretrained: ModelVariant,
-    tokenizerFolder: URL? = nil,
-    useBackgroundSession: Bool = false
-) async throws -> WhisperTokenizer {
-    return try await ModelUtilities.loadTokenizer(for: pretrained, tokenizerFolder: tokenizerFolder, useBackgroundSession: useBackgroundSession)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use ModelUtilities.modelSupport(for:from:) -> ModelSupport instead.")
-public func modelSupport(for deviceName: String, from config: ModelSupportConfig? = nil) -> ModelSupport {
-    return ModelUtilities.modelSupport(for: deviceName, from: config)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use ModelUtilities.modelSupport(for:from:) -> ModelSupport instead.")
-@_disfavoredOverload
-public func modelSupport(for deviceName: String, from config: ModelSupportConfig? = nil) -> (default: String, disabled: [String]) {
-    let modelSupport = ModelUtilities.modelSupport(for: deviceName, from: config)
-    return (modelSupport.default, modelSupport.disabled)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `ModelUtilities.detectModelURL(inFolder:named:)` instead.")
-public func detectModelURL(inFolder path: URL, named modelName: String) -> URL {
-    return ModelUtilities.detectModelURL(inFolder: path, named: modelName)
-    
-}

--- a/Sources/WhisperKit/Utilities/TextUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TextUtilities.swift
@@ -53,12 +53,3 @@ public struct TextUtilities {
     }
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TextUtilities.compressionRatio(of:)` instead.")
-public func compressionRatio(of array: [Int]) -> Float {
-    return TextUtilities.compressionRatio(of: array)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TextUtilities.compressionRatio(of:)` instead.")
-public func compressionRatio(of text: String) -> Float {
-    return TextUtilities.compressionRatio(of: text)
-}

--- a/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
@@ -158,27 +158,3 @@ public struct TranscriptionUtilities {
     }
 }
 
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.formatSegments(_:withTimestamps:)` instead.")
-public func formatSegments(_ segments: [TranscriptionSegment], withTimestamps: Bool = true) -> [String] {
-    return TranscriptionUtilities.formatSegments(segments, withTimestamps: withTimestamps)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.findLongestCommonPrefix(_:_:)` instead.")
-public func findLongestCommonPrefix(_ words1: [WordTiming], _ words2: [WordTiming]) -> [WordTiming] {
-    return TranscriptionUtilities.findLongestCommonPrefix(words1, words2)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.findLongestDifferentSuffix(_:_:)` instead.")
-public func findLongestDifferentSuffix(_ words1: [WordTiming], _ words2: [WordTiming]) -> [WordTiming] {
-    TranscriptionUtilities.findLongestDifferentSuffix(words1, words2)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.mergeTranscriptionResults(_:confirmedWords:)` instead.")
-public func mergeTranscriptionResults(_ results: [TranscriptionResult?], confirmedWords: [WordTiming]? = nil) -> TranscriptionResult {
-    return TranscriptionUtilities.mergeTranscriptionResults(results, confirmedWords: confirmedWords)
-}
-
-@available(*, deprecated, message: "Subject to removal in a future version. Use `TranscriptionUtilities.updateSegmentTimings(segment:seekTime:)` instead.")
-public func updateSegmentTimings(segment: TranscriptionSegment, seekTime: Float) -> TranscriptionSegment {
-    return TranscriptionUtilities.updateSegmentTimings(segment: segment, seekTime: seekTime)
-}


### PR DESCRIPTION
Removes all APIs previously marked @available(*, deprecated) or @available(*, unavailable, renamed/message:) across WhisperKit, SpeakerKit, and ArgmaxCore. Callers should migrate to the replacement APIs listed in each original deprecation message.

Removed:
- WhisperKit.transcribe(audioPath:) / transcribe(audioArray:) overloads returning TranscriptionResult? (use [TranscriptionResult] versions)
- TextDecoding.decodeText / detectLanguage MLMultiArray overloads (use any AudioEncoderOutputType / any DecodingInputsType versions)
- Top-level free functions now on ModelUtilities, TranscriptionUtilities, TextUtilities, Logging, and FileManager
- WhisperKit.formatModelFiles (use ModelUtilities.formatModelFiles)
- SpeakerKit.init(models:), SpeakerKit.init(diarizer:), and the SpeakerKitModelManager typealias
- ModelUtilities.getModelInputDimention / getModelOutputDimention misspelled wrappers (use getModelInputDimension / getModelOutputDimension)
- MLTensor sync conversions asIntArray / asFloatArray / asMLMultiArray (use await toIntArray() / toFloatArray() / toMLMultiArray()). As a result, TokenSampling.update(...) is now async.