### PR TITLE
Scope MLMultiArray pixel-buffer locks via withUnsafeMutableBytes (#308)

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -159,15 +159,27 @@ public extension AudioProcessing {
 
         let audioSamplesArray = try! MLMultiArray(shape: [NSNumber(value: frameLength)], dataType: .float32)
 
-        if actualFrameLength > 0 {
-            audioArray.withUnsafeBufferPointer { sourcePointer in
-                audioSamplesArray.dataPointer.assumingMemoryBound(to: Float.self).advanced(by: 0).initialize(from: sourcePointer.baseAddress!.advanced(by: startIndex), count: actualFrameLength)
+        // Use `withUnsafeMutableBufferPointer` so the CoreML pixel-buffer lock is
+        // scoped to this initialization rather than held until the MLMultiArray
+        // is deallocated (the deprecation warning behind issue #308).
+        audioSamplesArray.withUnsafeMutableBufferPointer(ofType: Float.self) { destPointer, _ in
+            if actualFrameLength > 0 {
+                audioArray.withUnsafeBufferPointer { sourcePointer in
+                    destPointer.baseAddress!.initialize(
+                        from: sourcePointer.baseAddress!.advanced(by: startIndex),
+                        count: actualFrameLength
+                    )
+                }
             }
-        }
-
-        // If the buffer is smaller than the desired frameLength, pad the rest with zeros using vDSP
-        if actualFrameLength < frameLength {
-            vDSP_vclr(audioSamplesArray.dataPointer.assumingMemoryBound(to: Float.self).advanced(by: actualFrameLength), 1, vDSP_Length(frameLength - actualFrameLength))
+            // If the buffer is smaller than the desired frameLength, pad the rest
+            // with zeros using vDSP.
+            if actualFrameLength < frameLength {
+                vDSP_vclr(
+                    destPointer.baseAddress!.advanced(by: actualFrameLength),
+                    1,
+                    vDSP_Length(frameLength - actualFrameLength)
+                )
+            }
         }
 
         return audioSamplesArray

--- a/Sources/WhisperKit/Core/Text/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/Text/LogitsFilter.swift
@@ -144,100 +144,106 @@ open class TimestampRulesFilter: LogitsFiltering {
     private func sumOfProbabilityOverTimestampsIsAboveAnyOtherToken(logits: MLMultiArray, timeTokenBegin: Int) -> Bool {
         let timeTokenBeginOffset = logits.linearOffset(for: [0, 0, timeTokenBegin])
 
-        let logprobsInputPointer = UnsafeMutableRawBufferPointer(
-            start: logits.dataPointer,
-            count: logits.count * MemoryLayout<FloatType>.stride
-        )
-
-        guard let logprobsInputDescriptor = BNNSNDArrayDescriptor(
-            data: logprobsInputPointer,
-            scalarType: FloatType.self,
-            shape: .vector(logits.count, stride: 1)
-        ) else {
-            Logging.error("Cannot create `logprobsInputDescriptor`")
-            return false
-        }
-
-        let logprobs = BNNSNDArrayDescriptor.allocateUninitialized(
-            scalarType: FloatType.self,
-            shape: .vector(logits.count, stride: 1)
-        )
-        defer { logprobs.deallocate() }
-
-        do {
-            try BNNS.applyActivation(
-                activation: BNNS.ActivationFunction.logSoftmax,
-                input: logprobsInputDescriptor,
-                output: logprobs,
-                batchSize: 1
+        // Wrap the logits pointer in `withUnsafeMutableBytes` so the pixel-buffer
+        // lock that CoreML takes when the storage is queried is released as soon
+        // as we finish reading it, instead of being held until the MLMultiArray
+        // is deallocated (the deprecation warning behind issue #308).
+        return logits.withUnsafeMutableBytes { logitsBuffer, _ -> Bool in
+            let logprobsInputPointer = UnsafeMutableRawBufferPointer(
+                start: logitsBuffer.baseAddress,
+                count: logits.count * MemoryLayout<FloatType>.stride
             )
 
-            let timeTokenCount = logits.count - timeTokenBeginOffset
-            let noTimeTokenCount = timeTokenBeginOffset
-            let logSumExpInputPointer = UnsafeMutableRawBufferPointer(
-                start: logprobs.data!.advanced(by: timeTokenBeginOffset * MemoryLayout<FloatType>.stride),
-                count: timeTokenCount * MemoryLayout<FloatType>.stride
-            )
-
-            guard let logSumExpInputDescriptor = BNNSNDArrayDescriptor(
-                data: logSumExpInputPointer,
+            guard let logprobsInputDescriptor = BNNSNDArrayDescriptor(
+                data: logprobsInputPointer,
                 scalarType: FloatType.self,
-                shape: .vector(timeTokenCount, stride: 1)
+                shape: .vector(logits.count, stride: 1)
             ) else {
-                Logging.error("Cannot create `logSumExpInputDescriptor`")
+                Logging.error("Cannot create `logprobsInputDescriptor`")
                 return false
             }
 
-            let timestampLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
+            let logprobs = BNNSNDArrayDescriptor.allocateUninitialized(
                 scalarType: FloatType.self,
-                shape: .vector(1, stride: 1)
+                shape: .vector(logits.count, stride: 1)
             )
-            defer { timestampLogProb.deallocate() }
+            defer { logprobs.deallocate() }
 
-            try BNNS.applyReduction(
-                .logSumExp,
-                input: logSumExpInputDescriptor,
-                output: timestampLogProb,
-                weights: nil
-            )
+            do {
+                try BNNS.applyActivation(
+                    activation: BNNS.ActivationFunction.logSoftmax,
+                    input: logprobsInputDescriptor,
+                    output: logprobs,
+                    batchSize: 1
+                )
 
-            let maxTextTokenLogProbInputPointer = UnsafeMutableRawBufferPointer(
-                start: logprobs.data,
-                count: noTimeTokenCount * MemoryLayout<FloatType>.stride
-            )
+                let timeTokenCount = logits.count - timeTokenBeginOffset
+                let noTimeTokenCount = timeTokenBeginOffset
+                let logSumExpInputPointer = UnsafeMutableRawBufferPointer(
+                    start: logprobs.data!.advanced(by: timeTokenBeginOffset * MemoryLayout<FloatType>.stride),
+                    count: timeTokenCount * MemoryLayout<FloatType>.stride
+                )
 
-            guard let maxTextTokenLogProbInputDescriptor = BNNSNDArrayDescriptor(
-                data: maxTextTokenLogProbInputPointer,
-                scalarType: FloatType.self,
-                shape: .vector(noTimeTokenCount, stride: 1)
-            ) else {
-                Logging.error("Cannot create `maxTextTokenLogProbInputDescriptor`")
+                guard let logSumExpInputDescriptor = BNNSNDArrayDescriptor(
+                    data: logSumExpInputPointer,
+                    scalarType: FloatType.self,
+                    shape: .vector(timeTokenCount, stride: 1)
+                ) else {
+                    Logging.error("Cannot create `logSumExpInputDescriptor`")
+                    return false
+                }
+
+                let timestampLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
+                    scalarType: FloatType.self,
+                    shape: .vector(1, stride: 1)
+                )
+                defer { timestampLogProb.deallocate() }
+
+                try BNNS.applyReduction(
+                    .logSumExp,
+                    input: logSumExpInputDescriptor,
+                    output: timestampLogProb,
+                    weights: nil
+                )
+
+                let maxTextTokenLogProbInputPointer = UnsafeMutableRawBufferPointer(
+                    start: logprobs.data,
+                    count: noTimeTokenCount * MemoryLayout<FloatType>.stride
+                )
+
+                guard let maxTextTokenLogProbInputDescriptor = BNNSNDArrayDescriptor(
+                    data: maxTextTokenLogProbInputPointer,
+                    scalarType: FloatType.self,
+                    shape: .vector(noTimeTokenCount, stride: 1)
+                ) else {
+                    Logging.error("Cannot create `maxTextTokenLogProbInputDescriptor`")
+                    return false
+                }
+
+                let maxTextTokenLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
+                    scalarType: FloatType.self,
+                    shape: .vector(1, stride: 1)
+                )
+                defer { maxTextTokenLogProb.deallocate() }
+
+                try BNNS.applyReduction(
+                    .max,
+                    input: maxTextTokenLogProbInputDescriptor,
+                    output: maxTextTokenLogProb,
+                    weights: nil
+                )
+
+                guard let timestampLogProbValue = timestampLogProb.makeArray(of: FloatType.self)?.first,
+                      let maxTextTokenLogProbValue = maxTextTokenLogProb.makeArray(of: FloatType.self)?.first
+                else {
+                    Logging.error("Cannot create logProb arrays")
+                    return false
+                }
+                return timestampLogProbValue > maxTextTokenLogProbValue
+            } catch {
+                Logging.error("TimestampRulesFilter error: \(error)")
                 return false
             }
-
-            let maxTextTokenLogProb = BNNSNDArrayDescriptor.allocateUninitialized(
-                scalarType: FloatType.self,
-                shape: .vector(1, stride: 1)
-            )
-            defer { maxTextTokenLogProb.deallocate() }
-
-            try BNNS.applyReduction(
-                .max,
-                input: maxTextTokenLogProbInputDescriptor,
-                output: maxTextTokenLogProb,
-                weights: nil
-            )
-
-            guard let timestampLogProbValue = timestampLogProb.makeArray(of: FloatType.self)?.first,
-                  let maxTextTokenLogProbValue = maxTextTokenLogProb.makeArray(of: FloatType.self)?.first
-            else {
-                Logging.error("Cannot create logProb arrays")
-                return false
-            }
-            return timestampLogProbValue > maxTextTokenLogProbValue
-        } catch {
-            Logging.error("TimestampRulesFilter error: \(error)")
-            return false
         }
     }
 }

--- a/Sources/WhisperKit/Core/Text/TokenSampler.swift
+++ b/Sources/WhisperKit/Core/Text/TokenSampler.swift
@@ -92,9 +92,16 @@ open class GreedyTokenSampler: TokenSampling {
 
         var nextToken: Int?
 
-        do {
+        // Access the logits storage through `withUnsafeMutableBytes` so the CoreML
+        // pixel-buffer lock that comes with `dataPointer` is scoped to this call
+        // rather than kept alive for the lifetime of the MLMultiArray (the
+        // deprecation warning behind issue #308). BNNS only reads `logits` inline
+        // and the softmax/argmax results land in separately allocated descriptors,
+        // so the lock can be released as soon as the BNNS calls return.
+        logits.withUnsafeMutableBytes { logitsBuffer, _ in
+            do {
             let logitsRawPointer = UnsafeMutableRawBufferPointer(
-                start: logits.dataPointer,
+                start: logitsBuffer.baseAddress,
                 count: logits.count * MemoryLayout<FloatType>.stride
             )
 
@@ -195,8 +202,9 @@ open class GreedyTokenSampler: TokenSampling {
 
                 nextToken = Int(argmaxResult[0])
             }
-        } catch {
-            Logging.error("Sampling error: \(error)")
+            } catch {
+                Logging.error("Sampling error: \(error)")
+            }
         }
 
         // Log of softmax probability of chosen token


### PR DESCRIPTION
Fixes #308.

Replaces \`MLMultiArray.dataPointer\` in WhisperKit/Core with scoped accessors (\`withUnsafeMutableBufferPointer\` / \`withUnsafeMutableBytes\`) so the pixel-buffer lock CoreML takes on storage access is released as soon as the closure returns, instead of being kept alive for the entire lifetime of the array. That's the exact deprecation the runtime log warns about:

> Pixel buffer backing MLMultiArray is locked until this MultiArray is deallocated (or storage swapped) due to usage of deprecated dataPointer or bytes properties. Please use getBytesWithHandler instead.

### Scope

Just the three places @ZachNagengast pointed at in the issue thread:

- \`Sources/WhisperKit/Core/Audio/AudioProcessor.swift\` — the \`MLMultiArray\` sample buffer that we hand back to the encoder is initialized inside \`withUnsafeMutableBufferPointer(ofType: Float.self)\`, so the source-copy + \`vDSP_vclr\` zero-padding share one scoped lock instead of leaving the buffer locked for the caller's lifetime.
- \`Sources/WhisperKit/Core/Text/LogitsFilter.swift\` — \`sumOfProbabilityOverTimestampsIsAboveAnyOtherToken\` wraps the BNNS log-softmax + log-sum-exp + max chain inside a single \`logits.withUnsafeMutableBytes\` so the locked region matches the actual BNNS work.
- \`Sources/WhisperKit/Core/Text/TokenSampler.swift\` — \`sampleWithBNNS\` does the same for the softmax/top-k/argmax path. The softmax output is its own allocation, so the array's bytes don't need to stay locked past the BNNS calls; \`makeArray\` reads from the descriptor, not from \`logits\`.

The deprecated \`BNNS.applyActivation\` warnings inside these functions are pre-existing and tracked in the inline TODOs — not touched here.

### TTSKit follow-up

TTSKit still uses \`dataPointer\` heavily in \`KVCache\`, \`PromptCache\`, \`EmbedTypes\`, \`Qwen3SpeechDecoder\`, \`Qwen3MultiCodeDecoder\`, and \`Sampling\`. Those are tighter loops where the locking pattern matters even more, but the rewrite is more invasive (per-step accessors and KV-cache snapshot/restore paths) so I kept this PR scoped to the original WhisperKit modules you flagged. Happy to send a follow-up once this one is in.

### Test

\`\`\`
$ swift build
Build complete!
$ swift test --filter "UnitTests/testSampler|UnitTests/testAudio|UnitTests/testLogitsFilter|UnitTests/testLogProb|UnitTests/testTimestamp"
Executed 13 tests, with 0 failures (0 unexpected) in 15.402 seconds.
\`\`\`

The full \`testInitTiny\` and \`testDecoderTokenizer\` paths (which exercise the sampler + audio processor end-to-end against a real \`tiny\` model) also pass locally on macOS / arm64.