### PR TITLE
Fix crash in GreedyTokenSampler when top-K probability sum is zero

### DIFF
--- a/Sources/TTSKit/Utilities/Sampling.swift
+++ b/Sources/TTSKit/Utilities/Sampling.swift
@@ -236,6 +236,12 @@ public class GreedyTokenSampler: TokenSampling, @unchecked Sendable {
             let probsArray = await topKProbs.toFloatArray()
             let idxArray = await topKIndices.toIntArray()
             let probSum = probsArray.reduce(0, +)
+            // Numerically degenerate softmax (all-zero or NaN probs) would make
+            // `Float.random(in: 0..<probSum)` trap. Fall back to argmax instead.
+            guard probSum.isFinite, probSum > 0 else {
+                let maxIdx = probsArray.enumerated().max(by: { $0.element < $1.element })?.offset ?? 0
+                return Int32(idxArray[maxIdx])
+            }
             let randomValue = Float.random(in: 0..<probSum, using: &rng)
             var cumulativeSum: Float = 0
             for (i, probability) in probsArray.enumerated() {

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -291,6 +291,30 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(token, 5, "Suppressed token should be skipped, picking next best")
     }
 
+    /// Regression for #478: degenerate softmax output (all logits at -Float.infinity)
+    /// makes the top-K probability sum zero, which used to crash
+    /// `Float.random(in: 0..<probSum)`. The sampler must fall back to argmax
+    /// and return a valid token index.
+    func testGreedySamplerZeroProbSumFallsBackToArgmax() async throws {
+        let sampler = GreedyTokenSampler(seed: 0)
+        let vocabSize = 16
+        let logits = try MLMultiArray(shape: [1, 1, NSNumber(value: vocabSize)], dataType: .float16)
+        let ptr = logits.dataPointer.bindMemory(to: FloatType.self, capacity: vocabSize)
+
+        // Every logit at -inf → softmax → all zeros (or NaN). Tag index 9 with a
+        // slightly less-negative value so argmax has a clear winner to fall back to.
+        for i in 0..<vocabSize { ptr[i] = FloatType(-Float.infinity) }
+        ptr[9] = FloatType(-1e30)
+
+        let token = await sampler.sampleCodec0(
+            logits: logits, temperature: 1.0, topK: 4,
+            generatedTokens: [], repetitionPenalty: 1.0, suppressTokenIds: []
+        )
+
+        XCTAssertGreaterThanOrEqual(token, 0)
+        XCTAssertLessThan(token, Int32(vocabSize))
+    }
+
     func testGreedySamplerMultiHeadDeterministic() async throws {
         let sampler1 = GreedyTokenSampler(seed: 7)
         let sampler2 = GreedyTokenSampler(seed: 7)


### PR DESCRIPTION
## Summary

- Guard `Float.random(in: 0..<probSum)` in `GreedyTokenSampler.sampleFromProbs` against degenerate softmax output.
- Fall back to argmax when top-K probabilities sum to zero or NaN.
- Add a regression test that reproduces the original crash.

## Problem

When softmax output becomes numerically degenerate — all logits at `-inf`, NaN propagation, or extreme underflow — the top-K probabilities sum to zero. `Float.random(in: 0..<probSum)` then traps with:

```
Fatal error: Can't get random value with an empty range
```

I confirmed this locally with the new test: temporarily reverting the guard reproduces the exact crash from Swift's `FloatingPointRandom.swift:52`.

## Fix

Inline guard in [`Sources/TTSKit/Utilities/Sampling.swift`](https://github.com/argmaxinc/WhisperKit/blob/main/Sources/TTSKit/Utilities/Sampling.swift). When `probSum` is zero or non-finite, return the highest-probability token from the top-K window (argmax fallback). Lock-free, no new dependencies, no API changes.

## Test plan

- [x] New regression test `testGreedySamplerZeroProbSumFallsBackToArgmax` constructs `[1, 1, vocabSize]` logits at `-Float.infinity`, calls `sampleCodec0` with `topK=4`, asserts no crash and a valid token index.
- [x] Verified the test reproduces the original crash without the guard.
- [x] All 5 existing `GreedyTokenSampler` tests pass.
- [x] `swift build` succeeds.

Fixes #478