### PR TITLE
Add ArgmaxOSSDynamic product

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Approvals
         id: reviews
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
           echo "Runtimes for testing:"
           xcrun simctl list runtimes
           echo "Destinations for testing:"
-          xcodebuild test-without-building -testPlan UnitTestsPlan -scheme whisperkit-Package -showdestinations
+          xcodebuild test-without-building -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -showdestinations
       - name: Boot Simulator and Wait
         if: ${{ matrix.run-config['condition'] == true }} && ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-26' }}
         # Slower runners require some time to fully boot the simulator
@@ -95,8 +95,8 @@ jobs:
         if: ${{ matrix.run-config['condition'] == true }}
         run: |
           set -o pipefail
-          xcodebuild clean build-for-testing -scheme whisperkit-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcpretty
-          xcodebuild test -testPlan UnitTestsPlan -scheme whisperkit-Package -destination '${{ matrix.run-config['test-destination'] }}'
+          xcodebuild clean build-for-testing -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcpretty
+          xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}'
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
             }
     timeout-minutes: ${{ matrix.run-config['name'] == 'visionOS' && 60 || 30 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ inputs.xcode-version || '26.4.1' }}
@@ -63,7 +63,7 @@ jobs:
         run: make setup
       - name: Setup Cache
         id: model-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Models
           key: ${{ runner.os }}-models
@@ -83,7 +83,7 @@ jobs:
           echo "Destinations for testing:"
           xcodebuild test-without-building -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -showdestinations
       - name: Boot Simulator and Wait
-        if: ${{ matrix.run-config['condition'] == true }} && ${{ matrix.run-config['name'] != 'macOS' }} && ${{ inputs.macos-runner == 'macos-26' }}
+        if: ${{ matrix.run-config['condition'] == true && matrix.run-config['name'] != 'macOS' && inputs.macos-runner == 'macos-26' }}
         # Slower runners require some time to fully boot the simulator
         # Parse the simulator name from the destination string, boot it, and wait
         run: |

--- a/.swiftpm/xcode/xcshareddata/xcschemes/argmax-oss-swift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/argmax-oss-swift-Package.xcscheme
@@ -62,6 +62,48 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ArgmaxOSSDynamic"
+               BuildableName = "ArgmaxOSSDynamic"
+               BlueprintName = "ArgmaxOSSDynamic"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpeakerKit"
+               BuildableName = "SpeakerKit"
+               BlueprintName = "SpeakerKit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "argmax-cli"
+               BuildableName = "argmax-cli"
+               BlueprintName = "argmax-cli"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -112,12 +154,21 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+            BlueprintIdentifier = "argmax-cli"
+            BuildableName = "argmax-cli"
+            BlueprintName = "argmax-cli"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
             BlueprintIdentifier = "whisperkit-cli"
             BuildableName = "whisperkit-cli"
             BlueprintName = "whisperkit-cli"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -129,9 +180,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "whisperkit-cli"
-            BuildableName = "whisperkit-cli"
-            BlueprintName = "whisperkit-cli"
+            BlueprintIdentifier = "argmax-cli"
+            BuildableName = "argmax-cli"
+            BlueprintName = "argmax-cli"
             ReferencedContainer = "container:">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Package.swift
+++ b/Package.swift
@@ -56,31 +56,25 @@ let package = Package(
                 "TTSKit",
                 "SpeakerKit",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "ArgmaxCore",
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "WhisperKit",
             dependencies: [
                 "ArgmaxCore",
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "TTSKit",
             dependencies: [
                 "ArgmaxCore",
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "SpeakerKit",
@@ -88,7 +82,7 @@ let package = Package(
                 "ArgmaxCore",
                 "WhisperKit",
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
+            swiftSettings: swiftSettings()
         ),
         .testTarget(
             name: "WhisperKitTests",
@@ -99,18 +93,14 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .testTarget(
             name: "TTSKitTests",
             dependencies: [
                 "TTSKit"
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .testTarget(
             name: "SpeakerKitTests",
@@ -121,9 +111,7 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            swiftSettings: swiftSettings()
         ),
         .executableTarget(
             name: "ArgmaxCLI",
@@ -139,9 +127,7 @@ let package = Package(
             ] : []),
             path: "Sources/ArgmaxCLI",
             exclude: (isServerEnabled() ? [] : ["Server"]),
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency"),
-            ] + (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
+            swiftSettings: swiftSettings() + (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
         )
     ],
     swiftLanguageVersions: [.v5]
@@ -154,4 +140,8 @@ func isServerEnabled() -> Bool {
 
     // Default disabled, change to true temporarily for local development
     return false
+}
+
+func swiftSettings() -> [SwiftSetting] {
+    [.enableExperimentalFeature("StrictConcurrency")]
 }

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -4,11 +4,6 @@
 import PackageDescription
 import Foundation
 
-let approachableConcurrencySettings: [SwiftSetting] = [
-    .enableUpcomingFeature("InferIsolatedConformances"),
-    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-]
-
 let package = Package(
     name: "argmax-oss-swift",
     platforms: [
@@ -33,6 +28,11 @@ let package = Package(
         .library(
             name: "SpeakerKit",
             targets: ["SpeakerKit"]
+        ),
+        .library(
+            name: "ArgmaxOSSDynamic",
+            type: .dynamic,
+            targets: ["ArgmaxOSS"]
         ),
         .executable(
             name: "argmax-cli",
@@ -60,25 +60,25 @@ let package = Package(
                 "TTSKit",
                 "SpeakerKit",
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "ArgmaxCore",
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "WhisperKit",
             dependencies: [
                 "ArgmaxCore",
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "TTSKit",
             dependencies: [
                 "ArgmaxCore",
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings()
         ),
         .target(
             name: "SpeakerKit",
@@ -86,7 +86,7 @@ let package = Package(
                 "ArgmaxCore",
                 "WhisperKit",
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings()
         ),
         .testTarget(
             name: "WhisperKitTests",
@@ -97,14 +97,14 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings(libraryEvolution: false)
         ),
         .testTarget(
             name: "TTSKitTests",
             dependencies: [
                 "TTSKit"
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings(libraryEvolution: false)
         ),
         .testTarget(
             name: "SpeakerKitTests",
@@ -115,7 +115,7 @@ let package = Package(
             resources: [
                 .process("Resources"),
             ],
-            swiftSettings: approachableConcurrencySettings
+            swiftSettings: swiftSettings(libraryEvolution: false)
         ),
         .executableTarget(
             name: "ArgmaxCLI",
@@ -131,7 +131,7 @@ let package = Package(
             ] : []),
             path: "Sources/ArgmaxCLI",
             exclude: (isServerEnabled() ? [] : ["Server"]),
-            swiftSettings: approachableConcurrencySettings + (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
+            swiftSettings: swiftSettings(libraryEvolution: false) + (isServerEnabled() ? [.define("BUILD_SERVER_CLI")] : [])
         )
     ],
     swiftLanguageModes: [.v6]
@@ -144,4 +144,36 @@ func isServerEnabled() -> Bool {
 
     // Default disabled, change to true temporarily for local development
     return false
+}
+
+func swiftSettings(libraryEvolution: Bool = true) -> [SwiftSetting] {
+    // Opt-in to Swift 6.2's "Approachable Concurrency" upcoming features.
+    // These reduce false-positive concurrency diagnostics by making the
+    // compiler infer isolation in places where it's almost always what the
+    // developer intended:
+    //   - InferIsolatedConformances (SE-0470): a protocol conformance on a
+    //     globally-isolated type (e.g. @MainActor) is itself inferred to be
+    //     isolated to that same actor, instead of forcing a `nonisolated`
+    //     conformance that can't touch the type's state.
+    //   - NonisolatedNonsendingByDefault (SE-0461): a `nonisolated` async
+    //     function runs on the caller's actor by default rather than hopping
+    //     to the generic executor, avoiding spurious Sendable errors on
+    //     arguments and return values that never actually cross actors.
+    let approachableConcurrencySettings: [SwiftSetting] = [
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    ]
+
+    // Equivalent to Xcode's BUILD_LIBRARY_FOR_DISTRIBUTION setting: enables
+    // library evolution and module stability so these targets can be linked
+    // against prebuilt binary frameworks (e.g. an .xcframework) without
+    // requiring the framework to be rebuilt for every Swift compiler version.
+    let dynamicSettings: [SwiftSetting] = libraryEvolution ? [
+        .unsafeFlags([
+            "-enable-library-evolution",
+            "-Xfrontend", "-alias-module-names-in-module-interface",
+        ])
+    ] : []
+
+    return approachableConcurrencySettings + dynamicSettings
 }

--- a/Sources/ArgmaxCore/ModelState.swift
+++ b/Sources/ArgmaxCore/ModelState.swift
@@ -17,7 +17,7 @@ import Foundation
 /// loaded   → unloading  → unloaded
 /// ```
 @frozen
-public enum ModelState: CustomStringConvertible {
+public enum ModelState: CustomStringConvertible, Equatable, Hashable {
     case unloading
     case unloaded
     case loading


### PR DESCRIPTION
- Adds a new `ArgmaxOSSDynamic` library product to `Package@swift-6.2.swift`
- Enables library evolution (-enable-library-evolution + -alias-module-names-in-module-interface) on every library target via a new libraryEvolutionSettings group, so these modules can be linked against prebuilt binary frameworks without recompilation per Swift version.
- Declares explicit Equatable, Hashable conformance on ModelState so its protocol witnesses are exported across the resilience boundary.
- Only applies to the Swift 6.2 manifest because `unsafeFlags` historically blocked SemVer-based dependency resolution; Swift 6.2+ lifted that restriction, so consumers can still depend on this package via `.package(url:, from:)`. Older toolchains continue to use the unchanged `Package.swift`.