### PR TITLE
Add supportedLanguageCodes API for ModelVariant and WhisperKit (#398)

### DIFF
--- a/Sources/WhisperKit/Core/Models.swift
+++ b/Sources/WhisperKit/Core/Models.swift
@@ -59,6 +59,26 @@ public enum ModelVariant: CustomStringConvertible, CaseIterable {
         }
     }
 
+    /// Whisper language codes (ISO-639-1, or `yue` for Cantonese) supported by this variant.
+    ///
+    /// English-only variants (`.tinyEn`, `.baseEn`, `.smallEn`, `.mediumEn`) report
+    /// just `"en"`. Multilingual variants up to `large-v2` cover the original 99
+    /// Whisper languages. `large-v3` adds Cantonese (`yue`) on top of those.
+    ///
+    /// Note: the turbo distillation (`openai_whisper-large-v3-v20240930`) shares
+    /// the multilingual vocabulary of `large-v3` and is reported as such here, but
+    /// transcription quality outside English is not on par with the full model.
+    public var supportedLanguageCodes: Set<String> {
+        switch self {
+            case .tinyEn, .baseEn, .smallEn, .mediumEn:
+                return ["en"]
+            case .largev3:
+                return Constants.languageCodes
+            case .tiny, .base, .small, .medium, .large, .largev2:
+                return Constants.languageCodes.subtracting(["yue"])
+        }
+    }
+
     public var description: String {
         switch self {
             case .tiny:

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -512,6 +512,19 @@ open class WhisperKit {
         Logging.updateCallback(callback)
     }
 
+    // MARK: - Language support
+
+    /// Whisper language codes supported by the loaded model variant.
+    ///
+    /// English-only models (those with `.en` in the name) return just `"en"`;
+    /// multilingual models return the 99 Whisper language codes, plus `yue`
+    /// (Cantonese) for `large-v3`. The variant is detected from the loaded
+    /// model, so this is only meaningful after `loadModels()` (otherwise it
+    /// falls back to the default `.tiny` variant's languages).
+    open var supportedLanguageCodes: Set<String> {
+        modelVariant.supportedLanguageCodes
+    }
+
     // MARK: - Detect language
 
     /// Detects the language of the audio file at the specified path.

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -1099,6 +1099,32 @@ final class UnitTests: XCTestCase {
         }
     }
     
+    func testSupportedLanguageCodesByVariant() async throws {
+        // English-only variants advertise just english.
+        for variant: ModelVariant in [.tinyEn, .baseEn, .smallEn, .mediumEn] {
+            XCTAssertEqual(variant.supportedLanguageCodes, ["en"],
+                           "English-only variant \(variant.description) should only support 'en'")
+        }
+
+        // Multilingual variants up to large-v2 cover the 99 base Whisper languages
+        // (no Cantonese).
+        let baseMultilingual = Constants.languageCodes.subtracting(["yue"])
+        for variant: ModelVariant in [.tiny, .base, .small, .medium, .large, .largev2] {
+            XCTAssertEqual(variant.supportedLanguageCodes, baseMultilingual,
+                           "Pre-large-v3 multilingual variant \(variant.description) should not include Cantonese")
+            XCTAssertFalse(variant.supportedLanguageCodes.contains("yue"))
+            XCTAssertTrue(variant.supportedLanguageCodes.contains("en"))
+        }
+
+        // large-v3 adds Cantonese on top.
+        XCTAssertEqual(ModelVariant.largev3.supportedLanguageCodes, Constants.languageCodes)
+        XCTAssertTrue(ModelVariant.largev3.supportedLanguageCodes.contains("yue"))
+
+        // The WhisperKit instance forwards to the loaded variant.
+        let kit = try await WhisperKit(prewarm: false, load: false, download: false)
+        XCTAssertEqual(kit.supportedLanguageCodes, kit.modelVariant.supportedLanguageCodes)
+    }
+
     func testTokenizerModelVariantDetection() async throws {
         // Test that model variant detection works correctly for tokenizer selection
         let testDimensions: [(logitsDim: Int, encoderDim: Int, expectedVariant: ModelVariant)] = [


### PR DESCRIPTION
Fixes #398. Adds a simple language-support introspection API on top of the existing variant detection so callers can decide which language list to show in their UI without parsing the model name themselves.

### Changes

- \`ModelVariant.supportedLanguageCodes: Set<String>\`
  - English-only (\`.tinyEn\` / \`.baseEn\` / \`.smallEn\` / \`.mediumEn\`) → \`["en"]\`
  - Multilingual up to \`large-v2\` → \`Constants.languageCodes\` minus \`yue\`
  - \`large-v3\` → \`Constants.languageCodes\` (the extra Cantonese token from [openai/whisper#1762](https://github.com/openai/whisper/discussions/1762))
- \`WhisperKit.supportedLanguageCodes\` forwards to the loaded variant.

The variant is detected from the loaded model via the existing \`ModelUtilities.detectVariant\` path, so this matches whatever \`modelVariant\` reports today — no new detection logic.

### Notes
- The turbo distillation (\`openai_whisper-large-v3-v20240930\`) shares the multilingual vocabulary of \`large-v3\` and is reported the same way here. As @ZachNagengast pointed out in the issue thread, non-English transcription quality on the turbo model is much weaker than the full \`large-v3\`, but that's a quality concern rather than a capability one. Happy to gate it differently if you'd prefer a separate variant case.
- I didn't touch \`Constants.languages\` (the name→code map) — its set of values is already the source of truth for \`Constants.languageCodes\`, which makes the variant-level filter trivial.

### Test
\`\`\`
$ swift test --filter UnitTests/testSupportedLanguageCodesByVariant
Test Case '-[WhisperKitTests.UnitTests testSupportedLanguageCodesByVariant]' passed (0.002 seconds).
\`\`\`
\`testSupportedLanguageCodesByVariant\` covers all 11 variants, the Cantonese inclusion on \`large-v3\`, and the \`WhisperKit\` forwarding (built with \`prewarm:false, load:false, download:false\` so it doesn't hit the network).