### PR TITLE
Remove TextDecoderContextPrefill model

### DIFF
--- a/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
+++ b/Examples/WhisperAX/WhisperAX/Views/ContentView.swift
@@ -42,7 +42,6 @@ struct ContentView: View {
     @AppStorage("repoName") private var repoName: String = "argmaxinc/whisperkit-coreml"
     @AppStorage("enableTimestamps") private var enableTimestamps: Bool = true
     @AppStorage("enablePromptPrefill") private var enablePromptPrefill: Bool = true
-    @AppStorage("enableCachePrefill") private var enableCachePrefill: Bool = true
     @AppStorage("enableSpecialCharacters") private var enableSpecialCharacters: Bool = false
     @AppStorage("enableEagerDecoding") private var enableEagerDecoding: Bool = false
     @AppStorage("enableDecoderPreview") private var enableDecoderPreview: Bool = true
@@ -1103,14 +1102,6 @@ struct ContentView: View {
             }
             .padding(.horizontal)
 
-            HStack {
-                Text("Cache Prefill")
-                InfoButton("When Cache Prefill is on, the decoder will try to use a lookup table of pre-computed KV caches instead of computing them during the decoding loop. \nThis allows the model to skip the compute required to force the initial prefill tokens, and can speed up inference")
-                Spacer()
-                Toggle("", isOn: $enableCachePrefill)
-            }
-            .padding(.horizontal)
-
             VStack {
                 HStack {
                     Text("Chunking Strategy")
@@ -1360,7 +1351,6 @@ struct ContentView: View {
             - Mel Spectrogram:  \(getComputeOptions().melCompute.description)
             - Audio Encoder:    \(getComputeOptions().audioEncoderCompute.description)
             - Text Decoder:     \(getComputeOptions().textDecoderCompute.description)
-            - Prefill Data:     \(getComputeOptions().prefillCompute.description)
         """)
 
         whisperKit = nil
@@ -1803,7 +1793,6 @@ struct ContentView: View {
             temperatureFallbackCount: Int(fallbackCount),
             sampleLength: Int(sampleLength),
             usePrefillPrompt: enablePromptPrefill,
-            usePrefillCache: enableCachePrefill,
             skipSpecialTokens: !enableSpecialCharacters,
             withoutTimestamps: !enableTimestamps,
             wordTimestamps: true,
@@ -2054,7 +2043,6 @@ struct ContentView: View {
             temperatureFallbackCount: Int(fallbackCount),
             sampleLength: Int(sampleLength),
             usePrefillPrompt: enablePromptPrefill,
-            usePrefillCache: enableCachePrefill,
             skipSpecialTokens: !enableSpecialCharacters,
             withoutTimestamps: !enableTimestamps,
             wordTimestamps: true, // required for eager mode

--- a/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
+++ b/Examples/WhisperAX/WhisperAXWatchApp/WhisperAXExampleView.swift
@@ -23,7 +23,6 @@ struct WhisperAXWatchView: View {
     @AppStorage("repoName") private var repoName: String = "argmaxinc/whisperkit-coreml"
     @AppStorage("enableTimestamps") private var enableTimestamps: Bool = false
     @AppStorage("enablePromptPrefill") private var enablePromptPrefill: Bool = true
-    @AppStorage("enableCachePrefill") private var enableCachePrefill: Bool = true
     @AppStorage("enableSpecialCharacters") private var enableSpecialCharacters: Bool = false
     @AppStorage("enableEagerDecoder") private var enableEagerDecoder: Bool = false
     @AppStorage("temperatureStart") private var temperatureStart: Double = 0

--- a/Sources/ArgmaxCLI/TranscribeCLIArguments.swift
+++ b/Sources/ArgmaxCLI/TranscribeCLIArguments.swift
@@ -58,9 +58,6 @@ struct TranscribeCLIArguments: ParsableArguments {
     @Flag(help: "Force initial prompt tokens based on language, task, and timestamp options")
     var usePrefillPrompt: Bool = false
 
-    @Flag(help: "Use decoder prefill data for faster initial decoding")
-    var usePrefillCache: Bool = false
-
     @Flag(help: "Skip special tokens in the output")
     var skipSpecialTokens: Bool = false
 

--- a/Sources/ArgmaxCLI/TranscribeCLIUtils.swift
+++ b/Sources/ArgmaxCLI/TranscribeCLIUtils.swift
@@ -54,7 +54,6 @@ internal class TranscribeCLIUtils {
             temperatureFallbackCount: arguments.temperatureFallbackCount,
             topK: arguments.bestOf,
             usePrefillPrompt: arguments.usePrefillPrompt || arguments.language != nil || task == .translate,
-            usePrefillCache: arguments.usePrefillCache,
             skipSpecialTokens: arguments.skipSpecialTokens,
             withoutTimestamps: arguments.withoutTimestamps,
             wordTimestamps: arguments.wordTimestamps,

--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -135,7 +135,6 @@ open class WhisperKitConfig {
 ///   - sampleLength: The maximum number of tokens to sample.
 ///   - topK: Number of candidates when sampling with non-zero temperature.
 ///   - usePrefillPrompt: If true, the prefill tokens will be forced according to task and language settings.
-///   - usePrefillCache: If true, the kv cache will be prefilled based on the prefill data mlmodel.
 ///   - detectLanguage: Use this in conjuntion with `usePrefillPrompt: true` to detect the language of the input audio.
 ///   - skipSpecialTokens: Whether to skip special tokens in the output.
 ///   - withoutTimestamps: Whether to include timestamps in the transcription result.
@@ -163,7 +162,6 @@ public struct DecodingOptions: Codable, Sendable {
     public var sampleLength: Int
     public var topK: Int
     public var usePrefillPrompt: Bool
-    public var usePrefillCache: Bool
     public var detectLanguage: Bool
     public var skipSpecialTokens: Bool
     public var withoutTimestamps: Bool
@@ -193,7 +191,6 @@ public struct DecodingOptions: Codable, Sendable {
         sampleLength: Int = Constants.maxTokenContext,
         topK: Int = 5,
         usePrefillPrompt: Bool = true,
-        usePrefillCache: Bool = true,
         detectLanguage: Bool? = nil,
         skipSpecialTokens: Bool = false,
         withoutTimestamps: Bool = false,
@@ -222,7 +219,6 @@ public struct DecodingOptions: Codable, Sendable {
         self.sampleLength = sampleLength
         self.topK = topK
         self.usePrefillPrompt = usePrefillPrompt
-        self.usePrefillCache = usePrefillCache
         self.detectLanguage = detectLanguage ?? !usePrefillPrompt // If prefill is false, detect language by default
         self.skipSpecialTokens = skipSpecialTokens
         self.withoutTimestamps = withoutTimestamps

--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -93,24 +93,20 @@ public struct ModelComputeOptions: Sendable {
     public var melCompute: MLComputeUnits
     public var audioEncoderCompute: MLComputeUnits
     public var textDecoderCompute: MLComputeUnits
-    public var prefillCompute: MLComputeUnits
 
     public init(
         melCompute: MLComputeUnits = .cpuAndGPU,
         audioEncoderCompute: MLComputeUnits? = nil,
-        textDecoderCompute: MLComputeUnits = .cpuAndNeuralEngine,
-        prefillCompute: MLComputeUnits = .cpuOnly
+        textDecoderCompute: MLComputeUnits = .cpuAndNeuralEngine
     ) {
         if WhisperKit.isRunningOnSimulator {
             self.melCompute = .cpuOnly
             self.audioEncoderCompute = .cpuOnly
             self.textDecoderCompute = .cpuOnly
-            self.prefillCompute = .cpuOnly
             return
         }
 
         self.melCompute = melCompute
-        self.prefillCompute = prefillCompute
         self.textDecoderCompute = textDecoderCompute
 
         if #available(macOS 14.0, iOS 17.0, *) {
@@ -301,10 +297,8 @@ open class DecodingInputs: DecodingInputsType {
     public var alignmentWeights: MLMultiArray
     public var kvCacheUpdateMask: MLMultiArray
     public var decoderKeyPaddingMask: MLMultiArray
-    public var prefillKeyCache: MLMultiArray
-    public var prefillValueCache: MLMultiArray
 
-    public init(initialPrompt: [Int], inputIds: MLMultiArray, cacheLength: MLMultiArray, keyCache: MLMultiArray, valueCache: MLMultiArray, alignmentWeights: MLMultiArray, kvCacheUpdateMask: MLMultiArray, decoderKeyPaddingMask: MLMultiArray, prefillKeyCache: MLMultiArray, prefillValueCache: MLMultiArray) {
+    public init(initialPrompt: [Int], inputIds: MLMultiArray, cacheLength: MLMultiArray, keyCache: MLMultiArray, valueCache: MLMultiArray, alignmentWeights: MLMultiArray, kvCacheUpdateMask: MLMultiArray, decoderKeyPaddingMask: MLMultiArray) {
         self.initialPrompt = initialPrompt
         self.inputIds = inputIds
         self.cacheLength = cacheLength
@@ -313,29 +307,17 @@ open class DecodingInputs: DecodingInputsType {
         self.alignmentWeights = alignmentWeights
         self.kvCacheUpdateMask = kvCacheUpdateMask
         self.decoderKeyPaddingMask = decoderKeyPaddingMask
-        self.prefillKeyCache = prefillKeyCache
-        self.prefillValueCache = prefillValueCache
     }
 
-    public func reset(prefilledCacheSize: Int, maxTokenContext: Int) {
-        // NOTE: Because we have a mask on the kvcache,
-        // we can simply shift the masks without touching the data,
-        // it will be overwritten by the new data without impact on the output
-        cacheLength[0] = NSNumber(value: prefilledCacheSize)
+    public func reset(maxTokenContext: Int) {
+        cacheLength[0] = 0
 
-        // Store token history and
         // Reset masks to prepare for next window
-        for i in 0..<maxTokenContext {
-            if i <= prefilledCacheSize {
-                // Inside overlap window
-                decoderKeyPaddingMask[i] = 0
-                kvCacheUpdateMask[i - 1] = 0
-                kvCacheUpdateMask[i] = 1
-            } else {
-                // Padding
-                decoderKeyPaddingMask[i] = -10000
-                kvCacheUpdateMask[i] = 0
-            }
+        decoderKeyPaddingMask[0] = 0
+        kvCacheUpdateMask[0] = 1
+        for i in 1..<maxTokenContext {
+            decoderKeyPaddingMask[i] = -10000
+            kvCacheUpdateMask[i] = 0
         }
     }
 }
@@ -511,7 +493,6 @@ open class TranscriptionResult: Codable, @unchecked Sendable {
         let logmelsTime = Logging.formatTimeWithPercentage(timings.logmels, timings.totalLogmelRuns, fullDecodingDuration)
         let encodingTime = Logging.formatTimeWithPercentage(timings.encoding, timings.totalEncodingRuns, fullDecodingDuration)
         let decodingInitTime = Logging.formatTimeWithPercentage(timings.decodingInit, 1, fullDecodingDuration)
-        let prefillInfo = Logging.formatTimeWithPercentage(timings.prefill, 1, fullDecodingDuration)
         let predictionsInfo = Logging.formatTimeWithPercentage(timings.decodingPredictions, totalLoops, fullDecodingDuration)
         let filteringInfo = Logging.formatTimeWithPercentage(timings.decodingFiltering, totalLoops, fullDecodingDuration)
         let samplingInfo = Logging.formatTimeWithPercentage(timings.decodingSampling, totalLoops, fullDecodingDuration)
@@ -530,7 +511,6 @@ open class TranscriptionResult: Codable, @unchecked Sendable {
         Mels:                \(logmelsTime)
         Encoding:            \(encodingTime)
         Matrices Init:       \(decodingInitTime)
-        Prefill:             \(prefillInfo)
         Decoding:            \(predictionsInfo)
         Non-inference:       \(nonPredTimeInfo)
         - Logit Filtering:   \(filteringInfo)
@@ -762,7 +742,6 @@ public struct TranscriptionTimings: Codable, Sendable {
     public var audioProcessing: TimeInterval
     public var logmels: TimeInterval
     public var encoding: TimeInterval
-    public var prefill: TimeInterval
     public var decodingInit: TimeInterval
     public var decodingLoop: TimeInterval
     public var decodingPredictions: TimeInterval
@@ -808,7 +787,6 @@ public struct TranscriptionTimings: Codable, Sendable {
                 audioProcessing: TimeInterval = 0,
                 logmels: TimeInterval = 0,
                 encoding: TimeInterval = 0,
-                prefill: TimeInterval = 0,
                 decodingInit: TimeInterval = 0,
                 decodingLoop: TimeInterval = 0,
                 decodingPredictions: TimeInterval = 0,
@@ -843,7 +821,6 @@ public struct TranscriptionTimings: Codable, Sendable {
         self.audioProcessing = audioProcessing
         self.logmels = logmels
         self.encoding = encoding
-        self.prefill = prefill
         self.decodingInit = decodingInit
         self.decodingLoop = decodingLoop
         self.decodingPredictions = decodingPredictions
@@ -1122,85 +1099,6 @@ public class TextDecoderOutput: MLFeatureProvider {
 
     public init(logits: MLMultiArray, key_cache_updates: MLMultiArray, value_cache_updates: MLMultiArray, logits_argmax _: MLMultiArray) {
         self.provider = try! MLDictionaryFeatureProvider(dictionary: ["logits": MLFeatureValue(multiArray: logits), "key_cache_updates": MLFeatureValue(multiArray: key_cache_updates), "value_cache_updates": MLFeatureValue(multiArray: value_cache_updates)])
-    }
-
-    public init(features: MLFeatureProvider) {
-        self.provider = features
-    }
-}
-
-// MARK: TextDecoderCachePrefill
-
-public class TextDecoderCachePrefillInput: MLFeatureProvider {
-    /// task as 1 element vector of 32-bit integers
-    public var task: MLMultiArray
-
-    /// language as 1 element vector of 32-bit integers
-    public var language: MLMultiArray
-
-    public var featureNames: Set<String> {
-        return ["task", "language"]
-    }
-
-    public func featureValue(for featureName: String) -> MLFeatureValue? {
-        if featureName == "task" {
-            return MLFeatureValue(multiArray: self.task)
-        }
-        if featureName == "language" {
-            return MLFeatureValue(multiArray: self.language)
-        }
-        return nil
-    }
-
-    public init(task: MLMultiArray, language: MLMultiArray) {
-        self.task = task
-        self.language = language
-    }
-
-    public convenience init(task: MLShapedArray<Int32>, language: MLShapedArray<Int32>) {
-        self.init(task: MLMultiArray(task), language: MLMultiArray(language))
-    }
-}
-
-/// Model Prediction Output Type
-public class TextDecoderCachePrefillOutput: MLFeatureProvider {
-    /// Source provided by CoreML
-    private let provider: MLFeatureProvider
-
-    /// key_cache_prefill as 1 × embed_dim * num_layers × 1 × 3 4-dimensional array of 16-bit floats
-    public var key_cache_prefill: MLMultiArray {
-        return self.provider.featureValue(for: "key_cache_prefill")!.multiArrayValue!
-    }
-
-    /// key_cache_prefill as 1 × embed_dim * num_layers × 1 × 3 4-dimensional array of 16-bit floats
-    @available(macOS, unavailable)
-    @available(macCatalyst, unavailable)
-    public var key_cache_prefillShapedArray: MLShapedArray<Float16> {
-        return MLShapedArray<Float16>(self.key_cache_prefill)
-    }
-
-    /// value_cache_prefill as 1 × embed_dim * num_layers × 1 × 3 4-dimensional array of 16-bit floats
-    public var value_cache_prefill: MLMultiArray {
-        return self.provider.featureValue(for: "value_cache_prefill")!.multiArrayValue!
-    }
-
-    /// value_cache_prefill as 1 × embed_dim * num_layers × 1 × 3 4-dimensional array of 16-bit floats
-    @available(macOS, unavailable)
-    @available(macCatalyst, unavailable)
-    public var value_cache_prefillShapedArray: MLShapedArray<Float16> {
-        return MLShapedArray<Float16>(self.value_cache_prefill)
-    }
-
-    public var featureNames: Set<String> {
-        return self.provider.featureNames
-    }
-
-    public func featureValue(for featureName: String) -> MLFeatureValue? {
-        return self.provider.featureValue(for: featureName)
-    }
-
-    public init(key_cache_prefill: MLMultiArray, value_cache_prefill: MLMultiArray) {
-        self.provider = try! MLDictionaryFeatureProvider(dictionary: ["key_cache_prefill": MLFeatureValue(multiArray: key_cache_prefill), "value_cache_prefill": MLFeatureValue(multiArray: value_cache_prefill)])
     }
 
     public init(features: MLFeatureProvider) {

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -54,12 +54,11 @@ public protocol DecodingInputsType {
     var inputIds: MLMultiArray { get set }
     var cacheLength: MLMultiArray { get set }
 
-    func reset(prefilledCacheSize: Int, maxTokenContext: Int)
+    func reset(maxTokenContext: Int)
 }
 
 public protocol TextDecoding {
     var tokenizer: WhisperTokenizer? { get set }
-    var prefillData: WhisperMLModel? { get set }
     var isModelMultilingual: Bool { get set }
     var supportsWordTimestamps: Bool { get }
     var logitsSize: Int? { get }
@@ -79,11 +78,6 @@ public protocol TextDecoding {
         _ decoderInputs: any DecodingInputsType,
         withOptions options: DecodingOptions?
     ) async throws -> any DecodingInputsType
-
-    func prefillKVCache(
-        withTask task: MLMultiArray,
-        andLanguage language: MLMultiArray
-    ) async throws -> DecodingCache?
 
     func decodeText(
         from encoderOutput: any AudioEncoderOutputType,
@@ -273,8 +267,6 @@ public extension TextDecoding {
         let alignmentWeights = try MLMultiArray(shape: [kvCacheMaxSequenceLengthValue, encoderOutputDimValue], dataType: .float16, initialValue: FloatType(0))
         let kvCacheUpdateMask = try MLMultiArray(shape: [1, kvCacheMaxSequenceLengthValue], dataType: .int32, initialValue: Int32(0))
         let decoderKeyPaddingMask = try MLMultiArray(shape: [1, kvCacheMaxSequenceLengthValue], dataType: .float16, initialValue: FloatType(-10000))
-        let prefillKeyCache = try! MLMultiArray(shape: [1, kvCacheEmbedDimValue, 1, kvCacheMaxSequenceLengthValue], dataType: .float16)
-        let prefillValueCache = try! MLMultiArray(shape: [1, kvCacheEmbedDimValue, 1, kvCacheMaxSequenceLengthValue], dataType: .float16)
 
         // Initialize default masks
         kvCacheUpdateMask[0] = 1.0
@@ -288,9 +280,7 @@ public extension TextDecoding {
             valueCache: valueCache,
             alignmentWeights: alignmentWeights,
             kvCacheUpdateMask: kvCacheUpdateMask,
-            decoderKeyPaddingMask: decoderKeyPaddingMask,
-            prefillKeyCache: prefillKeyCache,
-            prefillValueCache: prefillValueCache
+            decoderKeyPaddingMask: decoderKeyPaddingMask
         )
 
         return decoderInputs
@@ -312,20 +302,17 @@ public extension TextDecoding {
         // Setup prefill tokens based on task and language
         var prefillTokens: [Int] = [tokenizer.specialTokens.startOfTranscriptToken] // SOT
 
-        var languageToken: Int = tokenizer.specialTokens.englishToken
-        var taskToken: Int = tokenizer.specialTokens.transcribeToken
-
         // Multilingual models require language and task tokens
         if let options = options {
             if isModelMultilingual {
                 // Set languageToken
                 let languageTokenString = "<|\(options.language ?? Constants.defaultLanguageCode)|>"
-                languageToken = tokenizer.convertTokenToId(languageTokenString) ?? tokenizer.specialTokens.englishToken
+                let languageToken = tokenizer.convertTokenToId(languageTokenString) ?? tokenizer.specialTokens.englishToken
                 prefillTokens.append(languageToken)
 
                 // Set taskToken
                 let taskTokenString = "<|\(options.task)|>"
-                taskToken = tokenizer.convertTokenToId(taskTokenString) ?? tokenizer.specialTokens.transcribeToken
+                let taskToken = tokenizer.convertTokenToId(taskTokenString) ?? tokenizer.specialTokens.transcribeToken
                 prefillTokens.append(taskToken)
             }
 
@@ -348,67 +335,10 @@ public extension TextDecoding {
         }
 
         prefilledDecoderInputs.initialPrompt = prefillTokens
-        var prefilledCacheSize = 0
-        if options?.usePrefillCache ?? false,
-           prefillData != nil,
-           options?.promptTokens == nil // TODO: allow prefill cache to be used with prompt tokens, currently breaks if it starts at non-zero index
-        {
-            // Prefilling kv cache data requires non-nil task and language tokens, set defaults if not provided
-            // Task tokens are remapped to 0->transcribe and 1->translate for the prefill lookup table
-            let task = try MLMultiArray.from([taskToken == tokenizer.specialTokens.transcribeToken ? 0 : 1])
-            let lang = try MLMultiArray.from([languageToken])
-            guard let prefillOutput = try await self.prefillKVCache(withTask: task, andLanguage: lang) else {
-                Logging.error("Unable to prefill cache")
-                return prefilledDecoderInputs
-            }
-
-            // Prefill kv cache
-            prefilledDecoderInputs.prefillKeyCache = prefillOutput.keyCache!
-            prefilledDecoderInputs.prefillValueCache = prefillOutput.valueCache!
-
-            TextDecoder.updateKVCache(keyTensor: prefilledDecoderInputs.keyCache,
-                                      keySlice: prefilledDecoderInputs.prefillKeyCache,
-                                      valueTensor: prefilledDecoderInputs.valueCache,
-                                      valueSlice: prefilledDecoderInputs.prefillValueCache,
-                                      insertAtIndex: prefillTokens.firstIndex(of: tokenizer.specialTokens.startOfTranscriptToken) ?? 0)
-            prefilledDecoderInputs.cacheLength[0] = prefilledDecoderInputs.prefillKeyCache.shape[3]
-            prefilledCacheSize = prefilledDecoderInputs.cacheLength[0].intValue
-        }
-
-        // Setup masks based on prefill values
-        prefilledCacheSize += 1 // Add 1 for initial masked cache update
-        for i in 0..<prefilledCacheSize {
-            prefilledDecoderInputs.kvCacheUpdateMask[i] = 0.0
-            prefilledDecoderInputs.decoderKeyPaddingMask[i] = 0.0
-        }
-        prefilledDecoderInputs.kvCacheUpdateMask[prefilledCacheSize - 1] = 1.0
+        prefilledDecoderInputs.kvCacheUpdateMask[0] = 1.0
+        prefilledDecoderInputs.decoderKeyPaddingMask[0] = 0.0
 
         return prefilledDecoderInputs
-    }
-
-    func prefillKVCache(withTask task: MLMultiArray, andLanguage language: MLMultiArray) async throws -> DecodingCache? {
-        let modelInputs = TextDecoderCachePrefillInput(
-            task: task,
-            language: language
-        )
-
-        guard let prefillModel = prefillData?.model else {
-            return nil
-        }
-
-        try Task.checkCancellation()
-
-        let outputFeatures = try await prefillModel.asyncPrediction(from: modelInputs, options: MLPredictionOptions())
-
-        let output = TextDecoderCachePrefillOutput(features: outputFeatures)
-
-        let kvCache = DecodingCache(
-            keyCache: output.key_cache_prefill,
-            valueCache: output.value_cache_prefill,
-            alignmentWeights: nil
-        )
-
-        return kvCache
     }
 
     static func updateKVCache(keyTensor: MLMultiArray, keySlice: MLMultiArray,
@@ -492,14 +422,9 @@ public extension TextDecoding {
     }
 }
 
-public class TextDecoderContextPrefill: WhisperMLModel {
-    public var model: MLModel?
-}
-
 open class TextDecoder: TextDecoding, WhisperMLModel {
     public var model: MLModel?
     public var tokenizer: WhisperTokenizer?
-    public var prefillData: WhisperMLModel?
     public var isModelMultilingual: Bool = false
     public var logitsFilters: [any LogitsFiltering]? = []
     private let earlyStopActor = EarlyStopActor()
@@ -531,10 +456,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         return ModelUtilities.getModelInputDimention(model, named: "encoder_output_embeds", position: 1)
     }
 
-    /// Override default so we an unload the prefill data as well
     public func unloadModel() {
         model = nil
-        prefillData = nil
         languageLogitsFilter = nil
     }
 

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -85,18 +85,11 @@ open class TranscribeTask {
         timings.decodingInit = decoderInitTime
         Logging.debug("Decoder init time: \(decoderInitTime)")
 
-        // MARK: - Prefill KV Cache
+        // MARK: - Prefill Prompt
 
-        let prefillStartTime = CFAbsoluteTimeGetCurrent()
         if options.usePrefillPrompt {
             decoderInputs = try await textDecoder.prefillDecoderInputs(decoderInputs, withOptions: options)
         }
-        // Update cache size based on prefill
-        let prefilledCacheSize = decoderInputs.cacheLength[0].intValue
-        let prefillTime = CFAbsoluteTimeGetCurrent() - prefillStartTime
-        timings.prefill = prefillTime
-
-        Logging.debug("Prefill time: \(prefillTime)")
         Logging.debug("Prefill prompt: \(decoderInputs.initialPrompt.map { tokenizer.convertIdToToken($0) ?? "" })")
 
         // MARK: - Main decoder loop
@@ -176,7 +169,6 @@ open class TranscribeTask {
                     decodingOptions: options,
                     decoderInputs: &decoderInputs,
                     detectedLanguage: &detectedLanguage,
-                    prefilledCacheSize: prefilledCacheSize,
                     callback: decodingCallback
                 )
 
@@ -277,7 +269,6 @@ open class TranscribeTask {
 
                 // Reset cache and move on to the next window
                 decoderInputs.reset(
-                    prefilledCacheSize: prefilledCacheSize,
                     maxTokenContext: decodeOptions?.sampleLength ?? Constants.maxTokenContext
                 )
 
@@ -327,7 +318,6 @@ open class TranscribeTask {
         decodingOptions options: DecodingOptions,
         decoderInputs: inout any DecodingInputsType,
         detectedLanguage: inout String?,
-        prefilledCacheSize: Int,
         callback: TranscriptionCallback? = nil
     ) async throws -> DecodingResult {
         let interval = Logging.beginSignpost("Decode", signposter: Logging.TranscribeTask.signposter)
@@ -406,7 +396,6 @@ open class TranscribeTask {
                 timings.decodingFallback += Date().timeIntervalSince(decodeWithFallbackStart)
                 timings.totalDecodingFallbacks = Double(i)
                 decoderInputs.reset(
-                    prefilledCacheSize: prefilledCacheSize,
                     maxTokenContext: options.sampleLength
                 )
                 Logging.info("Fallback #\(i + 1) (\(fallback.fallbackReason))")

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -372,7 +372,6 @@ open class WhisperKit {
         let logmelUrl = ModelUtilities.detectModelURL(inFolder: path, named: "MelSpectrogram")
         let encoderUrl = ModelUtilities.detectModelURL(inFolder: path, named: "AudioEncoder")
         let decoderUrl = ModelUtilities.detectModelURL(inFolder: path, named: "TextDecoder")
-        let decoderPrefillUrl = ModelUtilities.detectModelURL(inFolder: path, named: "TextDecoderContextPrefill")
 
         for item in [logmelUrl, encoderUrl, decoderUrl] {
             if !FileManager.default.fileExists(atPath: item.path) {
@@ -388,17 +387,6 @@ open class WhisperKit {
                 prewarmMode: prewarmMode
             )
             Logging.debug("Loaded feature extractor")
-        }
-
-        if FileManager.default.fileExists(atPath: decoderPrefillUrl.path) {
-            Logging.debug("Loading text decoder prefill data")
-            textDecoder.prefillData = TextDecoderContextPrefill()
-            try await textDecoder.prefillData?.loadModel(
-                at: decoderPrefillUrl,
-                computeUnits: modelCompute.prefillCompute,
-                prewarmMode: prewarmMode
-            )
-            Logging.debug("Loaded text decoder prefill data")
         }
 
         if let textDecoder = textDecoder as? WhisperMLModel {

--- a/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
@@ -123,7 +123,6 @@ public struct TranscriptionUtilities {
             audioProcessing: validResults.map { $0.timings.audioProcessing }.reduce(0, +),
             logmels: validResults.map { $0.timings.logmels }.reduce(0, +),
             encoding: validResults.map { $0.timings.encoding }.reduce(0, +),
-            prefill: validResults.map { $0.timings.prefill }.reduce(0, +),
             decodingInit: validResults.map { $0.timings.decodingInit }.reduce(0, +),
             decodingLoop: validResults.map { $0.timings.decodingLoop }.reduce(0, +),
             decodingPredictions: validResults.map { $0.timings.decodingPredictions }.reduce(0, +),

--- a/Sources/WhisperKit/Utilities/WhisperError.swift
+++ b/Sources/WhisperKit/Utilities/WhisperError.swift
@@ -7,7 +7,6 @@ import Foundation
 public enum WhisperError: Error, LocalizedError, Equatable {
     case tokenizerUnavailable(String = "Tokenizer is unavailable")
     case modelsUnavailable(String = "Models are unavailable")
-    case prefillFailed(String = "Prefill failed")
     case audioProcessingFailed(String = "Audio processing failed")
     case decodingLogitsFailed(String = "Unable to decode logits from the model output")
     case segmentingFailed(String = "Creating segments failed")
@@ -22,7 +21,6 @@ public enum WhisperError: Error, LocalizedError, Equatable {
         switch self {
         case let .tokenizerUnavailable(message),
             let .modelsUnavailable(message),
-            let .prefillFailed(message),
             let .audioProcessingFailed(message),
             let .decodingLogitsFailed(message),
             let .segmentingFailed(message),


### PR DESCRIPTION
### Summary
Removes the `TextDecoderContextPrefill` model along `usePrefillCache` decoding flags. What goes away is the optional KV-cache pre-seeding path, where a separate CoreML model supplied precomputed key/value cache entries for the initial tokens (SOT, language, task, timestamp) to skip the first decoder step. The decoder's own KV cache is unchanged and still populated normally as decoding proceeds.

### API breaking changes
DecodingOptions:
- Removed field `usePrefillCache: Bool`

TextDecoding protocol / TextDecoder class:
- Removed property `prefillData: WhisperMLModel?`
- Removed method `prefillKVCache(withTask:andLanguage:)`
- Removed class `TextDecoderContextPrefill`

DecodingInputsType protocol / DecodingInputs class:
- `reset(prefilledCacheSize:maxTokenContext:)` -> `reset(maxTokenContext:) (first param dropped)`
- Removed fields `prefillKeyCache`, `prefillValueCache`
- `DecodingInputs.init` no longer accepts those two parameters

ModelComputeOptions: 
- Removed field `prefillCompute: MLComputeUnits`; removed from init

TranscriptionTimings / DecodingTimings
- Removed field `prefill: TimeInterval`; removed from init

WhisperError
- Removed `case .prefillFailed`

Removed types:
- `TextDecoderCachePrefillInput`
- `TextDecoderCachePrefillOutput`

CLI
Removed --use-prefill-cache flag