### PR TITLE
Add tokenizerEndpoint to WhisperKitConfig (#388)

### DIFF
--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -15,6 +15,9 @@ open class WhisperKitConfig {
     public var modelToken: String?
     /// HuggingFace Hub compatible endpoint URL
     public var modelEndpoint: String?
+    /// HuggingFace Hub compatible endpoint URL for the tokenizer.
+    /// Falls back to `modelEndpoint` when `nil`. See #388.
+    public var tokenizerEndpoint: String?
     /// Folder to store models
     public var modelFolder: String?
     /// Folder to store tokenizers
@@ -77,6 +80,7 @@ open class WhisperKitConfig {
                 modelRepo: String? = nil,
                 modelToken: String? = nil,
                 modelEndpoint: String? = nil,
+                tokenizerEndpoint: String? = nil,
                 modelFolder: String? = nil,
                 tokenizerFolder: URL? = nil,
                 computeOptions: ModelComputeOptions? = nil,
@@ -100,6 +104,7 @@ open class WhisperKitConfig {
         self.modelRepo = modelRepo
         self.modelToken = modelToken
         self.modelEndpoint = modelEndpoint
+        self.tokenizerEndpoint = tokenizerEndpoint
         self.modelFolder = modelFolder
         self.tokenizerFolder = tokenizerFolder
         self.computeOptions = computeOptions

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -46,6 +46,7 @@ open class WhisperKit {
     /// Configuration
     public var modelFolder: URL?
     public var tokenizerFolder: URL?
+    public var tokenizerEndpoint: String?
     public private(set) var useBackgroundDownloadSession: Bool
 
     /// Callbacks
@@ -67,6 +68,7 @@ open class WhisperKit {
         segmentSeeker = config.segmentSeeker ?? SegmentSeeker()
         voiceActivityDetector = config.voiceActivityDetector
         tokenizerFolder = config.tokenizerFolder ?? config.downloadBase
+        tokenizerEndpoint = config.tokenizerEndpoint ?? config.modelEndpoint
         useBackgroundDownloadSession = config.useBackgroundDownloadSession
         currentTimings = TranscriptionTimings()
         Logging.updateLogLevel(config.verbose ? config.logLevel : .none)
@@ -476,7 +478,8 @@ open class WhisperKit {
             for: modelVariant,
             tokenizerFolder: tokenizerFolder,
             additionalSearchPaths: additionalSearchPaths,
-            useBackgroundSession: useBackgroundDownloadSession
+            useBackgroundSession: useBackgroundDownloadSession,
+            endpoint: tokenizerEndpoint
         )
         currentTimings.tokenizerLoadTime = CFAbsoluteTimeGetCurrent() - tokenizerLoadStart
 

--- a/Sources/WhisperKit/Utilities/ModelUtilities.swift
+++ b/Sources/WhisperKit/Utilities/ModelUtilities.swift
@@ -18,10 +18,15 @@ extension ModelUtilities {
         for pretrained: ModelVariant,
         tokenizerFolder: URL? = nil,
         additionalSearchPaths: [URL] = [],
-        useBackgroundSession: Bool = false
+        useBackgroundSession: Bool = false,
+        endpoint: String? = nil
     ) async throws -> WhisperTokenizer {
         let tokenizerName = tokenizerNameForVariant(pretrained)
-        let hubApi = HubApiWrapper(downloadBase: tokenizerFolder, useBackgroundSession: useBackgroundSession)
+        let hubApi = HubApiWrapper(
+            downloadBase: tokenizerFolder,
+            endpoint: endpoint,
+            useBackgroundSession: useBackgroundSession
+        )
         let hubTokenizerFolder = hubApi.localRepoLocation(HubApiWrapper.Repo(id: tokenizerName))
         
         // Determine which local folder to use

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -962,6 +962,46 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(whisperKitWithDownloadBaseOnly.tokenizerFolder?.path, downloadBaseOnly.path, "tokenizerFolder should fall back to downloadBase when not explicitly set")
     }
     
+    func testTokenizerEndpointFromConfig() async throws {
+        // Default: no endpoint specified — tokenizerEndpoint resolves to nil
+        let configDefault = WhisperKitConfig(model: "tiny", load: false, download: false)
+        let kitDefault = try await WhisperKit(configDefault)
+        XCTAssertNil(kitDefault.tokenizerEndpoint, "tokenizerEndpoint should be nil by default")
+
+        // Only modelEndpoint set — tokenizerEndpoint falls back to modelEndpoint
+        let mirror = "https://hf-mirror.example.com"
+        let configModelOnly = WhisperKitConfig(
+            model: "tiny",
+            modelEndpoint: mirror,
+            load: false,
+            download: false
+        )
+        let kitModelOnly = try await WhisperKit(configModelOnly)
+        XCTAssertEqual(kitModelOnly.tokenizerEndpoint, mirror, "tokenizerEndpoint should fall back to modelEndpoint when not explicitly set")
+
+        // Explicit tokenizerEndpoint overrides fallback
+        let tokenizerMirror = "https://tokenizers.example.com"
+        let configBoth = WhisperKitConfig(
+            model: "tiny",
+            modelEndpoint: mirror,
+            tokenizerEndpoint: tokenizerMirror,
+            load: false,
+            download: false
+        )
+        let kitBoth = try await WhisperKit(configBoth)
+        XCTAssertEqual(kitBoth.tokenizerEndpoint, tokenizerMirror, "tokenizerEndpoint should override modelEndpoint when explicitly set")
+
+        // Only tokenizerEndpoint set — modelEndpoint stays nil
+        let configTokenizerOnly = WhisperKitConfig(
+            model: "tiny",
+            tokenizerEndpoint: tokenizerMirror,
+            load: false,
+            download: false
+        )
+        let kitTokenizerOnly = try await WhisperKit(configTokenizerOnly)
+        XCTAssertEqual(kitTokenizerOnly.tokenizerEndpoint, tokenizerMirror, "tokenizerEndpoint should be set even when modelEndpoint is nil")
+    }
+
     func testTokenizerLoadingPriority() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("tokenizer_loading_test_folder_\(UUID().uuidString)")
         


### PR DESCRIPTION
Fixes #388.

Adds a `tokenizerEndpoint` option to `WhisperKitConfig` so tokenizer downloads honor a custom HuggingFace-compatible endpoint, mirroring `modelEndpoint`. When `tokenizerEndpoint` is `nil` it falls back to `modelEndpoint`, so the issue author's expected behavior — set one endpoint and both downloads route through it — works without extra wiring. Users that need separate endpoints (e.g. a private mirror that only hosts tokenizers) can still override.

### Changes
- `WhisperKitConfig.tokenizerEndpoint: String?` (optional, defaults to `nil`)
- `WhisperKit.tokenizerEndpoint` stored property, resolved at init as `config.tokenizerEndpoint ?? config.modelEndpoint`
- `ModelUtilities.loadTokenizer` gains optional `endpoint:` parameter, passed to `HubApiWrapper(endpoint:)`
- `UnitTests.testTokenizerEndpointFromConfig` covering 4 cases (default / fallback / override / tokenizer-only)

### Test
```
$ swift test --filter UnitTests/testTokenizerEndpointFromConfig
Test Case '-[WhisperKitTests.UnitTests testTokenizerEndpointFromConfig]' passed (0.002 seconds).
```
Adjacent `testTokenizerFolderFromConfig` still passes.

### Backward compatibility
All new parameters/properties are optional with `nil` defaults. The `convenience init` is left alone (parity with how `modelEndpoint` is exposed today).

Happy to broaden the scope to a `DownloadConfig` wrapper as you suggested in the issue thread — let me know if you'd rather have that landed first.