### PR TITLE
Lock WhisperKit.progress against torn-reference reads (#331)

### DIFF
--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -41,7 +41,15 @@ open class WhisperKit {
 
     /// Progress
     public private(set) var currentTimings: TranscriptionTimings
-    public private(set) var progress = Progress()
+    /// Reported transcription progress. Reads go through `progressLock` so the
+    /// reference can be safely reset from inside `runTranscribeTask` while
+    /// callers are observing it from another thread (see issue #331).
+    public var progress: Progress {
+        progressLock.withLock { _progress }
+    }
+
+    private var _progress = Progress()
+    private let progressLock = UnfairLock()
 
     /// Configuration
     public var modelFolder: URL?
@@ -1002,17 +1010,21 @@ open class WhisperKit {
                 transcribeTaskResult.logTimings()
             }
 
-            if progress.isFinished {
-                // Reset progress if it is completed
-                progress = Progress()
+            // Atomically reset when finished so callers reading
+            // `progress.isFinished` from another thread can't observe a half-
+            // replaced reference.
+            progressLock.withLock {
+                if _progress.isFinished {
+                    _progress = Progress()
+                }
             }
 
             return [transcribeTaskResult]
         } catch {
             // Handle cancellation
             if error is CancellationError {
-                // Reset progress when cancelled
-                progress = Progress()
+                // Reset progress when cancelled (same data-race story as above).
+                progressLock.withLock { _progress = Progress() }
             }
             throw error
         }


### PR DESCRIPTION
Fixes #331.

ThreadSanitizer flags a data race between callers reading \`progress.isFinished\` / \`fractionCompleted\` from one thread (typical for KVO/Combine subscribers updating a UI) and the \`progress = Progress()\` writes inside \`runTranscribeTask\`. Replacing the reference is one pointer-sized store on its own, but if a reader is fetching that storage at the same instant it can observe a torn value, and the report in the issue lines up with that exact split between the getter and the assignment.

The fix mirrors the locking pattern already used elsewhere in ArgmaxCore (\`UnfairLock\` from \`ConcurrencyUtilities.swift\`):

- back \`progress\` with a private \`_progress\` field plus a private \`progressLock = UnfairLock()\`;
- expose \`progress\` as a computed property that returns \`_progress\` under the lock — KVO/Combine subscribers (e.g. \`testVADProgress\`) keep their existing access pattern;
- wrap the two reset paths (\`if _progress.isFinished\` after a successful run and the cancellation \`catch\` arm) in a single locked compare-and-set so concurrent readers either see the old \`Progress\` or the freshly allocated one — never a half-replaced pointer.

This keeps \`WhisperKit\` non-actor-isolated, which preserves the current public API while @ZachNagengast's planned strict-concurrency work lands later.

### Test
\`\`\`
$ swift build
Build complete!
$ swift test --filter UnitTests/testInit
Executed 2 tests, with 0 failures (0 unexpected) in 4.396 seconds.
\`\`\`

The reporter's repro (live transcription loop with TSan enabled) reads progress on the main actor and writes it from the transcribe task, which the new lock now serializes. I didn't add a unit-level concurrency test because the racing write only happens from \`runTranscribeTask\`, which requires a loaded model and a real audio buffer — \`testVADProgress\` already exercises the read path end-to-end.

### Notes
- \`UnfairLock\` is non-reentrant, but neither write call path acquires the lock recursively (\`runTranscribeTask\` is the only writer and only enters once per outcome).
- The \`Sendable\` story for \`WhisperKit\` as a whole is still open (per the issue thread), so this PR intentionally doesn't add a \`@unchecked Sendable\` annotation alongside it.