### PR TITLE
Add TTS endpoint (/v1/audio/speech) to local server

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,69 @@
 {
+  "originHash" : "92120d48fcd51bd047cfb7f7d5d9501b317f54d4b27da07be1c4c49cc7066d4b",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
+      }
+    },
+    {
+      "identity" : "console-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/console-kit.git",
+      "state" : {
+        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
+        "version" : "4.16.0"
+      }
+    },
+    {
+      "identity" : "multipart-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/multipart-kit.git",
+      "state" : {
+        "revision" : "3498e60218e6003894ff95192d756e238c01f44e",
+        "version" : "4.7.1"
+      }
+    },
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit",
+      "state" : {
+        "revision" : "343b2c1793058fcc53c1bd7e2907f8e3a4d640fb",
+        "version" : "3.9.0"
+      }
+    },
+    {
+      "identity" : "routing-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/routing-kit.git",
+      "state" : {
+        "revision" : "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
+        "version" : "4.9.3"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -8,7 +72,250 @@
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
       }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-openapi-generator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-generator",
+      "state" : {
+        "revision" : "83e8301d6d62c423f8e11d6fcb0c8276d4dbb032",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-openapi-runtime",
+      "state" : {
+        "revision" : "f039fa6d6338aab5164f3d1be16281524c9a8f89",
+        "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-openapi-vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-openapi-vapor",
+      "state" : {
+        "revision" : "b53c1517e889d5479567729fbe143a59da302ffc",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "vapor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/vapor.git",
+      "state" : {
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/ArgmaxCLI/Server/ServeCLI.swift
+++ b/Sources/ArgmaxCLI/Server/ServeCLI.swift
@@ -5,6 +5,7 @@ import ArgumentParser
 import CoreML
 import Foundation
 @preconcurrency import WhisperKit
+import TTSKit
 import Vapor
 import OpenAPIRuntime
 import OpenAPIVapor
@@ -48,10 +49,11 @@ struct ServeCLI: AsyncParsableCommand {
         app.get("") { req async throws -> EndpointInfo in
             return EndpointInfo(
                 status: "ok",
-                service: "WhisperKit Local Server",
+                service: "Argmax Voice Server",
                 endpoints: [
                     Endpoint(method: "POST", path: "/v1/audio/transcriptions", description: "Transcribe audio to text"),
                     Endpoint(method: "POST", path: "/v1/audio/translations", description: "Translate audio to English"),
+                    Endpoint(method: "POST", path: "/v1/audio/speech", description: "Generate speech from text"),
                     Endpoint(method: "GET", path: "/health", description: "Health check endpoint")
                 ]
             )
@@ -59,6 +61,82 @@ struct ServeCLI: AsyncParsableCommand {
 
         app.get("health") { req async throws -> [String: String] in
             return ["status": "ok"]
+        }
+
+        // --- TTS Setup ---
+        app.logger.notice("Loading TTSKit (Qwen3-TTS 0.6B)...")
+        let ttsConfig = TTSKitConfig(model: .qwen3TTS_0_6b, verbose: cliArguments.transcribe.verbose)
+        let ttsKit = try await TTSKit(ttsConfig)
+        app.logger.notice("TTSKit loaded successfully")
+
+        app.post("v1", "audio", "speech") { req async throws -> Response in
+            struct SpeechRequest: Content {
+                var input: String
+                var model: String?
+                var voice: String?
+                var language: String?
+                var response_format: String?
+                var speed: Float?
+            }
+
+            let speechReq = try req.content.decode(SpeechRequest.self)
+
+            guard !speechReq.input.isEmpty else {
+                throw Abort(.badRequest, reason: "input text must not be empty")
+            }
+
+            let speaker: Qwen3Speaker = {
+                switch speechReq.voice?.lowercased() {
+                case "alloy", nil: return .ryan
+                case "echo": return .aiden
+                case "nova": return .serena
+                case "shimmer": return .vivian
+                case "onyx": return .eric
+                case "fable": return .dylan
+                default:
+                    return Qwen3Speaker(rawValue: speechReq.voice ?? "ryan") ?? .ryan
+                }
+            }()
+
+            let language: Qwen3Language = {
+                switch speechReq.language?.lowercased() {
+                case "es", "spanish": return .spanish
+                case "en", "english", nil: return .english
+                case "fr", "french": return .french
+                case "de", "german": return .german
+                case "pt", "portuguese": return .portuguese
+                case "it", "italian": return .italian
+                case "ja", "japanese": return .japanese
+                case "ko", "korean": return .korean
+                case "zh", "chinese": return .chinese
+                case "ru", "russian": return .russian
+                default: return .english
+                }
+            }()
+
+            let options = GenerationOptions(
+                temperature: 0.9,
+                topK: 50,
+                repetitionPenalty: 1.05,
+                maxNewTokens: 245,
+                concurrentWorkerCount: 1
+            )
+
+            req.logger.notice("TTS request: voice=\(speaker.rawValue) language=\(language.rawValue) text=\"\(speechReq.input.prefix(80))\"")
+
+            let result = try await ttsKit.generate(
+                text: speechReq.input,
+                speaker: speaker,
+                language: language,
+                options: options
+            )
+
+            let wavData = TTSAudioEncoder.encodeWAV(samples: result.audio, sampleRate: result.sampleRate)
+
+            var headers = HTTPHeaders()
+            headers.add(name: .contentType, value: "audio/wav")
+            headers.add(name: .contentDisposition, value: "attachment; filename=\"speech.wav\"")
+            return Response(status: .ok, headers: headers, body: .init(data: wavData))
         }
     }
 
@@ -98,4 +176,40 @@ fileprivate struct EndpointInfo: Content {
     let status: String
     let service: String
     let endpoints: [Endpoint]
+}
+
+enum TTSAudioEncoder {
+    static func encodeWAV(samples: [Float], sampleRate: Int) -> Data {
+        let numChannels: Int16 = 1
+        let bitsPerSample: Int16 = 16
+        let byteRate = Int32(sampleRate * Int(numChannels) * Int(bitsPerSample / 8))
+        let blockAlign = Int16(numChannels * (bitsPerSample / 8))
+        let dataSize = Int32(samples.count * Int(bitsPerSample / 8))
+        let chunkSize = 36 + dataSize
+
+        var data = Data()
+        data.reserveCapacity(44 + samples.count * 2)
+
+        data.append(contentsOf: "RIFF".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: chunkSize.littleEndian) { Array($0) })
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: Int32(16).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: Int16(1).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: numChannels.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: Int32(sampleRate).littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: byteRate.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: blockAlign.littleEndian) { Array($0) })
+        data.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
+        data.append(contentsOf: "data".utf8)
+        data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
+
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let int16Val = Int16(clamped * Float(Int16.max))
+            data.append(contentsOf: withUnsafeBytes(of: int16Val.littleEndian) { Array($0) })
+        }
+
+        return data
+    }
 }


### PR DESCRIPTION
  ## Summary

  Adds a text-to-speech endpoint to the local server (`argmax-cli serve`), enabling the same server to handle both STT and TTS via OpenAI-compatible APIs.

  - `POST /v1/audio/transcriptions` — STT (existing)
  - `POST /v1/audio/speech` — TTS (new)

  ## Changes

  - Import `TTSKit` in `ServeCLI.swift`
  - Load Qwen3-TTS 0.6B model alongside WhisperKit on server startup
  - Add `POST /v1/audio/speech` as a manual Vapor route (same pattern as `/health`)
  - OpenAI voice name mapping (alloy → ryan, nova → serena, echo → aiden, shimmer → vivian, onyx → eric, fable → dylan) with passthrough for native Qwen3 voice names
  - 10 languages supported via short code or full name (es/spanish, en/english, fr/french, etc.)
  - WAV response encoder (24kHz mono 16-bit PCM)
  - Updated endpoint listing on root `/` route

  ## Motivation

  The local server currently only handles transcription. Adding TTS makes it a complete voice server — useful for smart home assistants, accessibility tools, or any application needing
  both STT and TTS from a single local endpoint on Apple Silicon.

  ## Real-world usage

  I built a Home Assistant custom integration that consumes this endpoint: [ha-argmax-tts](https://github.com/j0nl1/ha-argmax-tts). It registers as a TTS provider in Home Assistant,
  allowing voice assistants to use argmax for local speech synthesis — no cloud APIs needed. The integration supports all 10 languages, configurable voice/model selection via UI, and
  connection validation via `/health`.

  ## Request format

  ```json
  POST /v1/audio/speech
  {
    "input": "Hello world",
    "voice": "nova",
    "language": "en",
    "model": "qwen3-tts-0.6b"
  }

  Returns audio/wav (24kHz mono 16-bit PCM).

  Testing

  Tested on Mac Studio (Apple Silicon) with Qwen3-TTS 0.6B model. TTS generation completes in ~300-500ms for short sentences.