### PR TITLE
Support optimized multifunction SpeechDecoder for Qwen3-TTS

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -17,7 +17,7 @@ jobs:
       ios-version: "26.4.1"
       ios-device: "iPhone 17"
       watchos-version: "26.4"
-      visionos-version: "26.4.1"
+      visionos-version: "latest"
       macos-runner: "macos-26"
       xcode-version: "26.4.1"
 

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -27,7 +27,7 @@ jobs:
             ios-version: "26.4.1"
             ios-device: "iPhone 17"
             watchos-version: "26.4"
-            visionos-version: "26.4.1"
+            visionos-version: "latest"
             macos-runner: "macos-26"
             xcode-version: "26.4.1"
     uses: ./.github/workflows/unit-tests.yml

--- a/Examples/TTS/TTSKitExample/TTSKitExample/SidebarView.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/SidebarView.swift
@@ -16,6 +16,11 @@ struct SidebarView: View {
 
             Divider()
 
+            // SpeechDecoder mode — a model-loading choice
+            SpeechDecoderModeView()
+
+            Divider()
+
             // Compute units configuration
             ComputeUnitsView()
                 .disabled(vm.modelState.isBusy)

--- a/Examples/TTS/TTSKitExample/TTSKitExample/SpeechDecoderModeView.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/SpeechDecoderModeView.swift
@@ -1,0 +1,48 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import SwiftUI
+import TTSKit
+
+/// Sidebar picker for the SpeechDecoder mode: `.latencyOptimized` (one frame per
+/// call, lowest TTFB) or `.throughputOptimized` (four frames per call). Changing it
+/// triggers a model reload.
+struct SpeechDecoderModeView: View {
+    @Environment(ViewModel.self) private var viewModel
+
+    var body: some View {
+        @Bindable var vm = viewModel
+
+        HStack(spacing: 8) {
+            Text("Speech Decoder Mode")
+                .font(.headline)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+                .layoutPriority(1)
+
+            Spacer(minLength: 4)
+
+            Picker("", selection: Binding(
+                get: { vm.speechDecoderMode },
+                set: {
+                    vm.speechDecoderMode = $0
+                    reloadIfNeeded()
+                }
+            )) {
+                Text("Latency").tag(Qwen3SpeechDecoderMode.latencyOptimized)
+                Text("Throughput").tag(Qwen3SpeechDecoderMode.throughputOptimized)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .fixedSize()
+        }
+        .disabled(viewModel.modelState.isBusy)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private func reloadIfNeeded() {
+        guard viewModel.modelState == .loaded else { return }
+        viewModel.reloadModelForComputeUnitChange()
+    }
+}

--- a/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
@@ -2,6 +2,7 @@
 //  Copyright © 2026 Argmax, Inc. All rights reserved.
 
 @preconcurrency import AVFoundation
+import ArgmaxCore
 import CoreML
 import Foundation
 import Observation
@@ -11,6 +12,24 @@ import WhisperKit
 #if os(macOS)
 import AppKit
 #endif
+
+// MARK: - Streaming helpers
+
+/// Lock-protected running total of audio samples streamed so far. Used by
+/// `streamGeneration` to ship a single `Int` snapshot to the main actor per
+/// chunk instead of the full `[Float]`, keeping the streaming callback's
+/// MainActor hop O(1) regardless of chunk size.
+private final class StreamedSamplesCounter: @unchecked Sendable {
+    private var total = 0
+    private let lock = UnfairLock()
+
+    func add(_ count: Int) -> Int {
+        lock.withLock {
+            total += count
+            return total
+        }
+    }
+}
 
 // MARK: - Data Model
 
@@ -137,6 +156,9 @@ private class Settings {
     @AppStorage("codeDecoderComputeUnits") var codeDecoderComputeUnitsRaw: Int = MLComputeUnits.cpuAndNeuralEngine.rawValue
     @AppStorage("multiCodeDecoderComputeUnits") var multiCodeDecoderComputeUnitsRaw: Int = MLComputeUnits.cpuAndNeuralEngine.rawValue
     @AppStorage("speechDecoderComputeUnits") var speechDecoderComputeUnitsRaw: Int = MLComputeUnits.cpuAndNeuralEngine.rawValue
+
+    /// Which function of the multifunction SpeechDecoder asset to load.
+    @AppStorage("speechDecoderMode") var speechDecoderModeRaw: String = Qwen3SpeechDecoderMode.latencyOptimized.rawValue
 }
 
 // MARK: - View Model
@@ -232,6 +254,12 @@ final class ViewModel: @unchecked Sendable {
         didSet { settings.speechDecoderComputeUnitsRaw = speechDecoderComputeUnits.rawValue }
     }
 
+    /// Which function of the multifunction SpeechDecoder asset to load
+    /// (`.latencyOptimized` for one RVQ frame per call; `.throughputOptimized` for four).
+    var speechDecoderMode: Qwen3SpeechDecoderMode {
+        didSet { settings.speechDecoderModeRaw = speechDecoderMode.rawValue }
+    }
+
     var computeOptions: ComputeOptions {
         ComputeOptions(
             embedderComputeUnits: embedderComputeUnits,
@@ -267,6 +295,7 @@ final class ViewModel: @unchecked Sendable {
         codeDecoderComputeUnits = MLComputeUnits(rawValue: settings.codeDecoderComputeUnitsRaw) ?? .cpuAndNeuralEngine
         multiCodeDecoderComputeUnits = MLComputeUnits(rawValue: settings.multiCodeDecoderComputeUnitsRaw) ?? .cpuAndNeuralEngine
         speechDecoderComputeUnits = MLComputeUnits(rawValue: settings.speechDecoderComputeUnitsRaw) ?? .cpuAndNeuralEngine
+        speechDecoderMode = Qwen3SpeechDecoderMode(rawValue: settings.speechDecoderModeRaw) ?? .latencyOptimized
     }
 
     // MARK: - Generation output
@@ -449,12 +478,7 @@ final class ViewModel: @unchecked Sendable {
         statusMessage = "Downloading \(selectedPreset.rawValue) model..."
 
         do {
-            // Set a HuggingFace token via TTSKitConfig(token:) if the model repo is private.
-            // For the public argmaxinc/ttskit-coreml repo no token is required.
-            let config = TTSKitConfig(
-                model: selectedPreset,
-                verbose: true
-            )
+            let config = TTSKitConfig(model: selectedPreset, verbose: true)
             let folder = try await TTSKit.download(config: config) { [weak self] progress in
                 Task { @MainActor in
                     self?.downloadProgress = progress.fractionCompleted
@@ -489,6 +513,7 @@ final class ViewModel: @unchecked Sendable {
             let ttsConfig = TTSKitConfig(
                 model: selectedPreset,
                 modelFolder: localModelPaths[selectedPreset].map { URL(fileURLWithPath: $0) },
+                speechDecoderMode: speechDecoderMode,
                 computeOptions: computeOptions,
                 verbose: true
             )
@@ -688,6 +713,10 @@ final class ViewModel: @unchecked Sendable {
             isStreaming = true
             activeAudioOutput = ttsKit.audioOutput
             startPlaybackUpdates()
+        @unknown default:
+            isStreaming = true
+            activeAudioOutput = ttsKit.audioOutput
+            startPlaybackUpdates()
         }
 
         do {
@@ -704,6 +733,12 @@ final class ViewModel: @unchecked Sendable {
                     playGeneration(gen)
                 }
             case .auto, .stream, .buffered:
+                result = try await streamGeneration(tts: ttsKit)
+                stopPlaybackUpdates()
+                activeAudioOutput = nil
+                isStreaming = false
+                try await finalizeGeneration(result: result)
+            @unknown default:
                 result = try await streamGeneration(tts: ttsKit)
                 stopPlaybackUpdates()
                 activeAudioOutput = nil
@@ -776,10 +811,17 @@ final class ViewModel: @unchecked Sendable {
         return result
     }
 
-    /// Run `play`, streaming waveform peaks and audio samples back to the main actor.
+    /// Run `play`, streaming waveform peaks to the main actor (the full audio is set
+    /// once at the end from `result.audio`). `WaveformView` shows one bar per ~80 ms
+    /// RVQ frame, so in `throughputOptimized` mode each chunk is resampled to one peak
+    /// per ~80 ms window via `peaksPerToken`.
     private func streamGeneration(tts: TTSKit) async throws -> SpeechResult {
         let options = buildOptions()
         let sampleRate = Double(Qwen3TTSConstants.sampleRate)
+
+        // Running duration accumulated off the main actor so we can ship a single
+        // `Double` to MainActor per chunk instead of a `[Float]`.
+        let streamedSamples = StreamedSamplesCounter()
 
         let result = try await tts.play(
             text: inputText,
@@ -789,12 +831,12 @@ final class ViewModel: @unchecked Sendable {
             playbackStrategy: selectedPlaybackStrategy,
             callback: { [weak self] progress in
                 let samples = progress.audio
-                let peak = samples.reduce(Float(0)) { max($0, abs($1)) }
+                let peaks = self?.peaksPerToken(from: samples) ?? []
+                let totalSamples = streamedSamples.add(samples.count)
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    currentAudioSamples.append(contentsOf: samples)
-                    currentDuration = Double(currentAudioSamples.count) / sampleRate
-                    currentWaveform.append(peak)
+                    currentWaveform.append(contentsOf: peaks)
+                    currentDuration = Double(totalSamples) / sampleRate
                 }
                 return nil
             }

--- a/README.md
+++ b/README.md
@@ -432,6 +432,26 @@ try await tts.play(
 
 Other strategies include `.stream` (immediate, no buffer), `.buffered(seconds:)` (fixed pre-buffer), and `.generateFirst` (generate all audio first, then play).
 
+### Speech Decoder Mode
+
+TTSKit's default speech decoder bundles two functions, selectable via `TTSKitConfig.speechDecoderMode`:
+
+| Mode | RVQ frames / call | Audio / call | Use case |
+|------|-------------------|--------------|----------|
+| `.latencyOptimized` (default) | 1 | ~80 ms | Lowest time-to-first-audio for streaming. |
+| `.throughputOptimized` | 4 | ~320 ms | Amortizes decoder overhead for higher throughput, at the cost of a ~4× larger first-buffer latency. |
+
+```swift
+// Default: latency-optimized (lowest time-to-first-audio)
+let tts = try await TTSKit()
+
+// Opt into throughput-optimized generation
+let config = TTSKitConfig(speechDecoderMode: .throughputOptimized)
+let throughputTTS = try await TTSKit(config)
+```
+
+The mode is read once when models are loaded; set it before constructing `TTSKit` (or reload the model to switch at runtime).
+
 ### Generation Options
 
 You can customize sampling, chunking, and concurrency via `GenerationOptions`:

--- a/Sources/ArgmaxCLI/TTSCLI.swift
+++ b/Sources/ArgmaxCLI/TTSCLI.swift
@@ -12,6 +12,7 @@ import WhisperKit
 extension Qwen3Speaker: ExpressibleByArgument {}
 extension Qwen3Language: ExpressibleByArgument {}
 extension TTSModelVariant: ExpressibleByArgument {}
+extension Qwen3SpeechDecoderMode: ExpressibleByArgument {}
 
 // MARK: - CLI Command
 
@@ -109,6 +110,9 @@ struct TTSCLI: AsyncParsableCommand {
     @Option(name: .long, help: "SpeechDecoder variant (overrides --model preset)")
     var speechDecoderVariant: String?
 
+    @Option(name: .long, help: "SpeechDecoder mode: latencyOptimized (default, lowest time-to-first-audio, 1 frame/call) or throughputOptimized (higher throughput, ~4x larger pre-buffer, 4 frames/call)")
+    var speechDecoderMode: Qwen3SpeechDecoderMode = .latencyOptimized
+
     // MARK: - Compute unit options
 
     @Option(name: .long, help: "Compute units for embedders (TextProjector, CodeEmbedder, MultiCodeEmbedder) {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine}")
@@ -166,6 +170,7 @@ struct TTSCLI: AsyncParsableCommand {
             codeDecoderVariant: codeDecoderVariant,
             multiCodeDecoderVariant: multiCodeDecoderVariant,
             speechDecoderVariant: speechDecoderVariant,
+            speechDecoderMode: speechDecoderMode,
             computeOptions: ComputeOptions(
                 embedderComputeUnits: embedderComputeUnits.asMLComputeUnits,
                 codeDecoderComputeUnits: codeDecoderComputeUnits.asMLComputeUnits,
@@ -208,7 +213,7 @@ struct TTSCLI: AsyncParsableCommand {
             print("  Version: \(config.versionDir)")
             print("  CodeDecoder: \(config.codeDecoderVariant)")
             print("  MultiCodeDecoder: \(config.multiCodeDecoderVariant)")
-            print("  SpeechDecoder: \(config.speechDecoderVariant)")
+            print("  SpeechDecoder: \(config.speechDecoderVariant) (\(config.speechDecoderMode.rawValue))")
             print("  Embedder compute: \(embedderComputeUnits.rawValue)")
             print("  CodeDecoder compute: \(codeDecoderComputeUnits.rawValue)")
             print("  MultiCodeDecoder compute: \(multiCodeDecoderComputeUnits.rawValue)")

--- a/Sources/TTSKit/Models.swift
+++ b/Sources/TTSKit/Models.swift
@@ -330,6 +330,10 @@ public struct SpeechTimings: Codable, Sendable {
     public var speechDecoder: TimeInterval = 0
     /// Sum of `model.prediction()` calls inside SpeechDecoder.
     public var speechDecoderPredictions: TimeInterval = 0
+    /// Number of SpeechDecoder invocations across all chunks. Differs from
+    /// `totalDecodingLoops` when `codesPerStep > 1` (e.g. throughputOptimized's
+    /// N=4 batches: one SD call per 4 RVQ frames plus a final partial flush).
+    public var totalSpeechDecoderInvocations: Double = 0
 
     // MARK: - Non-model overhead
 
@@ -407,6 +411,7 @@ public struct SpeechTimings: Codable, Sendable {
         totalMultiCodeDecoderPredictions += other.totalMultiCodeDecoderPredictions
         speechDecoder += other.speechDecoder
         speechDecoderPredictions += other.speechDecoderPredictions
+        totalSpeechDecoderInvocations += other.totalSpeechDecoderInvocations
         kvCacheUpdate += other.kvCacheUpdate
         codeEmbed += other.codeEmbed
         codecHidden += other.codecHidden
@@ -467,8 +472,8 @@ public struct SpeechResult: Codable, Sendable {
             - Sampling:              \(formatTime(timings.multiCodeDecoderSampling, totalLoops))
             - Embedding:             \(formatTime(timings.multiCodeDecoderEmbedding, totalLoops))
             - KV Caching:            \(formatTime(timings.decodingKvCaching, totalLoops))
-            SpeechDecoder:           \(formatTime(timings.speechDecoder, totalLoops))
-            - Predictions:           \(formatTime(timings.speechDecoderPredictions, totalLoops))
+            SpeechDecoder:           \(formatTime(timings.speechDecoder, timings.totalSpeechDecoderInvocations))
+            - Predictions:           \(formatTime(timings.speechDecoderPredictions, timings.totalSpeechDecoderInvocations))
             KV Cache (outer):        \(formatTime(timings.kvCacheUpdate, totalLoops))
             Code Embed (outer):      \(formatTime(timings.codeEmbed, totalLoops))
             Codec Hidden:            \(formatTime(timings.codecHidden, totalLoops))

--- a/Sources/TTSKit/Protocols.swift
+++ b/Sources/TTSKit/Protocols.swift
@@ -114,22 +114,37 @@ public protocol SpeechDecoding: MLModelLoading {
 
     // MARK: - Cache geometry (read after loadModel)
 
+    /// KV-cache embedding dimension (channel count of each cached key/value),
+    /// read from the model's `key_cache` input shape after `loadModel`.
     var kvCacheEmbedDim: Int { get }
+    /// Maximum KV-cache sequence length (capacity in positions), read from the
+    /// model's `key_cache` input shape after `loadModel`.
     var kvCacheMaxSequenceLength: Int { get }
+    /// Hidden-state dimension consumed by the decoder, read from the model's
+    /// `hidden_context` input shape after `loadModel`.
     var hiddenDim: Int { get }
+    /// Length of the rolling hidden-context window the decoder attends over,
+    /// read from the model's `hidden_context` input shape after `loadModel`.
     var hiddenContextLen: Int { get }
+    /// Number of RVQ frames consumed per decode call (1 for latency-optimized
+    /// SpeechDecoder, 4 for throughput-optimized). Read from the loaded model's
+    /// `audio_codes` input shape. Implies `qk_mask` is consumed iff this is > 1.
+    var codesPerStep: Int { get }
 
     // MARK: - Decoding
 
-    /// Decode a single RVQ frame (16 codes) into audio samples.
+    /// Decode `codesPerStep` RVQ frames (each 16 codes) into audio samples.
+    /// Pass an array of `codesPerStep` frames; an outer-array length mismatch
+    /// throws `TTSError.generationFailed`.
     func decodeFrame(
-        codes: [Int32],
+        codes: [[Int32]],
         cache: SpeechDecoderCache
     ) async throws -> [Float]
 
-    /// Async decode that returns audio samples with wall-clock timing.
+    /// Async decode returning audio samples plus wall-clock timing.
+    /// Pass an array of `codesPerStep` frames.
     func decodeFrameAsync(
-        codes: [Int32],
+        codes: [[Int32]],
         cache: SpeechDecoderCache
     ) async throws -> SpeechDecoderTimedResult
 }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
@@ -109,7 +109,7 @@ public enum Qwen3VariantDefaults {
     public static let codeEmbedder = "W16A16"
     public static let multiCodeEmbedder = "W16A16"
     public static let textProjector = "W8A16"
-    public static let speechDecoder = "W8A16"
+    public static let speechDecoder = "W8A16-multifunction"
 }
 
 // MARK: - TTSKit Configuration
@@ -189,6 +189,10 @@ open class TTSKitConfig {
     public var multiCodeEmbedderVariant: String
     public var textProjectorVariant: String
     public var speechDecoderVariant: String
+
+    /// Which multifunction SpeechDecoder function to load. `.latencyOptimized`
+    /// (default) decodes one frame per call; `.throughputOptimized` decodes four.
+    public var speechDecoderMode: Qwen3SpeechDecoderMode
 
     // MARK: - Compute
 
@@ -274,6 +278,7 @@ open class TTSKitConfig {
         multiCodeEmbedderVariant: String? = nil,
         textProjectorVariant: String? = nil,
         speechDecoderVariant: String? = nil,
+        speechDecoderMode: Qwen3SpeechDecoderMode = .latencyOptimized,
         computeOptions: ComputeOptions = ComputeOptions(),
         verbose: Bool = true,
         logLevel: Logging.LogLevel = .info,
@@ -299,6 +304,7 @@ open class TTSKitConfig {
         self.multiCodeEmbedderVariant = multiCodeEmbedderVariant ?? model.multiCodeEmbedderVariant
         self.textProjectorVariant = textProjectorVariant ?? model.textProjectorVariant
         self.speechDecoderVariant = speechDecoderVariant ?? model.speechDecoderVariant
+        self.speechDecoderMode = speechDecoderMode
         self.computeOptions = computeOptions
         self.verbose = verbose
         self.logLevel = logLevel

--- a/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
@@ -339,11 +339,13 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         let roleTokenIds = tokenizer.encode(text: "<|im_start|>assistant\n").map { Int32($0) }
         let maxStepsByPrefill = 8 * (roleTokenIds.count + tokenizeResult.textTokenIds.count)
 
+        let codesPerStep = speechDecoder.codesPerStep
         let sdCache = try SpeechDecoderCache(
             cacheDim: speechDecoder.kvCacheEmbedDim,
             maxSeqLength: speechDecoder.kvCacheMaxSequenceLength,
             hiddenDim: speechDecoder.hiddenDim,
-            hiddenContextLen: speechDecoder.hiddenContextLen
+            hiddenContextLen: speechDecoder.hiddenContextLen,
+            codesPerStep: codesPerStep
         )
 
         var generatedTokens: [Int32] = []
@@ -356,9 +358,26 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         )
         generatedTokens.append(code0)
 
-        var allAudio: [Float] = []
         var stepIndex = 0
-        var firstBufferEmitted = false
+        var stopRequested = false
+
+        let padFrame: [Int32] = [Int32](repeating: Qwen3TTSConstants.codecPAD, count: 16)
+
+        // Owns RVQ-frame buffering, the overlapped SpeechDecoder decode/drain, pad
+        // trimming, audio accumulation, and callback emission. Extracted so this loop
+        // stays flat; SpeechDecoder timings are folded into `timings` (passed `inout`).
+        let writer = SpeechStreamWriter(
+            speechDecoder: speechDecoder,
+            sdCache: sdCache,
+            callback: callback,
+            pipelineStart: pipelineStart,
+            baseTimings: baseTimings,
+            padFrame: padFrame
+        )
+
+        // Tear down the writer's overlapped decode on every exit path — it is an
+        // unstructured Task that does not inherit this loop's cancellation.
+        defer { writer.cancelPendingDecode() }
 
         // TODO: Remove forking logic with package with min os version upgrade
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *), !options.forceLegacyEmbedPath {
@@ -393,107 +412,38 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 timings.decodingKvCaching += mcdResult.timings.decodingKvCaching
                 timings.totalMultiCodeDecoderPredictions += mcdResult.timings.totalMultiCodeDecoderPredictions
 
+                // Captured before `code0` is resampled below; ingested into the writer
+                // after sampling (nothing between here and then reads the buffer).
                 let rvqFrame = [code0] + mcdResult.codes
 
-                if !firstBufferEmitted {
-                    // First step: give SpeechDecoder exclusive compute access for minimum TTFB.
-                    // Emit the buffer immediately, then do the remaining step work (codec hidden,
-                    // text projection, CodeDecoder) which only affects the *next* step's readiness.
-                    let sdResult = try await speechDecoder.decodeFrameAsync(codes: rvqFrame, cache: sdCache)
-                    let stepTime = CFAbsoluteTimeGetCurrent() - stepStart
-                    timings.speechDecoderPredictions += sdResult.timings.speechDecoderPredictions
-                    timings.speechDecoder += sdResult.timings.speechDecoderPredictions
-                    allAudio.append(contentsOf: sdResult.samples)
-
-                    timings.timeToFirstBuffer = CFAbsoluteTimeGetCurrent() - pipelineStart
-                    firstBufferEmitted = true
-
-                    if callback?(
-                        SpeechProgress(
-                            audio: sdResult.samples,
-                            timings: timings,
-                            stepTime: stepTime
-                        )
-                    ) == false {
-                        break
-                    }
-
-                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
-                    guard let lastMcdCode = mcdResult.codes.last else {
-                        throw TTSError.generationFailed("Multi-code generation result has no codes")
-                    }
-                    let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
-                    let code15EmbedTensor: MLTensor = try await multiCodeEmbedder.embed(tokenId: code15OffsetId)
-                    var allCodeEmbedTensors: [MLTensor] = [code0EmbedTensor]
-                    if let tensorEmbeds = mcdResult.offsetCodeEmbedTensors {
-                        allCodeEmbedTensors += tensorEmbeds
-                    } else {
-                        allCodeEmbedTensors += mcdResult.offsetCodeEmbeds.map { $0.asMLTensor() }
-                    }
-                    allCodeEmbedTensors.append(code15EmbedTensor)
-                    let codecHiddenTensor = EmbedUtilities.sumEmbeddings(allCodeEmbedTensors)
-                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
-
-                    let textProjStart = CFAbsoluteTimeGetCurrent()
-                    let textEmbedTensor: MLTensor =
-                        stepIndex < tokenizeResult.trailingTextTokens.count
-                        ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
-                        : textPadEmbedTensor
-                    let combinedTensor = EmbedUtilities.addEmbeddings(codecHiddenTensor, textEmbedTensor)
-                    timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
-
-                    let decodingStart = CFAbsoluteTimeGetCurrent()
-                    lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedTensor, cache: cdCache, state: cdState)
-                    timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart - lastCdOutput.internalCacheUpdateTime
-                    timings.kvCacheUpdate += lastCdOutput.internalCacheUpdateTime
-                } else {
-                    // Subsequent steps: overlap SpeechDecoder with CodeDecoder for throughput
-                    async let speechResult = speechDecoder.decodeFrameAsync(codes: rvqFrame, cache: sdCache)
-
-                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
-                    guard let lastMcdCode = mcdResult.codes.last else {
-                        throw TTSError.generationFailed("Multi-code generation result has no codes")
-                    }
-                    let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
-                    let code15EmbedTensor: MLTensor = try await multiCodeEmbedder.embed(tokenId: code15OffsetId)
-                    var allCodeEmbedTensors: [MLTensor] = [code0EmbedTensor]
-                    if let tensorEmbeds = mcdResult.offsetCodeEmbedTensors {
-                        allCodeEmbedTensors += tensorEmbeds
-                    } else {
-                        allCodeEmbedTensors += mcdResult.offsetCodeEmbeds.map { $0.asMLTensor() }
-                    }
-                    allCodeEmbedTensors.append(code15EmbedTensor)
-                    let codecHiddenTensor = EmbedUtilities.sumEmbeddings(allCodeEmbedTensors)
-                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
-
-                    let textProjStart = CFAbsoluteTimeGetCurrent()
-                    let textEmbedTensor: MLTensor =
-                        stepIndex < tokenizeResult.trailingTextTokens.count
-                        ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
-                        : textPadEmbedTensor
-                    let combinedTensor = EmbedUtilities.addEmbeddings(codecHiddenTensor, textEmbedTensor)
-                    timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
-
-                    let decodingStart = CFAbsoluteTimeGetCurrent()
-                    lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedTensor, cache: cdCache, state: cdState)
-                    timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart - lastCdOutput.internalCacheUpdateTime
-                    timings.kvCacheUpdate += lastCdOutput.internalCacheUpdateTime
-
-                    let sdResult = try await speechResult
-                    timings.speechDecoderPredictions += sdResult.timings.speechDecoderPredictions
-                    timings.speechDecoder += sdResult.timings.speechDecoderPredictions
-                    allAudio.append(contentsOf: sdResult.samples)
-
-                    if callback?(
-                        SpeechProgress(
-                            audio: sdResult.samples,
-                            timings: {
-                                var merged = baseTimings; merged.merge(timings); return merged
-                            }(), stepTime: nil)) == false
-                    {
-                        break
-                    }
+                let codecHiddenStart = CFAbsoluteTimeGetCurrent()
+                guard let lastMcdCode = mcdResult.codes.last else {
+                    throw TTSError.generationFailed("Multi-code generation result has no codes")
                 }
+                let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
+                let code15EmbedTensor: MLTensor = try await multiCodeEmbedder.embed(tokenId: code15OffsetId)
+                var allCodeEmbedTensors: [MLTensor] = [code0EmbedTensor]
+                if let tensorEmbeds = mcdResult.offsetCodeEmbedTensors {
+                    allCodeEmbedTensors += tensorEmbeds
+                } else {
+                    allCodeEmbedTensors += mcdResult.offsetCodeEmbeds.map { $0.asMLTensor() }
+                }
+                allCodeEmbedTensors.append(code15EmbedTensor)
+                let codecHiddenTensor = EmbedUtilities.sumEmbeddings(allCodeEmbedTensors)
+                timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
+
+                let textProjStart = CFAbsoluteTimeGetCurrent()
+                let textEmbedTensor: MLTensor =
+                    stepIndex < tokenizeResult.trailingTextTokens.count
+                    ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
+                    : textPadEmbedTensor
+                let combinedTensor = EmbedUtilities.addEmbeddings(codecHiddenTensor, textEmbedTensor)
+                timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
+
+                let decodingStart = CFAbsoluteTimeGetCurrent()
+                lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedTensor, cache: cdCache, state: cdState)
+                timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart - lastCdOutput.internalCacheUpdateTime
+                timings.kvCacheUpdate += lastCdOutput.internalCacheUpdateTime
 
                 let samplingStart = CFAbsoluteTimeGetCurrent()
                 code0 = await sampler.sampleCodec0(
@@ -505,6 +455,11 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 )
                 generatedTokens.append(code0)
                 timings.decodingSampling += CFAbsoluteTimeGetCurrent() - samplingStart
+
+                if !(try await writer.append(rvqFrame, stepStart: stepStart, loopTimings: &timings)) {
+                    stopRequested = true
+                    break
+                }
 
                 timings.decodingLoop += CFAbsoluteTimeGetCurrent() - stepStart
                 stepIndex += 1
@@ -519,8 +474,14 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 }
             }
         } else {
-            // Legacy path (older OS)
-            while code0 != Qwen3TTSConstants.codecEOS && !cdCache.isFull && stepIndex < options.maxNewTokens && stepIndex < maxStepsByPrefill {
+            // Legacy embed path (forced via options.forceLegacyEmbedPath, or pre-macOS-15
+            // OSes — note the multifunction SpeechDecoder asset still requires iOS 18+,
+            // so SD calls will throw at runtime on older OSes).
+            while code0 != Qwen3TTSConstants.codecEOS
+                && !cdCache.isFull
+                && stepIndex < options.maxNewTokens
+                && stepIndex < maxStepsByPrefill
+            {
                 try Task.checkCancellation()
                 let stepStart = CFAbsoluteTimeGetCurrent()
 
@@ -549,91 +510,32 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 timings.decodingKvCaching += mcdResult.timings.decodingKvCaching
                 timings.totalMultiCodeDecoderPredictions += mcdResult.timings.totalMultiCodeDecoderPredictions
 
+                // Captured before `code0` is resampled below; ingested into the writer
+                // after sampling (nothing between here and then reads the buffer).
                 let rvqFrame = [code0] + mcdResult.codes
 
-                if !firstBufferEmitted {
-                    let sdResult = try await speechDecoder.decodeFrameAsync(codes: rvqFrame, cache: sdCache)
-                    timings.speechDecoderPredictions += sdResult.timings.speechDecoderPredictions
-                    timings.speechDecoder += sdResult.timings.speechDecoderPredictions
-                    allAudio.append(contentsOf: sdResult.samples)
-
-                    timings.timeToFirstBuffer = CFAbsoluteTimeGetCurrent() - pipelineStart
-                    firstBufferEmitted = true
-                    let stepTime = CFAbsoluteTimeGetCurrent() - stepStart
-
-                    if callback?(
-                        SpeechProgress(
-                            audio: sdResult.samples,
-                            timings: {
-                                var merged = baseTimings; merged.merge(timings); return merged
-                            }(), stepTime: stepTime)) == false
-                    {
-                        break
-                    }
-
-                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
-                    guard let lastMcdCode = mcdResult.codes.last else {
-                        throw TTSError.generationFailed("Multi-code generation result has no codes")
-                    }
-                    let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
-                    var allCodeEmbeds: [[FloatType]] = [code0Embed]
-                    allCodeEmbeds += mcdResult.offsetCodeEmbeds
-                    try await allCodeEmbeds.append(multiCodeEmbedder.embed(tokenId: code15OffsetId))
-                    let codecHidden = EmbedUtilities.sumEmbeddings(allCodeEmbeds)
-                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
-
-                    let textProjStart = CFAbsoluteTimeGetCurrent()
-                    let textTokenEmbed: [FloatType] =
-                        stepIndex < tokenizeResult.trailingTextTokens.count
-                        ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
-                        : tokenizeResult.textPadEmbed
-                    let combinedArr = try EmbedUtilities.createEmbedMLArray(EmbedUtilities.addEmbeddings(codecHidden, textTokenEmbed))
-                    timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
-
-                    let decodingStart = CFAbsoluteTimeGetCurrent()
-                    lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedArr, cache: cdCache, state: cdState)
-                    timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart
-                } else {
-                    async let speechResult = speechDecoder.decodeFrameAsync(codes: rvqFrame, cache: sdCache)
-
-                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
-                    guard let lastMcdCode = mcdResult.codes.last else {
-                        throw TTSError.generationFailed("Multi-code generation result has no codes")
-                    }
-                    let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
-                    var allCodeEmbeds: [[FloatType]] = [code0Embed]
-                    allCodeEmbeds += mcdResult.offsetCodeEmbeds
-                    try await allCodeEmbeds.append(multiCodeEmbedder.embed(tokenId: code15OffsetId))
-                    let codecHidden = EmbedUtilities.sumEmbeddings(allCodeEmbeds)
-                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
-
-                    let textProjStart = CFAbsoluteTimeGetCurrent()
-                    let textTokenEmbed: [FloatType] =
-                        stepIndex < tokenizeResult.trailingTextTokens.count
-                        ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
-                        : tokenizeResult.textPadEmbed
-                    let combinedArr = try EmbedUtilities.createEmbedMLArray(EmbedUtilities.addEmbeddings(codecHidden, textTokenEmbed))
-                    timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
-
-                    let decodingStart = CFAbsoluteTimeGetCurrent()
-                    lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedArr, cache: cdCache, state: cdState)
-                    timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart
-
-                    let sdResult = try await speechResult
-                    timings.speechDecoderPredictions += sdResult.timings.speechDecoderPredictions
-                    timings.speechDecoder += sdResult.timings.speechDecoderPredictions
-                    allAudio.append(contentsOf: sdResult.samples)
-
-                    if callback?(
-                        SpeechProgress(
-                            audio: sdResult.samples,
-                            timings: {
-                                var merged = baseTimings; merged.merge(timings); return merged
-                            }(), stepTime: nil)) == false
-                    {
-                        break
-                    }
+                let codecHiddenStart = CFAbsoluteTimeGetCurrent()
+                guard let lastMcdCode = mcdResult.codes.last else {
+                    throw TTSError.generationFailed("Multi-code generation result has no codes")
                 }
+                let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
+                var allCodeEmbeds: [[FloatType]] = [code0Embed]
+                allCodeEmbeds += mcdResult.offsetCodeEmbeds
+                try await allCodeEmbeds.append(multiCodeEmbedder.embed(tokenId: code15OffsetId))
+                let codecHidden = EmbedUtilities.sumEmbeddings(allCodeEmbeds)
+                timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
+
+                let textProjStart = CFAbsoluteTimeGetCurrent()
+                let textTokenEmbed: [FloatType] =
+                    stepIndex < tokenizeResult.trailingTextTokens.count
+                    ? try await textProjector.project(tokenId: tokenizeResult.trailingTextTokens[stepIndex])
+                    : tokenizeResult.textPadEmbed
+                let combinedArr = try EmbedUtilities.createEmbedMLArray(EmbedUtilities.addEmbeddings(codecHidden, textTokenEmbed))
+                timings.textProjection += CFAbsoluteTimeGetCurrent() - textProjStart
+
+                let decodingStart = CFAbsoluteTimeGetCurrent()
+                lastCdOutput = try await codeDecoder.decode(inputEmbeds: combinedArr, cache: cdCache, state: cdState)
+                timings.decodingPredictions += CFAbsoluteTimeGetCurrent() - decodingStart
 
                 let samplingStart = CFAbsoluteTimeGetCurrent()
                 code0 = await sampler.sampleCodec0(
@@ -645,6 +547,11 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 )
                 generatedTokens.append(code0)
                 timings.decodingSampling += CFAbsoluteTimeGetCurrent() - samplingStart
+
+                if !(try await writer.append(rvqFrame, stepStart: stepStart, loopTimings: &timings)) {
+                    stopRequested = true
+                    break
+                }
 
                 timings.decodingLoop += CFAbsoluteTimeGetCurrent() - stepStart
                 stepIndex += 1
@@ -660,6 +567,13 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
             }
         }
 
+        // Drain the in-flight decode from the last completed flush, then flush any
+        // remaining partial buffer. Skipped entirely when the callback already asked
+        // to stop in the loop, so we don't emit one more `SpeechProgress` after that.
+        if !stopRequested {
+            try await writer.finish(loopTimings: &timings)
+        }
+
         let stopReason: String
         if code0 == Qwen3TTSConstants.codecEOS {
             stopReason = "EOS token"
@@ -673,7 +587,7 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         Logging.info("Loop stopped: \(stopReason) after \(stepIndex) steps")
 
         timings.totalDecodingLoops = Double(stepIndex)
-        return GenerationLoopResult(audio: allAudio, steps: stepIndex, timings: timings)
+        return GenerationLoopResult(audio: writer.collectedAudio, steps: stepIndex, timings: timings)
     }
 
     // MARK: - Embedding Helpers

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
@@ -54,7 +54,7 @@ public enum Qwen3TTSConstants {
     public static let sdCacheDim: Int = 8192
     public static let sdMaxSeq: Int = 256
     public static let sdHiddenDim: Int = 1024
-    public static let sdHiddenContextLen: Int = 16
+    public static let sdHiddenContextLen: Int = 4
 
     // MARK: Default HuggingFace sources
 
@@ -169,6 +169,25 @@ public enum Qwen3Language: String, CaseIterable, Sendable {
             case .portuguese: return 2071
             case .spanish: return 2054
             case .italian: return 2070
+        }
+    }
+}
+
+// MARK: - SpeechDecoder Mode
+
+/// Selects which SpeechDecoder mode to use — i.e. how much audio is produced by a
+/// single prediction. `.latencyOptimized` decodes one RVQ frame per call;
+/// `.throughputOptimized` decodes four.
+@frozen
+public enum Qwen3SpeechDecoderMode: String, Sendable, CaseIterable {
+    case latencyOptimized
+    case throughputOptimized
+
+    /// CoreML function name corresponding to this mode.
+    public var functionName: String {
+        switch self {
+            case .latencyOptimized: return "latency"
+            case .throughputOptimized: return "throughput"
         }
     }
 }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
@@ -57,9 +57,12 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
         modelConfig.computeUnits = computeUnits
         // Multifunction `functionName` selection is iOS 18+ / macOS 15+. The asset
         // itself requires the same minimum, so callers on older OS cannot load it.
-        if #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) {
-            modelConfig.functionName = mode.functionName
+        guard #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) else {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder requires macOS 15 / iOS 18 (multifunction CoreML model)"
+            )
         }
+        modelConfig.functionName = mode.functionName
         let loaded: MLModel
         do {
             loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)

--- a/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
@@ -8,7 +8,13 @@ import Foundation
 
 // MARK: - Implementation
 
-/// RVQ-to-audio waveform decoder backed by a CoreML model.
+/// RVQ-to-audio waveform decoder backed by a CoreML multifunction model.
+///
+/// The model bundles two graphs (`latency` and `throughput`) that differ only in
+/// how many RVQ frames they consume per call. The choice is made at load time via
+/// `MLModelConfiguration.functionName` and surfaced as `codesPerStep` after load
+/// (1 for the latency function, 4 for throughput). Multifunction CoreML requires
+/// macOS 15 / iOS 18 and so does the asset itself.
 ///
 /// Thread safety: mutable state (`model`, dimension properties) is set once during
 /// `loadModel()` and read-only thereafter. `MLModel.prediction()` is thread-safe.
@@ -19,8 +25,17 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
 
     public let sampleRate: Int = Qwen3TTSConstants.sampleRate
     public let samplesPerFrame: Int = Qwen3TTSConstants.samplesPerFrame
-    /// Minimum pre-buffer: 80ms ≈ 2 audio frames at 24 kHz / 1920 spf.
-    public let minimumBufferDuration: TimeInterval = 0.08
+    /// Minimum pre-buffer in seconds. Defaults to 0.08 (RVQ frame = 80ms @ 24kHz); at
+    /// load time it becomes `0.08 * codesPerStep` — ~80 ms for latency, ~320 ms for
+    /// throughput.
+    public private(set) var minimumBufferDuration: TimeInterval = 0.08
+
+    // MARK: - Mode (set by TTSKit before loadModel)
+
+    /// Which function of the multifunction `.mlmodelc` to load.
+    public var mode: Qwen3SpeechDecoderMode = .latencyOptimized
+
+    // MARK: - Detected from the loaded model
 
     /// Detected from model metadata at load time
     public private(set) var hiddenContextLen: Int = Qwen3TTSConstants.sdHiddenContextLen
@@ -30,101 +45,124 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
     public private(set) var kvCacheMaxSequenceLength: Int = Qwen3TTSConstants.sdMaxSeq
     /// Hidden state dimension
     public private(set) var hiddenDim: Int = Qwen3TTSConstants.sdHiddenDim
+    /// Number of RVQ frames consumed per `decodeFrame{Async}` call. 1 for latency,
+    /// 4 for throughput. Read from the loaded model's `audio_codes` input shape.
+    /// Also implies the model consumes a `qk_mask` input iff > 1.
+    public private(set) var codesPerStep: Int = 1
+
     public init() {}
 
     public func loadModel(at url: URL, computeUnits: MLComputeUnits, prewarmMode: Bool = false) async throws {
         let modelConfig = MLModelConfiguration()
         modelConfig.computeUnits = computeUnits
-        let loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
+        // Multifunction `functionName` selection is iOS 18+ / macOS 15+. The asset
+        // itself requires the same minimum, so callers on older OS cannot load it.
+        if #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            modelConfig.functionName = mode.functionName
+        }
+        let loaded: MLModel
+        do {
+            loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
+        } catch {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder: failed to load function '\(mode.functionName)' from " +
+                "\(url.lastPathComponent). This must be a multifunction CoreML asset " +
+                "with 'latency' and 'throughput' functions, running on macOS 15 / iOS 18 " +
+                "or newer. (\(error.localizedDescription))"
+            )
+        }
 
         // In prewarm mode, compilation is complete - discard to free memory before next model compiles
         guard !prewarmMode else { return }
 
         self.model = loaded
 
-        // Detect dimensions from model description
-        // hidden_context input shape: [1, hiddenDim, 1, contextLen]
-        if let dim = ModelUtilities.getModelInputDimension(model, named: "hidden_context", position: 1) {
-            self.hiddenDim = dim
+        // Read required dimensions from the model description. Every input below has a
+        // fixed shape in a well-formed multifunction SpeechDecoder asset, so a missing
+        // dimension means the asset is malformed — fail loudly instead of silently
+        // keeping the defaults. In particular, silently defaulting `codesPerStep` to 1
+        // would mis-drive a throughput-optimized model (consuming 1 of its 4 frames per
+        // call) and produce corrupt audio.
+        let assetName = url.lastPathComponent
+        // audio_codes input shape: [1, 16, codesPerStep]
+        self.codesPerStep = try Self.requireInputDimension(named: "audio_codes", position: 2, in: loaded, assetName: assetName)
+        // hidden_context input shape: [1, hiddenDim, 1, hiddenContextLen]
+        self.hiddenDim = try Self.requireInputDimension(named: "hidden_context", position: 1, in: loaded, assetName: assetName)
+        self.hiddenContextLen = try Self.requireInputDimension(named: "hidden_context", position: 3, in: loaded, assetName: assetName)
+        // key_cache input shape: [1, kvCacheEmbedDim, 1, kvCacheMaxSequenceLength]
+        self.kvCacheEmbedDim = try Self.requireInputDimension(named: "key_cache", position: 1, in: loaded, assetName: assetName)
+        self.kvCacheMaxSequenceLength = try Self.requireInputDimension(named: "key_cache", position: 3, in: loaded, assetName: assetName)
+
+        // Scale streaming buffer to the audio output per call.
+        self.minimumBufferDuration = 0.08 * TimeInterval(codesPerStep)
+    }
+
+    /// Read a required fixed-shape input dimension from a loaded model, throwing a
+    /// descriptive error if the named input or its dimension at `position` is absent.
+    private static func requireInputDimension(
+        named name: String, position: Int, in model: MLModel, assetName: String
+    ) throws -> Int {
+        guard let value = ModelUtilities.getModelInputDimension(model, named: name, position: position) else {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder: missing expected input dimension '\(name)'[\(position)] in " +
+                "\(assetName). Expected a well-formed multifunction SpeechDecoder asset."
+            )
         }
-        if let ctxLen = ModelUtilities.getModelInputDimension(model, named: "hidden_context", position: 3) {
-            self.hiddenContextLen = ctxLen
-        }
-        // key_cache input shape: [1, cacheDim, 1, maxSeqLen]
-        if let dim = ModelUtilities.getModelInputDimension(model, named: "key_cache", position: 1) {
-            self.kvCacheEmbedDim = dim
-        }
-        if let seq = ModelUtilities.getModelInputDimension(model, named: "key_cache", position: 3) {
-            self.kvCacheMaxSequenceLength = seq
-        }
+        return value
     }
 
     public func decodeFrame(
-        codes: [Int32],
+        codes: [[Int32]],
         cache: SpeechDecoderCache
     ) async throws -> [Float] {
-        guard let model else {
-            throw TTSError.generationFailed("SpeechDecoder model not loaded")
-        }
-
-        let codesArr = try MLMultiArray(shape: [1, 16, 1], dataType: .int32)
-        let codesPtr = codesArr.dataPointer.bindMemory(to: Int32.self, capacity: 16)
-        for i in 0..<16 {
-            codesPtr[i] = codes[i]
-        }
-
-        guard let keyCache = cache.keyCache, let valueCache = cache.valueCache else {
-            throw TTSError.generationFailed("SpeechDecoder: KV cache not initialized")
-        }
-        let input = try MLDictionaryFeatureProvider(dictionary: [
-            "audio_codes": MLFeatureValue(multiArray: codesArr),
-            "cache_length": MLFeatureValue(multiArray: cache.makeCacheLengthArray()),
-            "key_cache": MLFeatureValue(multiArray: keyCache),
-            "value_cache": MLFeatureValue(multiArray: valueCache),
-            "kv_cache_update_mask": MLFeatureValue(multiArray: cache.kvCacheUpdateMask),
-            "key_padding_mask": MLFeatureValue(multiArray: cache.keyPaddingMask),
-            "hidden_context": MLFeatureValue(multiArray: cache.hiddenContext)
-        ])
-
-        let output = try await model.asyncPrediction(from: input)
-        cache.updateWithHiddenContext(output: output)
-
-        guard let audioArr = output.featureValue(for: "audio")?.multiArrayValue else {
-            throw TTSError.generationFailed("SpeechDecoder: missing audio output array")
-        }
-        let sampleCount = audioArr.count
-        let audioPtr = audioArr.dataPointer.bindMemory(to: FloatType.self, capacity: sampleCount)
-        var samples = [Float](repeating: 0, count: sampleCount)
-        for i in 0..<sampleCount {
-            samples[i] = Float(audioPtr[i])
-        }
-
-        return samples
+        let result = try await decodeFrameAsync(codes: codes, cache: cache)
+        return result.samples
     }
 
-    /// Async variant for concurrent execution via `async let`.
-    /// On macOS 15+ / iOS 18+ uses `[String: MLTensor]` directly to avoid FeatureProvider boxing.
-    /// Falls back to `asyncPrediction(from:)` on older OS.
-    /// Returns samples and a SpeechTimings with speechDecoder fields populated.
+    /// Async multi-frame decode. Returns audio samples plus per-call timings.
+    /// On macOS 15+/iOS 18+ uses `[String: MLTensor]` directly to avoid FeatureProvider boxing.
     public func decodeFrameAsync(
-        codes: [Int32],
+        codes: [[Int32]],
         cache: SpeechDecoderCache
     ) async throws -> SpeechDecoderTimedResult {
         guard let model else {
             throw TTSError.generationFailed("SpeechDecoder model not loaded")
         }
+        guard codes.count == codesPerStep else {
+            throw TTSError.generationFailed(
+                "SpeechDecoder: expected \(codesPerStep) RVQ frames per call, got \(codes.count)"
+            )
+        }
+        for (i, frame) in codes.enumerated() {
+            guard frame.count == 16 else {
+                throw TTSError.generationFailed(
+                    "SpeechDecoder: frame \(i) has \(frame.count) codes, expected 16"
+                )
+            }
+        }
 
         var timings = SpeechTimings()
 
-        // TODO: Remove forking logic with package with min os version upgrade
         if #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            // Flatten codes into [1, 16, codesPerStep] with codes[frameIndex][codebookIndex]
+            // at position (codebookIndex * codesPerStep + frameIndex) because the natural
+            // layout for that shape is (..., codebookIndex, frameIndex) — the last axis
+            // (codesPerStep) is the fastest-varying.
+            var flat = [Int32](repeating: 0, count: 16 * codesPerStep)
+            for codebookIndex in 0..<16 {
+                let base = codebookIndex * codesPerStep
+                for frameIndex in 0..<codesPerStep {
+                    flat[base + frameIndex] = codes[frameIndex][codebookIndex]
+                }
+            }
+
             guard let keyCacheTensor = cache.keyCacheTensor,
                 let valueCacheTensor = cache.valueCacheTensor
             else {
                 throw TTSError.generationFailed("SpeechDecoder: KV cache tensors not initialized")
             }
-            let inputs: [String: MLTensor] = [
-                "audio_codes": MLTensor(shape: [1, codes.count, 1], scalars: codes),
+            var inputs: [String: MLTensor] = [
+                "audio_codes": MLTensor(shape: [1, 16, codesPerStep], scalars: flat),
                 "cache_length": cache.cacheLengthTensor,
                 "key_cache": keyCacheTensor,
                 "value_cache": valueCacheTensor,
@@ -132,6 +170,9 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
                 "key_padding_mask": cache.keyPaddingMaskTensor,
                 "hidden_context": cache.hiddenContextTensor
             ]
+            if codesPerStep > 1, let qkMaskTensor = cache.qkMaskTensor {
+                inputs["qk_mask"] = qkMaskTensor
+            }
 
             let predictionStart = CFAbsoluteTimeGetCurrent()
             let outputs = try await model.prediction(from: inputs)
@@ -145,39 +186,9 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
             let samples = await audioTensor.toFloatArray()
             return SpeechDecoderTimedResult(samples: samples, timings: timings)
         } else {
-            let codesArr = try MLMultiArray(shape: [1, 16, 1], dataType: .int32)
-            let codesPtr = codesArr.dataPointer.bindMemory(to: Int32.self, capacity: 16)
-            for i in 0..<16 {
-                codesPtr[i] = codes[i]
-            }
-            guard let keyCacheFallback = cache.keyCache, let valueCacheFallback = cache.valueCache else {
-                throw TTSError.generationFailed("SpeechDecoder: KV cache not initialized (legacy path)")
-            }
-            let input = try MLDictionaryFeatureProvider(dictionary: [
-                "audio_codes": MLFeatureValue(multiArray: codesArr),
-                "cache_length": MLFeatureValue(multiArray: cache.makeCacheLengthArray()),
-                "key_cache": MLFeatureValue(multiArray: keyCacheFallback),
-                "value_cache": MLFeatureValue(multiArray: valueCacheFallback),
-                "kv_cache_update_mask": MLFeatureValue(multiArray: cache.kvCacheUpdateMask),
-                "key_padding_mask": MLFeatureValue(multiArray: cache.keyPaddingMask),
-                "hidden_context": MLFeatureValue(multiArray: cache.hiddenContext)
-            ])
-
-            let predictionStart = CFAbsoluteTimeGetCurrent()
-            let output = try await model.asyncPrediction(from: input, options: MLPredictionOptions())
-            timings.speechDecoderPredictions += CFAbsoluteTimeGetCurrent() - predictionStart
-
-            cache.updateWithHiddenContext(output: output)
-            guard let audioArr = output.featureValue(for: "audio")?.multiArrayValue else {
-                throw TTSError.generationFailed("SpeechDecoder: missing audio output array (legacy path)")
-            }
-            let sampleCount = audioArr.count
-            let audioPtr = audioArr.dataPointer.bindMemory(to: FloatType.self, capacity: sampleCount)
-            var samples = [Float](repeating: 0, count: sampleCount)
-            for i in 0..<sampleCount {
-                samples[i] = Float(audioPtr[i])
-            }
-            return SpeechDecoderTimedResult(samples: samples, timings: timings)
+            throw TTSError.generationFailed(
+                "SpeechDecoder requires macOS 15 / iOS 18 (multifunction CoreML model)"
+            )
         }
     }
 

--- a/Sources/TTSKit/Qwen3TTS/SpeechStreamWriter.swift
+++ b/Sources/TTSKit/Qwen3TTS/SpeechStreamWriter.swift
@@ -1,0 +1,213 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import ArgmaxCore
+import CoreML
+import Foundation
+
+// MARK: - SpeechStreamWriter
+
+/// Buffers decoded RVQ frames and streams them out as audio, owning the
+/// overlapped-decode / drain / partial-flush logic and callback emission.
+///
+/// Single-use and not thread-safe: create one per generation and drive it serially
+/// from one task.
+final class SpeechStreamWriter<Decoder: SpeechDecoding & Sendable> {
+    private let speechDecoder: Decoder
+    private let sdCache: SpeechDecoderCache
+    private let callback: SpeechCallback
+    private let pipelineStart: CFAbsoluteTime
+    private let baseTimings: SpeechTimings
+    private let padFrame: [Int32]
+    /// RVQ frames consumed per decode call; read from `speechDecoder`.
+    private let codesPerStep: Int
+    /// PCM samples produced per RVQ frame; read from `speechDecoder`.
+    private let samplesPerFrame: Int
+
+    /// Audio accumulated across every emitted buffer, in emission order.
+    private(set) var collectedAudio: [Float] = []
+
+    /// Whether the first buffer has been emitted. Drives the synchronous-first-buffer
+    /// path (for minimum TTFB) and the time-to-first-buffer timing.
+    private(set) var hasEmittedFirstBuffer = false
+
+    /// RVQ frames accumulated since the last flush (length `0..<codesPerStep`).
+    private var rvqBuffer: [[Int32]] = []
+
+    /// In-flight overlapped SpeechDecoder decode awaiting its drain on the next flush.
+    private var pendingDecode: (
+        task: Task<SpeechDecoderTimedResult, Error>,
+        padCount: Int,
+        isFirstBuffer: Bool,
+        stepStart: CFAbsoluteTime
+    )?
+
+    init(
+        speechDecoder: Decoder,
+        sdCache: SpeechDecoderCache,
+        callback: SpeechCallback,
+        pipelineStart: CFAbsoluteTime,
+        baseTimings: SpeechTimings,
+        padFrame: [Int32]
+    ) {
+        self.speechDecoder = speechDecoder
+        self.sdCache = sdCache
+        self.callback = callback
+        self.pipelineStart = pipelineStart
+        self.baseTimings = baseTimings
+        self.padFrame = padFrame
+        // Cache geometry comes straight from the decoder — no need to thread it in.
+        self.codesPerStep = speechDecoder.codesPerStep
+        self.samplesPerFrame = speechDecoder.samplesPerFrame
+        rvqBuffer.reserveCapacity(speechDecoder.codesPerStep)
+    }
+
+    // MARK: - Driving the stream
+
+    /// Append one decoded RVQ frame. Once `codesPerStep` frames have accumulated,
+    /// drains the previous in-flight decode and submits a new one.
+    ///
+    /// - Returns: `false` when a callback (the drained buffer's, or the first
+    ///   buffer's) asked generation to stop; `true` to continue.
+    func append(
+        _ frame: [Int32],
+        stepStart: CFAbsoluteTime,
+        loopTimings: inout SpeechTimings
+    ) async throws -> Bool {
+        rvqBuffer.append(frame)
+        guard rvqBuffer.count == codesPerStep else { return true }
+        // Drain the previous in-flight SD (if any) before kicking off a new one —
+        // its execution overlapped with this step's CD/MCD work.
+        guard try await drainPendingDecode(loopTimings: &loopTimings) else { return false }
+        return try await submitDecode(stepStart: stepStart, loopTimings: &loopTimings)
+    }
+
+    /// Drain any in-flight decode, then flush the remaining partial buffer (padded to
+    /// `codesPerStep`, trimming the pad-derived trailing samples).
+    ///
+    /// - Returns: `false` when the drain's callback asked to stop. The final partial
+    ///   flush's callback result is intentionally ignored — there is nothing left to
+    ///   stop — matching the original loop behavior.
+    @discardableResult
+    func finish(loopTimings: inout SpeechTimings) async throws -> Bool {
+        guard try await drainPendingDecode(loopTimings: &loopTimings) else { return false }
+        guard !rvqBuffer.isEmpty else { return true }
+
+        let padCount = max(0, codesPerStep - rvqBuffer.count)
+        var toSubmit = rvqBuffer
+        for _ in 0..<padCount { toSubmit.append(padFrame) }
+        let result = try await speechDecoder.decodeFrameAsync(codes: toSubmit, cache: sdCache)
+        _ = emitDecodedBuffer(
+            samples: result.samples,
+            padCount: padCount,
+            predictionTime: result.timings.speechDecoderPredictions,
+            isFirstBuffer: !hasEmittedFirstBuffer,
+            stepStart: CFAbsoluteTimeGetCurrent(),
+            loopTimings: &loopTimings
+        )
+        rvqBuffer.removeAll(keepingCapacity: true)
+        return true
+    }
+
+    /// Cancel any in-flight decode so it cannot outlive the loop. Called on every
+    /// exit path (the overlapped `Task` does not inherit the loop's cancellation).
+    func cancelPendingDecode() {
+        pendingDecode?.task.cancel()
+        pendingDecode = nil
+    }
+
+    // MARK: - Decode submission / drain
+
+    /// Await the in-flight decode (if any) and emit its buffer.
+    /// Required before submitting a new decode so `sdCache` mutations stay ordered.
+    private func drainPendingDecode(loopTimings: inout SpeechTimings) async throws -> Bool {
+        guard let pending = pendingDecode else { return true }
+        pendingDecode = nil
+        let result = try await pending.task.value
+        return emitDecodedBuffer(
+            samples: result.samples,
+            padCount: pending.padCount,
+            predictionTime: result.timings.speechDecoderPredictions,
+            isFirstBuffer: pending.isFirstBuffer,
+            stepStart: pending.stepStart,
+            loopTimings: &loopTimings
+        )
+    }
+
+    /// Snapshot the current buffer and either decode synchronously (first buffer, for
+    /// minimum TTFB) or kick off an overlapped `Task` drained on the next flush.
+    /// Callers must drain any previous `pendingDecode` first.
+    ///
+    /// - Returns: `false` when the first-buffer callback asked to stop; otherwise `true`.
+    private func submitDecode(stepStart: CFAbsoluteTime, loopTimings: inout SpeechTimings) async throws -> Bool {
+        let snapshot = rvqBuffer
+        rvqBuffer.removeAll(keepingCapacity: true)
+
+        if !hasEmittedFirstBuffer {
+            let result = try await speechDecoder.decodeFrameAsync(codes: snapshot, cache: sdCache)
+            return emitDecodedBuffer(
+                samples: result.samples,
+                padCount: 0,
+                predictionTime: result.timings.speechDecoderPredictions,
+                isFirstBuffer: true,
+                stepStart: stepStart,
+                loopTimings: &loopTimings
+            )
+        } else {
+            let decoder = speechDecoder
+            let cache = sdCache
+            pendingDecode = (
+                task: Task { try await decoder.decodeFrameAsync(codes: snapshot, cache: cache) },
+                padCount: 0,
+                isFirstBuffer: false,
+                stepStart: stepStart
+            )
+            return true
+        }
+    }
+
+    /// Trim trailing pad-derived audio samples, append to ``collectedAudio``, fold the
+    /// decode's timing into `loopTimings`, build a `SpeechProgress`, emit the callback,
+    /// and bookkeep first-buffer / TTFB state.
+    ///
+    /// - Returns: `false` when the callback asked generation to stop; `true` otherwise.
+    private func emitDecodedBuffer(
+        samples sourceSamples: [Float],
+        padCount: Int,
+        predictionTime: TimeInterval,
+        isFirstBuffer: Bool,
+        stepStart: CFAbsoluteTime,
+        loopTimings: inout SpeechTimings
+    ) -> Bool {
+        loopTimings.speechDecoderPredictions += predictionTime
+        loopTimings.speechDecoder += predictionTime
+        loopTimings.totalSpeechDecoderInvocations += 1
+
+        var samples = sourceSamples
+        if padCount > 0 {
+            let padSamples = padCount * samplesPerFrame
+            if samples.count > padSamples {
+                samples = Array(samples.prefix(samples.count - padSamples))
+            } else {
+                samples.removeAll()
+            }
+        }
+        collectedAudio.append(contentsOf: samples)
+
+        let now = CFAbsoluteTimeGetCurrent()
+        if isFirstBuffer {
+            loopTimings.timeToFirstBuffer = now - pipelineStart
+            hasEmittedFirstBuffer = true
+        }
+
+        let progress: SpeechProgress
+        if isFirstBuffer {
+            progress = SpeechProgress(audio: samples, timings: loopTimings, stepTime: now - stepStart)
+        } else {
+            var merged = baseTimings
+            merged.merge(loopTimings)
+            progress = SpeechProgress(audio: samples, timings: merged, stepTime: nil)
+        }
+        return callback?(progress) != false
+    }
+}

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -471,6 +471,12 @@ open class TTSKit: @unchecked Sendable {
             try await loadTokenizerIfNeeded()
         }
 
+        // Propagate Qwen3-specific config to the concrete SpeechDecoder before `loadModel`
+        // selects which function of the multifunction asset to compile.
+        if let qwen3SD = speechDecoder as? Qwen3SpeechDecoder {
+            qwen3SD.mode = config.speechDecoderMode
+        }
+
         // Load the six CoreML models.
         // Prewarm: sequential to serialize compilation -> lower peak memory.
         // Normal: concurrent since compiled artifacts are already cached.

--- a/Sources/TTSKit/Utilities/KVCache.swift
+++ b/Sources/TTSKit/Utilities/KVCache.swift
@@ -13,6 +13,11 @@ import Foundation
 /// or position tracking and attention masks only for stateful models whose weights
 /// are managed internally by CoreML via `MLState`.
 ///
+/// Components that consume more than one new position per call (e.g. the
+/// throughput-optimized SpeechDecoder, which processes 4 RVQ frames at once)
+/// pass `codesPerStep > 1`. The `kvCacheUpdateMask` shape and update logic
+/// adapt accordingly.
+///
 /// Thread safety: each `Qwen3GenerateTask` creates its own cache instance.
 /// Caches are never shared across concurrent tasks.
 public class KVCache: @unchecked Sendable {
@@ -20,6 +25,11 @@ public class KVCache: @unchecked Sendable {
     public let maxSeqLength: Int
     public let cacheDim: Int
     public let isStateful: Bool
+    /// Number of new positions written per `update()` call.
+    public let codesPerStep: Int
+    /// When `true`, `kvCacheUpdateMask` is `[1, codesPerStep, maxSeqLength]` (rank 3, one row
+    /// per new position). When `false`, `[1, maxSeqLength]` (rank 2 — single-position path).
+    public let useRank3UpdateMask: Bool
 
     /// External key cache -- nil for stateful models
     public let keyCache: MLMultiArray?
@@ -28,9 +38,36 @@ public class KVCache: @unchecked Sendable {
     public let kvCacheUpdateMask: MLMultiArray
     public let keyPaddingMask: MLMultiArray
 
-    public init(cacheDim: Int, maxSeqLength: Int, isStateful: Bool = false) throws {
+    /// Additive attention-mask bias applied to masked-out positions (padded key
+    /// slots and future positions in the intra-step causal triangle). A large
+    /// negative value so that, after softmax, attention to those positions is ~0.
+    static let maskedAttentionBias = FloatType(-10000)
+
+    public init(
+        cacheDim: Int,
+        maxSeqLength: Int,
+        codesPerStep: Int = 1,
+        useRank3UpdateMask: Bool = false,
+        isStateful: Bool = false
+    ) throws {
+        // Validate the configuration and fail gracefully (the init already throws) so a
+        // misconfigured cache surfaces an error to the caller instead of crashing the app.
+        guard codesPerStep >= 1 else {
+            throw TTSError.invalidConfiguration("KVCache: codesPerStep must be >= 1, got \(codesPerStep)")
+        }
+        // Multi-position updates require the rank-3 update mask: the rank-2 mask is
+        // `[1, maxSeqLength]` and can only encode a single active update column, so it
+        // cannot describe `codesPerStep > 1` new positions per call.
+        guard codesPerStep == 1 || useRank3UpdateMask else {
+            throw TTSError.invalidConfiguration(
+                "KVCache: codesPerStep > 1 (\(codesPerStep)) requires useRank3UpdateMask " +
+                "(the rank-2 update mask only encodes one position)"
+            )
+        }
         self.cacheDim = cacheDim
         self.maxSeqLength = maxSeqLength
+        self.codesPerStep = codesPerStep
+        self.useRank3UpdateMask = useRank3UpdateMask
         self.isStateful = isStateful
 
         if isStateful {
@@ -48,10 +85,10 @@ public class KVCache: @unchecked Sendable {
             )
         }
 
-        kvCacheUpdateMask = try MLMultiArray(
-            shape: [1, NSNumber(value: maxSeqLength)],
-            dataType: .float16
-        )
+        let updateShape: [NSNumber] = useRank3UpdateMask
+            ? [1, NSNumber(value: codesPerStep), NSNumber(value: maxSeqLength)]
+            : [1, NSNumber(value: maxSeqLength)]
+        kvCacheUpdateMask = try MLMultiArray(shape: updateShape, dataType: .float16)
         keyPaddingMask = try MLMultiArray(
             shape: [1, NSNumber(value: maxSeqLength)],
             dataType: .float16
@@ -62,29 +99,55 @@ public class KVCache: @unchecked Sendable {
 
     public func reset() {
         cacheLength = 0
+        let seqLen = maxSeqLength
 
         // Zero-fill external KV caches (stateful models don't have them)
         if let keyCache, let valueCache {
-            memset(keyCache.dataPointer, 0, cacheDim * maxSeqLength * MemoryLayout<FloatType>.size)
-            memset(valueCache.dataPointer, 0, cacheDim * maxSeqLength * MemoryLayout<FloatType>.size)
+            memset(keyCache.dataPointer, 0, cacheDim * seqLen * MemoryLayout<FloatType>.size)
+            memset(valueCache.dataPointer, 0, cacheDim * seqLen * MemoryLayout<FloatType>.size)
         }
 
-        // Initialize masks: first position active, rest masked
-        let updatePtr = kvCacheUpdateMask.dataPointer.bindMemory(to: FloatType.self, capacity: maxSeqLength)
-        let paddingPtr = keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: maxSeqLength)
-        for i in 0..<maxSeqLength {
-            updatePtr[i] = (i == 0) ? FloatType(1.0) : FloatType(0.0)
-            paddingPtr[i] = (i == 0) ? FloatType(0.0) : FloatType(-10000.0)
+        // Update mask: zero everything then set initial active entries.
+        memset(kvCacheUpdateMask.dataPointer, 0, kvCacheUpdateMask.count * MemoryLayout<FloatType>.size)
+        let updatePtr = kvCacheUpdateMask.dataPointer.bindMemory(
+            to: FloatType.self, capacity: kvCacheUpdateMask.count
+        )
+        if useRank3UpdateMask {
+            // [1, codesPerStep, maxSeqLength]: mask[0, i, i] = 1 for i in 0..<codesPerStep
+            for i in 0..<codesPerStep where i < seqLen {
+                updatePtr[i * seqLen + i] = FloatType(1)
+            }
+        } else {
+            // [1, maxSeqLength]: mask[0, 0] = 1
+            updatePtr[0] = FloatType(1)
+        }
+
+        // Padding mask: unmasked region is the first codesPerStep positions at startup.
+        let paddingPtr = keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: seqLen)
+        for j in 0..<seqLen {
+            paddingPtr[j] = (j < codesPerStep) ? FloatType(0) : Self.maskedAttentionBias
         }
     }
 
-    /// Write cache updates at current position and advance.
+    /// Write cache updates at the current position and advance by `codesPerStep`.
     /// For stateful models, only advances position and updates masks (KV cache is internal).
     public func update(keyCacheUpdates: MLMultiArray? = nil, valueCacheUpdates: MLMultiArray? = nil) {
         let writePos = Int(cacheLength)
         let seqLen = maxSeqLength
 
-        // Update external KV cache if present (non-stateful model)
+        // Defensive bounds check. The per-element writes below clamp at `seqLen`, so a
+        // multi-position update that runs past the end of the cache would silently drop
+        // the overflow. In normal operation generation halts on `isFull` before this can
+        // trigger; surface it as a warning rather than dropping K/V (and mask) values
+        // without any signal.
+        if writePos + codesPerStep > seqLen {
+            Logging.error(
+                "KVCache.update: write at position \(writePos) + codesPerStep \(codesPerStep) exceeds " +
+                "capacity \(seqLen); \(writePos + codesPerStep - seqLen) trailing position(s) dropped."
+            )
+        }
+
+        // Scatter `codesPerStep` new K/V positions into external KV cache (skip for stateful).
         if !isStateful, let keyCache, let valueCache, let keyCacheUpdates, let valueCacheUpdates {
             let embedDim = cacheDim
             let keyCachePtr = keyCache.dataPointer.bindMemory(to: FloatType.self, capacity: embedDim * seqLen)
@@ -92,32 +155,64 @@ public class KVCache: @unchecked Sendable {
 
             let keyUpdatePtr = keyCacheUpdates.dataPointer.bindMemory(to: FloatType.self, capacity: keyCacheUpdates.count)
             let valueUpdatePtr = valueCacheUpdates.dataPointer.bindMemory(to: FloatType.self, capacity: valueCacheUpdates.count)
-            let keyUpdateStride = keyCacheUpdates.strides[1].intValue
-            let valueUpdateStride = valueCacheUpdates.strides[1].intValue
+            // Strides along the embed-dim axis (1) and frame axis (3) of the
+            // `[1, embedDim, 1, codesPerStep]` updates tensor.
+            let keyEmbedStride = keyCacheUpdates.strides[1].intValue
+            let valueEmbedStride = valueCacheUpdates.strides[1].intValue
+            let keyFrameStride = keyCacheUpdates.strides[3].intValue
+            let valueFrameStride = valueCacheUpdates.strides[3].intValue
 
             for dim in 0..<embedDim {
-                keyCachePtr[dim * seqLen + writePos] = keyUpdatePtr[dim * keyUpdateStride]
-                valueCachePtr[dim * seqLen + writePos] = valueUpdatePtr[dim * valueUpdateStride]
+                let cacheBase = dim * seqLen
+                let keyBase = dim * keyEmbedStride
+                let valueBase = dim * valueEmbedStride
+                for i in 0..<codesPerStep {
+                    let dst = writePos + i
+                    if dst < seqLen {
+                        keyCachePtr[cacheBase + dst] = keyUpdatePtr[keyBase + i * keyFrameStride]
+                        valueCachePtr[cacheBase + dst] = valueUpdatePtr[valueBase + i * valueFrameStride]
+                    }
+                }
             }
         }
 
-        // Advance position and update masks
-        cacheLength += 1
-        let nextPos = Int(cacheLength)
-
-        let updateMaskPtr = kvCacheUpdateMask.dataPointer.bindMemory(to: FloatType.self, capacity: seqLen)
-        let paddingMaskPtr = keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: seqLen)
-        updateMaskPtr[writePos] = FloatType(0.0)
-        if nextPos < seqLen {
-            updateMaskPtr[nextPos] = FloatType(1.0)
-            paddingMaskPtr[nextPos] = FloatType(0.0)
+        // Incrementally update masks for the *next* iteration.
+        let oldCacheLen = writePos
+        let newCacheLen = writePos + codesPerStep
+        let updatePtr = kvCacheUpdateMask.dataPointer.bindMemory(
+            to: FloatType.self, capacity: kvCacheUpdateMask.count
+        )
+        if useRank3UpdateMask {
+            // For each row i: clear (oldCacheLen + i), set (newCacheLen + i).
+            for i in 0..<codesPerStep {
+                let oldCol = oldCacheLen + i
+                let newCol = newCacheLen + i
+                if oldCol < seqLen { updatePtr[i * seqLen + oldCol] = FloatType(0) }
+                if newCol < seqLen { updatePtr[i * seqLen + newCol] = FloatType(1) }
+            }
+        } else {
+            // [1, maxSeqLength]: clear writePos, set writePos+codesPerStep.
+            if oldCacheLen < seqLen { updatePtr[oldCacheLen] = FloatType(0) }
+            if newCacheLen < seqLen { updatePtr[newCacheLen] = FloatType(1) }
         }
+
+        // Extend the unmasked region by `codesPerStep` (positions
+        // [newCacheLen, newCacheLen + codesPerStep)).
+        let paddingPtr = keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: seqLen)
+        for j in newCacheLen..<min(newCacheLen + codesPerStep, seqLen) {
+            paddingPtr[j] = FloatType(0)
+        }
+
+        cacheLength = Int32(newCacheLen)
     }
 
-    public var isFull: Bool { Int(cacheLength) >= maxSeqLength - 1 }
+    /// `true` once there is no longer room for a full `codesPerStep`-wide write.
+    /// Reserves `codesPerStep` positions (one write) so `update()` never overruns;
+    /// for `codesPerStep == 1` this is the original `maxSeqLength - 1` threshold.
+    public var isFull: Bool { Int(cacheLength) >= maxSeqLength - codesPerStep }
 
-    /// How many free positions remain before the cache is full
-    public var freePositions: Int { maxSeqLength - 1 - Int(cacheLength) }
+    /// How many free positions remain before the cache is full.
+    public var freePositions: Int { maxSeqLength - codesPerStep - Int(cacheLength) }
 
     public func makeCacheLengthArray() throws -> MLMultiArray {
         let arr = try MLMultiArray(shape: [1], dataType: .int32)
@@ -132,7 +227,8 @@ public class KVCache: @unchecked Sendable {
 public extension KVCache {
     /// Cache position as a `[1]` Int32 tensor.
     var cacheLengthTensor: MLTensor { MLTensor(shape: [1], scalars: [Int32(cacheLength)]) }
-    /// Update-mask as a `[1, maxSeqLength]` Float16 tensor.
+    /// Update-mask tensor. Shape is `[1, maxSeqLength]` (rank-2 path) or
+    /// `[1, codesPerStep, maxSeqLength]` (rank-3 path) — driven by the cache's mode.
     var kvCacheUpdateMaskTensor: MLTensor { MLTensor(MLShapedArray<FloatType>(kvCacheUpdateMask)) }
     /// Padding-mask as a `[1, maxSeqLength]` Float16 tensor.
     var keyPaddingMaskTensor: MLTensor { MLTensor(MLShapedArray<FloatType>(keyPaddingMask)) }
@@ -151,21 +247,33 @@ public extension KVCache {
 
 // MARK: - Speech Decoder Cache
 
-/// Extended KV cache for SpeechDecoder with a rolling hidden context buffer.
+/// Extended KV cache for the SpeechDecoder.
 ///
-/// The hidden context window length varies by quantization variant
-/// (e.g. 4 for W8A16, 16 for W16A16) and is read from the model at load time.
-/// Task-local, never shared across concurrent tasks.
+/// Adds:
+/// - A rolling hidden-context buffer `[1, hiddenDim, 1, hiddenContextLen]` whose
+///   length is read from the loaded model (4 for the latency function, 1 for
+///   throughput).
+/// - An optional `qkMask` of shape `[1, codesPerStep, maxSeqLength]` that encodes
+///   the intra-step causal triangle; only allocated when `codesPerStep > 1` (the
+///   throughput function). The latency function does not consume `qk_mask`.
+///
+/// Always uses the rank-3 `kvCacheUpdateMask` shape since the new multifunction
+/// SpeechDecoder asset requires it for both functions (`[1, 1, maxSeqLength]` for
+/// the latency function, `[1, 4, maxSeqLength]` for throughput).
 public class SpeechDecoderCache: KVCache, @unchecked Sendable {
     public let hiddenContext: MLMultiArray // [1, hiddenDim, 1, contextLen]
     public let hiddenDim: Int
     public let hiddenContextLen: Int
+    /// Intra-step causal mask `[1, codesPerStep, maxSeqLength]`. `nil` when
+    /// `codesPerStep == 1` (latency function does not consume a `qk_mask` input).
+    public let qkMask: MLMultiArray?
 
     public init(
         cacheDim: Int = Qwen3TTSConstants.sdCacheDim,
         maxSeqLength: Int = Qwen3TTSConstants.sdMaxSeq,
         hiddenDim: Int = Qwen3TTSConstants.sdHiddenDim,
-        hiddenContextLen: Int = Qwen3TTSConstants.sdHiddenContextLen
+        hiddenContextLen: Int = Qwen3TTSConstants.sdHiddenContextLen,
+        codesPerStep: Int = 1
     ) throws {
         self.hiddenDim = hiddenDim
         self.hiddenContextLen = hiddenContextLen
@@ -174,34 +282,144 @@ public class SpeechDecoderCache: KVCache, @unchecked Sendable {
             dataType: .float16
         )
         memset(hiddenContext.dataPointer, 0, hiddenDim * hiddenContextLen * MemoryLayout<FloatType>.size)
-        // Speech decoder is currently non-stateful
-        try super.init(cacheDim: cacheDim, maxSeqLength: maxSeqLength, isStateful: false)
+
+        if codesPerStep > 1 {
+            qkMask = try MLMultiArray(
+                shape: [1, NSNumber(value: codesPerStep), NSNumber(value: maxSeqLength)],
+                dataType: .float16
+            )
+        } else {
+            qkMask = nil
+        }
+
+        // Speech decoder is non-stateful; always uses the rank-3 update mask
+        // (latency = [1, 1, maxSeqLength], throughput = [1, codesPerStep, maxSeqLength]).
+        try super.init(
+            cacheDim: cacheDim,
+            maxSeqLength: maxSeqLength,
+            codesPerStep: codesPerStep,
+            useRank3UpdateMask: true,
+            isStateful: false
+        )
+
     }
 
-    /// Update KV cache and roll hidden context left, appending new hidden state
+    /// Reset all state (KV cache, masks, hidden context buffer, qk mask).
+    /// Swift's two-phase initialization guarantees the subclass's stored properties
+    /// are set before `super.init` runs `reset()`, so it is safe to touch them here.
+    public override func reset() {
+        super.reset()
+        memset(hiddenContext.dataPointer, 0, hiddenDim * hiddenContextLen * MemoryLayout<FloatType>.size)
+        resetQkMask()
+    }
+
+    /// Zero the qk mask, then write the initial intra-step causal triangle at
+    /// `cacheLength = 0` (one row per code in the current step).
+    private func resetQkMask() {
+        guard let qkMask else { return }
+        let seqLen = maxSeqLength
+        let totalCount = qkMask.count
+        memset(qkMask.dataPointer, 0, totalCount * MemoryLayout<FloatType>.size)
+        let ptr = qkMask.dataPointer.bindMemory(to: FloatType.self, capacity: totalCount)
+        // qkMask[0, i, j] = -1e4 for i < j < codesPerStep
+        for i in 0..<codesPerStep {
+            for j in (i + 1)..<min(codesPerStep, seqLen) {
+                ptr[i * seqLen + j] = FloatType(-10000)
+            }
+        }
+    }
+
+    /// Advance the cache and incrementally update the qk mask in addition to the base
+    /// kv update / padding masks.
+    public override func update(keyCacheUpdates: MLMultiArray? = nil, valueCacheUpdates: MLMultiArray? = nil) {
+        let writePos = Int(cacheLength)
+        let seqLen = maxSeqLength
+        super.update(keyCacheUpdates: keyCacheUpdates, valueCacheUpdates: valueCacheUpdates)
+
+        guard let qkMask else { return }
+        let ptr = qkMask.dataPointer.bindMemory(to: FloatType.self, capacity: qkMask.count)
+        let oldCacheLen = writePos
+        let newCacheLen = writePos + codesPerStep
+        for i in 0..<codesPerStep {
+            // Clear old triangle for row i: columns
+            //     (oldCacheLen + i + 1 ..< oldCacheLen + codesPerStep)
+            let oldStart = oldCacheLen + i + 1
+            let oldEnd = min(oldCacheLen + codesPerStep, seqLen)
+            if oldStart < oldEnd {
+                for j in oldStart..<oldEnd {
+                    ptr[i * seqLen + j] = FloatType(0)
+                }
+            }
+            // Set new triangle for row i: columns
+            //     (newCacheLen + i + 1 ..< newCacheLen + codesPerStep)
+            let newStart = newCacheLen + i + 1
+            let newEnd = min(newCacheLen + codesPerStep, seqLen)
+            if newStart < newEnd {
+                for j in newStart..<newEnd {
+                    ptr[i * seqLen + j] = Self.maskedAttentionBias
+                }
+            }
+        }
+    }
+
+    /// Pull cache updates + hidden context update from a CoreML output feature provider,
+    /// scatter the new KV slots, and roll the hidden context buffer left by `codesPerStep`.
     public func updateWithHiddenContext(output: MLFeatureProvider) {
         guard let keyCU = output.featureValue(for: "key_cache_updates")?.multiArrayValue,
             let valCU = output.featureValue(for: "value_cache_updates")?.multiArrayValue
         else {
             return
         }
-        super.update(keyCacheUpdates: keyCU, valueCacheUpdates: valCU)
+        update(keyCacheUpdates: keyCU, valueCacheUpdates: valCU)
 
-        // Roll hidden context left and append new state
-        let hidDim = hiddenDim
-        let contextLen = hiddenContextLen
-        let hiddenContextPtr = hiddenContext.dataPointer.bindMemory(to: FloatType.self, capacity: hidDim * contextLen)
         guard let updateArr = output.featureValue(for: "hidden_context_update")?.multiArrayValue else { return }
-        let hiddenUpdatePtr = updateArr.dataPointer.bindMemory(to: FloatType.self, capacity: updateArr.count)
-        let hiddenUpdateStride = updateArr.strides[1].intValue
+        rollHiddenContext(from: updateArr)
+    }
 
-        for dim in 0..<hidDim {
-            // Shift left by one position
-            for timeStep in 0..<(contextLen - 1) {
-                hiddenContextPtr[dim * contextLen + timeStep] = hiddenContextPtr[dim * contextLen + timeStep + 1]
+    /// Roll the rolling hidden-context buffer:
+    /// `combined = concat(currentHC, newHC)` (length `hiddenContextLen + codesPerStep`);
+    /// keep the last `hiddenContextLen` columns.
+    ///
+    /// - When `codesPerStep >= hiddenContextLen`: result is the trailing
+    ///   `hiddenContextLen` columns of newHC (full overwrite).
+    /// - When `codesPerStep <  hiddenContextLen`: shift current left by
+    ///   `codesPerStep`, then append the new `codesPerStep` columns.
+    private func rollHiddenContext(from updateArr: MLMultiArray) {
+        let hcPtr = hiddenContext.dataPointer.bindMemory(
+            to: FloatType.self, capacity: hiddenDim * hiddenContextLen
+        )
+        let updatePtr = updateArr.dataPointer.bindMemory(to: FloatType.self, capacity: updateArr.count)
+        // updateArr shape: [1, hiddenDim, 1, codesPerStep] — strides along the
+        // hidden-dim axis (1) and the frame axis (3).
+        let updateHiddenStride = updateArr.strides[1].intValue
+        let updateFrameStride = updateArr.strides[3].intValue
+
+        if codesPerStep >= hiddenContextLen {
+            // Result is the last `hiddenContextLen` columns of newHC.
+            for dim in 0..<hiddenDim {
+                let dst = dim * hiddenContextLen
+                let src = dim * updateHiddenStride
+                let offset = codesPerStep - hiddenContextLen
+                for i in 0..<hiddenContextLen {
+                    hcPtr[dst + i] = updatePtr[src + (offset + i) * updateFrameStride]
+                }
             }
-            // Append new value at the end (stride-safe)
-            hiddenContextPtr[dim * contextLen + (contextLen - 1)] = hiddenUpdatePtr[dim * hiddenUpdateStride]
+        } else {
+            // Shift left by `codesPerStep`, then append `codesPerStep` new columns
+            // at the end.
+            for dim in 0..<hiddenDim {
+                let dst = dim * hiddenContextLen
+                let src = dim * updateHiddenStride
+                // Shift: current[codesPerStep..<hiddenContextLen]
+                //     -> dst[0..<hiddenContextLen - codesPerStep]
+                for t in 0..<(hiddenContextLen - codesPerStep) {
+                    hcPtr[dst + t] = hcPtr[dst + t + codesPerStep]
+                }
+                // Append the new `codesPerStep` columns
+                for i in 0..<codesPerStep {
+                    hcPtr[dst + (hiddenContextLen - codesPerStep + i)] = updatePtr[src + i * updateFrameStride]
+                }
+            }
         }
     }
 }
@@ -211,30 +429,24 @@ public class SpeechDecoderCache: KVCache, @unchecked Sendable {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public extension SpeechDecoderCache {
     var hiddenContextTensor: MLTensor { MLTensor(MLShapedArray<FloatType>(hiddenContext)) }
+    var qkMaskTensor: MLTensor? { qkMask.map { MLTensor(MLShapedArray<FloatType>($0)) } }
 
-    /// Update KV cache and rolling hidden context from `[String: MLTensor]` prediction outputs.
-    /// Materializes tensors asynchronously to avoid blocking the cooperative thread pool.
+    /// Update KV cache, qk mask, and rolling hidden context from `[String: MLTensor]`
+    /// prediction outputs. Materializes tensors asynchronously to avoid blocking the
+    /// cooperative thread pool.
     func updateWithHiddenContext(tensorOutputs: [String: MLTensor]) async {
         guard let keyUpdateTensor = tensorOutputs["key_cache_updates"],
             let valueUpdateTensor = tensorOutputs["value_cache_updates"]
         else {
             return
         }
-        await super.update(keyTensor: keyUpdateTensor, valueTensor: valueUpdateTensor)
+        let keyArr = await keyUpdateTensor.toMLMultiArray()
+        let valArr = await valueUpdateTensor.toMLMultiArray()
+        update(keyCacheUpdates: keyArr, valueCacheUpdates: valArr)
 
-        let hidDim = hiddenDim
-        let contextLen = hiddenContextLen
-        let ctxPtr = hiddenContext.dataPointer.bindMemory(to: FloatType.self, capacity: hidDim * contextLen)
         guard let hiddenUpdateTensor = tensorOutputs["hidden_context_update"] else { return }
         let updateArr = await hiddenUpdateTensor.toMLMultiArray()
-        let updatePtr = updateArr.dataPointer.bindMemory(to: FloatType.self, capacity: updateArr.count)
-        let updateStride = updateArr.strides[1].intValue
-        for dim in 0..<hidDim {
-            for t in 0..<(contextLen - 1) {
-                ctxPtr[dim * contextLen + t] = ctxPtr[dim * contextLen + t + 1]
-            }
-            ctxPtr[dim * contextLen + (contextLen - 1)] = updatePtr[dim * updateStride]
-        }
+        rollHiddenContext(from: updateArr)
     }
 }
 

--- a/Sources/TTSKit/Utilities/TTSError.swift
+++ b/Sources/TTSKit/Utilities/TTSError.swift
@@ -7,6 +7,9 @@ import Foundation
 public enum TTSError: Error, LocalizedError, Equatable {
     case emptyText
     case modelNotFound(String)
+    /// A model bundle was found but could not be loaded or introspected (e.g. a
+    /// failed `MLModel.load`, or a malformed asset missing an expected input shape).
+    case modelLoadingFailed(String)
     case generationFailed(String)
     case tokenizerUnavailable(String)
     case audioOutputFailed(String)
@@ -18,6 +21,7 @@ public enum TTSError: Error, LocalizedError, Equatable {
         switch self {
             case .emptyText: return "Input text is empty"
             case let .modelNotFound(path): return "Model directory not found: \(path)"
+            case let .modelLoadingFailed(msg): return "Model loading failed: \(msg)"
             case let .generationFailed(msg): return "Generation failed: \(msg)"
             case let .tokenizerUnavailable(msg): return "Tokenizer unavailable: \(msg)"
             case let .audioOutputFailed(msg): return "Audio output failed: \(msg)"

--- a/Tests/TTSKitTests/SpeechStreamWriterTests.swift
+++ b/Tests/TTSKitTests/SpeechStreamWriterTests.swift
@@ -1,0 +1,299 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import ArgmaxCore
+import CoreML
+@testable import TTSKit
+import XCTest
+
+/// Unit tests for `SpeechStreamWriter` — the RVQ-frame buffering / overlapped-decode /
+/// drain / partial-flush logic extracted from `Qwen3GenerateTask.runGenerationLoop`.
+/// Driven through a `MockSpeechDecoder` so no CoreML asset is required.
+final class SpeechStreamWriterTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// Deterministic `SpeechDecoding` stub. Each call returns `samplesPerFrame`
+    /// samples per input frame, valued by that frame's `code0`, so emitted audio is
+    /// traceable back to specific frames (and pad frames are identifiable).
+    private final class MockSpeechDecoder: SpeechDecoding, @unchecked Sendable {
+        let sampleRate = 24_000
+        let samplesPerFrame: Int
+        let minimumBufferDuration: TimeInterval = 0.08
+        let kvCacheEmbedDim = Qwen3TTSConstants.sdCacheDim
+        let kvCacheMaxSequenceLength = Qwen3TTSConstants.sdMaxSeq
+        let hiddenDim = Qwen3TTSConstants.sdHiddenDim
+        let hiddenContextLen = Qwen3TTSConstants.sdHiddenContextLen
+        let codesPerStep: Int
+        var model: MLModel? { nil }
+
+        let predictionTimePerCall: TimeInterval
+
+        private let lock = NSLock()
+        private var _recordedCalls: [[[Int32]]] = []
+        /// The `codes` argument of every `decodeFrameAsync` call, in completion order.
+        var recordedCalls: [[[Int32]]] { lock.withLock { _recordedCalls } }
+        var callCount: Int { recordedCalls.count }
+
+        init(samplesPerFrame: Int, codesPerStep: Int, predictionTimePerCall: TimeInterval = 0.01) {
+            self.samplesPerFrame = samplesPerFrame
+            self.codesPerStep = codesPerStep
+            self.predictionTimePerCall = predictionTimePerCall
+        }
+
+        func loadModel(at url: URL, computeUnits: MLComputeUnits, prewarmMode: Bool) async throws {}
+        func unloadModel() {}
+
+        func decodeFrame(codes: [[Int32]], cache: SpeechDecoderCache) async throws -> [Float] {
+            try await decodeFrameAsync(codes: codes, cache: cache).samples
+        }
+
+        func decodeFrameAsync(codes: [[Int32]], cache: SpeechDecoderCache) async throws -> SpeechDecoderTimedResult {
+            lock.withLock { _recordedCalls.append(codes) }
+
+            var samples: [Float] = []
+            samples.reserveCapacity(codes.count * samplesPerFrame)
+            for frame in codes {
+                let value = Float(frame.first ?? -1)
+                samples.append(contentsOf: repeatElement(value, count: samplesPerFrame))
+            }
+            var timings = SpeechTimings()
+            timings.speechDecoderPredictions = predictionTimePerCall
+            return SpeechDecoderTimedResult(samples: samples, timings: timings)
+        }
+    }
+
+    /// Records every emitted `SpeechProgress`, optionally signalling "stop" after a
+    /// given number of callbacks (to exercise callback-driven cancellation).
+    private final class ProgressRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _progresses: [SpeechProgress] = []
+        private let stopAfter: Int?
+
+        init(stopAfter: Int? = nil) { self.stopAfter = stopAfter }
+
+        var progresses: [SpeechProgress] {
+            lock.lock(); defer { lock.unlock() }
+            return _progresses
+        }
+
+        func record(_ progress: SpeechProgress) -> Bool? {
+            lock.lock(); defer { lock.unlock() }
+            _progresses.append(progress)
+            if let stopAfter, _progresses.count >= stopAfter { return false }
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// A 16-code RVQ frame whose first code (code0) is `code0`, used as the frame's
+    /// signature in `MockSpeechDecoder`'s output.
+    private func frame(_ code0: Int32) -> [Int32] {
+        [code0] + [Int32](repeating: 0, count: 15)
+    }
+
+    private func makeWriter(
+        decoder: MockSpeechDecoder,
+        recorder: ProgressRecorder,
+        baseTimings: SpeechTimings = SpeechTimings()
+    ) throws -> SpeechStreamWriter<MockSpeechDecoder> {
+        let cache = try SpeechDecoderCache(codesPerStep: decoder.codesPerStep)
+        return SpeechStreamWriter(
+            speechDecoder: decoder,
+            sdCache: cache,
+            callback: { progress in recorder.record(progress) },
+            pipelineStart: CFAbsoluteTimeGetCurrent(),
+            baseTimings: baseTimings,
+            padFrame: [Int32](repeating: Qwen3TTSConstants.codecPAD, count: 16)
+        )
+    }
+
+    /// Drive `writer` with `frames`, mimicking `runGenerationLoop`: append each frame,
+    /// stopping early if a callback asks to; then `finish()` if not stopped.
+    /// Returns whether the run completed without a callback-requested stop.
+    @discardableResult
+    private func drive(
+        _ writer: SpeechStreamWriter<MockSpeechDecoder>,
+        frames: [[Int32]],
+        timings: inout SpeechTimings
+    ) async throws -> Bool {
+        for frame in frames {
+            let stepStart = CFAbsoluteTimeGetCurrent()
+            if try await writer.append(frame, stepStart: stepStart, loopTimings: &timings) == false {
+                return false
+            }
+        }
+        try await writer.finish(loopTimings: &timings)
+        return true
+    }
+
+    // MARK: - Latency mode (codesPerStep == 1)
+
+    func testLatencyModeEmitsOneBufferPerFrame() async throws {
+        let spf = 2
+        let decoder = MockSpeechDecoder(samplesPerFrame: spf, codesPerStep: 1)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        let frames = (1...5).map { frame(Int32($0)) }
+        let completed = try await drive(writer, frames: frames, timings: &timings)
+
+        XCTAssertTrue(completed)
+        XCTAssertEqual(decoder.callCount, 5, "One decode call per frame in latency mode")
+        XCTAssertEqual(recorder.progresses.count, 5, "One callback per buffer")
+        // Audio is each frame's code0 repeated `spf` times, in order, no padding.
+        XCTAssertEqual(writer.collectedAudio, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5])
+    }
+
+    // MARK: - Throughput mode (codesPerStep > 1)
+
+    func testThroughputModeFullBuffers() async throws {
+        let spf = 2
+        let decoder = MockSpeechDecoder(samplesPerFrame: spf, codesPerStep: 4)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        let frames = (1...8).map { frame(Int32($0)) }
+        try await drive(writer, frames: frames, timings: &timings)
+
+        XCTAssertEqual(decoder.callCount, 2, "8 frames / 4 per step = 2 decode calls")
+        XCTAssertEqual(recorder.progresses.count, 2)
+        XCTAssertEqual(writer.collectedAudio, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8])
+    }
+
+    func testThroughputModePartialBufferPadsAndTrims() async throws {
+        let spf = 2
+        let decoder = MockSpeechDecoder(samplesPerFrame: spf, codesPerStep: 4)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        // 6 frames: one full buffer (f1..f4) + a partial buffer (f5, f6) padded to 4.
+        let frames = (1...6).map { frame(Int32($0)) }
+        try await drive(writer, frames: frames, timings: &timings)
+
+        XCTAssertEqual(decoder.callCount, 2, "One full flush + one partial flush")
+        XCTAssertEqual(recorder.progresses.count, 2)
+        // The 2 pad frames' worth of trailing samples (2 frames × spf = 4 samples) are
+        // trimmed, leaving exactly the 6 real frames' audio.
+        XCTAssertEqual(writer.collectedAudio, [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])
+        XCTAssertEqual(writer.collectedAudio.count, 6 * spf)
+        // No pad-derived samples leaked into the output.
+        XCTAssertFalse(writer.collectedAudio.contains(Float(Qwen3TTSConstants.codecPAD)))
+    }
+
+    func testPartialOnlyBufferIsPaddedAndTrimmed() async throws {
+        let spf = 3
+        let decoder = MockSpeechDecoder(samplesPerFrame: spf, codesPerStep: 4)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        // Fewer than codesPerStep frames: only the final partial flush runs.
+        let frames = [frame(7), frame(9)]
+        try await drive(writer, frames: frames, timings: &timings)
+
+        XCTAssertEqual(decoder.callCount, 1)
+        XCTAssertEqual(recorder.progresses.count, 1)
+        XCTAssertEqual(writer.collectedAudio, [7, 7, 7, 9, 9, 9])
+    }
+
+    // MARK: - Ordering, timings, first-buffer semantics
+
+    func testDecodeCallOrderMatchesFrameOrder() async throws {
+        let decoder = MockSpeechDecoder(samplesPerFrame: 1, codesPerStep: 1)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        let frames = (1...4).map { frame(Int32($0)) }
+        try await drive(writer, frames: frames, timings: &timings)
+
+        // Even though decodes after the first run on overlapped tasks, each is drained
+        // before the next is submitted, so completion order matches frame order.
+        let firstCodes = decoder.recordedCalls.map { $0.first?.first }
+        XCTAssertEqual(firstCodes, [1, 2, 3, 4])
+    }
+
+    func testFirstBufferCarriesStepTimeAndTTFB() async throws {
+        let decoder = MockSpeechDecoder(samplesPerFrame: 1, codesPerStep: 1)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        try await drive(writer, frames: (1...3).map { frame(Int32($0)) }, timings: &timings)
+
+        let progresses = recorder.progresses
+        XCTAssertEqual(progresses.count, 3)
+        XCTAssertNotNil(progresses.first?.stepTime, "First buffer carries stepTime for adaptive buffering")
+        XCTAssertTrue(progresses.dropFirst().allSatisfy { $0.stepTime == nil },
+                      "Only the first buffer carries stepTime")
+        XCTAssertGreaterThan(timings.timeToFirstBuffer, 0, "TTFB recorded on first buffer")
+        XCTAssertTrue(writer.hasEmittedFirstBuffer)
+    }
+
+    func testTimingsAccumulatedAcrossDecodes() async throws {
+        let predictionTime: TimeInterval = 0.01
+        let decoder = MockSpeechDecoder(samplesPerFrame: 1, codesPerStep: 1, predictionTimePerCall: predictionTime)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        try await drive(writer, frames: (1...5).map { frame(Int32($0)) }, timings: &timings)
+
+        XCTAssertEqual(timings.totalSpeechDecoderInvocations, 5, accuracy: 0.0001)
+        XCTAssertEqual(timings.speechDecoderPredictions, 5 * predictionTime, accuracy: 1e-9)
+        XCTAssertEqual(timings.speechDecoder, 5 * predictionTime, accuracy: 1e-9)
+    }
+
+    // MARK: - Callback-driven cancellation
+
+    func testCallbackStopHaltsStreaming() async throws {
+        let spf = 2
+        let decoder = MockSpeechDecoder(samplesPerFrame: spf, codesPerStep: 1)
+        let recorder = ProgressRecorder(stopAfter: 2) // stop after the 2nd buffer
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        let frames = (1...6).map { frame(Int32($0)) }
+        let completed = try await drive(writer, frames: frames, timings: &timings)
+
+        XCTAssertFalse(completed, "drive() should report an early callback stop")
+        XCTAssertEqual(recorder.progresses.count, 2, "No further callbacks after stop")
+        // Buffer 1 (sync) emits during frame 1; buffer 2 emits while draining during a
+        // later frame and returns stop, so only those two buffers' audio is collected.
+        XCTAssertEqual(writer.collectedAudio, [1, 1, 2, 2])
+    }
+
+    // MARK: - Edge cases
+
+    func testNoFramesProducesNoAudioOrCalls() async throws {
+        let decoder = MockSpeechDecoder(samplesPerFrame: 2, codesPerStep: 4)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        try await drive(writer, frames: [], timings: &timings)
+
+        XCTAssertEqual(decoder.callCount, 0)
+        XCTAssertTrue(recorder.progresses.isEmpty)
+        XCTAssertTrue(writer.collectedAudio.isEmpty)
+        XCTAssertFalse(writer.hasEmittedFirstBuffer)
+    }
+
+    func testCancelPendingDecodeIsSafe() async throws {
+        let decoder = MockSpeechDecoder(samplesPerFrame: 1, codesPerStep: 1)
+        let recorder = ProgressRecorder()
+        let writer = try makeWriter(decoder: decoder, recorder: recorder)
+
+        var timings = SpeechTimings()
+        // Submit a few frames (leaves an overlapped decode pending), then cancel without
+        // finishing — must not crash or emit further callbacks.
+        _ = try await writer.append(frame(1), stepStart: CFAbsoluteTimeGetCurrent(), loopTimings: &timings)
+        _ = try await writer.append(frame(2), stepStart: CFAbsoluteTimeGetCurrent(), loopTimings: &timings)
+        writer.cancelPendingDecode()
+    }
+}

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -206,12 +206,26 @@ final class TTSKitUnitTests: XCTestCase {
 
     func testKVCacheIsFull() throws {
         let cache = try KVCache(cacheDim: 4, maxSeqLength: 4)
-        // maxSeqLength=4, isFull when cacheLength >= 3 (maxSeqLength - 1)
+        // codesPerStep == 1 (default): isFull when cacheLength >= maxSeqLength - 1 == 3.
         cache.update()
         cache.update()
         XCTAssertFalse(cache.isFull)
         cache.update()
         XCTAssertTrue(cache.isFull)
+    }
+
+    func testKVCacheIsFullThroughput() throws {
+        // codesPerStep=4: isFull reserves a full write, flipping at maxSeqLength - codesPerStep (12).
+        let cache = try KVCache(
+            cacheDim: 4, maxSeqLength: 16, codesPerStep: 4, useRank3UpdateMask: true
+        )
+        cache.update() // cacheLength 0 -> 4
+        cache.update() // 4 -> 8
+        XCTAssertFalse(cache.isFull)
+        XCTAssertEqual(cache.freePositions, 4) // 16 - 4 - 8
+        cache.update() // 8 -> 12
+        XCTAssertTrue(cache.isFull)
+        XCTAssertEqual(cache.freePositions, 0) // 16 - 4 - 12
     }
 
     func testKVCacheReset() throws {
@@ -231,6 +245,265 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(cache.hiddenDim, 32)
         XCTAssertEqual(cache.hiddenContextLen, 4)
         XCTAssertEqual(cache.hiddenContext.shape, [1, 32, 1, 4] as [NSNumber])
+        // Latency function default (N=1): rank-3 kvCacheUpdateMask, no qkMask.
+        XCTAssertEqual(cache.kvCacheUpdateMask.shape, [1, 1, 16] as [NSNumber])
+        XCTAssertNil(cache.qkMask)
+    }
+
+    func testSpeechDecoderCacheThroughputMaskShapes() throws {
+        let cache = try SpeechDecoderCache(
+            cacheDim: 64, maxSeqLength: 16, hiddenDim: 32, hiddenContextLen: 1, codesPerStep: 4
+        )
+        XCTAssertEqual(cache.codesPerStep, 4)
+        XCTAssertEqual(cache.kvCacheUpdateMask.shape, [1, 4, 16] as [NSNumber])
+        XCTAssertNotNil(cache.qkMask)
+        XCTAssertEqual(cache.qkMask?.shape, [1, 4, 16] as [NSNumber])
+    }
+
+    func testSpeechDecoderCacheInitialMasksLatency() throws {
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: 8, hiddenDim: 4, hiddenContextLen: 4, codesPerStep: 1
+        )
+        let update = cache.kvCacheUpdateMask
+        let updatePtr = update.dataPointer.bindMemory(to: FloatType.self, capacity: update.count)
+        // [1, 1, 8] — only [0, 0, 0] = 1
+        XCTAssertEqual(Float(updatePtr[0]), 1.0, accuracy: 0.001)
+        for j in 1..<8 {
+            XCTAssertEqual(Float(updatePtr[j]), 0.0, accuracy: 0.001)
+        }
+        let pad = cache.keyPaddingMask
+        let padPtr = pad.dataPointer.bindMemory(to: FloatType.self, capacity: pad.count)
+        XCTAssertEqual(Float(padPtr[0]), 0.0, accuracy: 0.001)
+        for j in 1..<8 {
+            XCTAssertEqual(Float(padPtr[j]), -10000.0, accuracy: 0.001)
+        }
+    }
+
+    func testSpeechDecoderCacheInitialMasksThroughput() throws {
+        let codesPerStep = 4
+        let maxSeqLength = 16
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: maxSeqLength, hiddenDim: 4, hiddenContextLen: 1, codesPerStep: codesPerStep
+        )
+        // kvCacheUpdateMask[0, i, i] = 1 for i in 0..<codesPerStep, else 0.
+        let update = cache.kvCacheUpdateMask
+        let updatePtr = update.dataPointer.bindMemory(to: FloatType.self, capacity: update.count)
+        for i in 0..<codesPerStep {
+            for j in 0..<maxSeqLength {
+                let expected: Float = (j == i) ? 1.0 : 0.0
+                XCTAssertEqual(Float(updatePtr[i * maxSeqLength + j]), expected, accuracy: 0.001,
+                               "kvCacheUpdateMask[0,\(i),\(j)]")
+            }
+        }
+        // qkMask[0, i, j] = -10000 for i < j < codesPerStep, else 0.
+        let qk = try XCTUnwrap(cache.qkMask)
+        let qkPtr = qk.dataPointer.bindMemory(to: FloatType.self, capacity: qk.count)
+        for i in 0..<codesPerStep {
+            for j in 0..<maxSeqLength {
+                let expected: Float = (i < j && j < codesPerStep) ? -10000.0 : 0.0
+                XCTAssertEqual(Float(qkPtr[i * maxSeqLength + j]), expected, accuracy: 0.001,
+                               "qkMask[0,\(i),\(j)]")
+            }
+        }
+        // keyPaddingMask: 0 for [0, codesPerStep), -10000 after.
+        let pad = cache.keyPaddingMask
+        let padPtr = pad.dataPointer.bindMemory(to: FloatType.self, capacity: pad.count)
+        for j in 0..<maxSeqLength {
+            let expected: Float = (j < codesPerStep) ? 0.0 : -10000.0
+            XCTAssertEqual(Float(padPtr[j]), expected, accuracy: 0.001, "keyPaddingMask[\(j)]")
+        }
+    }
+
+    func testSpeechDecoderCacheUpdateShiftsMasksThroughput() throws {
+        // Advance once with codesPerStep=4 and confirm masks shift to the next block.
+        let codesPerStep = 4
+        let maxSeqLength = 16
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: maxSeqLength, hiddenDim: 4, hiddenContextLen: 1, codesPerStep: codesPerStep
+        )
+        // The update call needs keyCacheUpdates/valueCacheUpdates of shape [1, 4, 1, codesPerStep];
+        // populating with zeros is fine because the test only inspects the masks.
+        let keyUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        let valueUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        memset(keyUpdates.dataPointer, 0, keyUpdates.count * MemoryLayout<FloatType>.size)
+        memset(valueUpdates.dataPointer, 0, valueUpdates.count * MemoryLayout<FloatType>.size)
+
+        cache.update(keyCacheUpdates: keyUpdates, valueCacheUpdates: valueUpdates)
+        XCTAssertEqual(cache.cacheLength, Int32(codesPerStep))
+
+        // kvCacheUpdateMask now has 1s at [0, i, codesPerStep + i] for i in 0..<codesPerStep.
+        let update = cache.kvCacheUpdateMask
+        let updatePtr = update.dataPointer.bindMemory(to: FloatType.self, capacity: update.count)
+        for i in 0..<codesPerStep {
+            for j in 0..<maxSeqLength {
+                let expected: Float = (j == codesPerStep + i) ? 1.0 : 0.0
+                XCTAssertEqual(Float(updatePtr[i * maxSeqLength + j]), expected, accuracy: 0.001,
+                               "post-update kvCacheUpdateMask[0,\(i),\(j)]")
+            }
+        }
+        // qkMask now has -10000 at columns (codesPerStep + i + 1, 2*codesPerStep) for each row i.
+        let qk = try XCTUnwrap(cache.qkMask)
+        let qkPtr = qk.dataPointer.bindMemory(to: FloatType.self, capacity: qk.count)
+        for i in 0..<codesPerStep {
+            for j in 0..<maxSeqLength {
+                let inNewTriangle = (j > codesPerStep + i) && (j < 2 * codesPerStep)
+                let expected: Float = inNewTriangle ? -10000.0 : 0.0
+                XCTAssertEqual(Float(qkPtr[i * maxSeqLength + j]), expected, accuracy: 0.001,
+                               "post-update qkMask[0,\(i),\(j)]")
+            }
+        }
+        // keyPaddingMask unmasked region extends to [0, 2N).
+        let pad = cache.keyPaddingMask
+        let padPtr = pad.dataPointer.bindMemory(to: FloatType.self, capacity: pad.count)
+        for j in 0..<maxSeqLength {
+            let expected: Float = (j < 2 * codesPerStep) ? 0.0 : -10000.0
+            XCTAssertEqual(Float(padPtr[j]), expected, accuracy: 0.001,
+                           "post-update keyPaddingMask[\(j)]")
+        }
+    }
+
+    func testKVCacheUpdateScattersNPositions() throws {
+        // Drive a non-stateful KVCache with codesPerStep=4 and verify the codesPerStep new
+        // K/V slots land at positions [cacheLength, cacheLength + codesPerStep).
+        let codesPerStep = 4
+        let maxSeqLength = 16
+        let cacheDim = 3
+        let cache = try KVCache(
+            cacheDim: cacheDim, maxSeqLength: maxSeqLength, codesPerStep: codesPerStep, useRank3UpdateMask: true
+        )
+        // Seed update tensors with distinct values per (dim, i).
+        let keyUpdates = try MLMultiArray(shape: [1, NSNumber(value: cacheDim), 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        let valueUpdates = try MLMultiArray(shape: [1, NSNumber(value: cacheDim), 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        let keyUpdatePtr = keyUpdates.dataPointer.bindMemory(to: FloatType.self, capacity: keyUpdates.count)
+        let valueUpdatePtr = valueUpdates.dataPointer.bindMemory(to: FloatType.self, capacity: valueUpdates.count)
+        for dim in 0..<cacheDim {
+            for i in 0..<codesPerStep {
+                keyUpdatePtr[dim * codesPerStep + i] = FloatType(Float(dim) + Float(i) * 0.1)
+                valueUpdatePtr[dim * codesPerStep + i] = FloatType(Float(dim) * 10 + Float(i))
+            }
+        }
+        cache.update(keyCacheUpdates: keyUpdates, valueCacheUpdates: valueUpdates)
+        XCTAssertEqual(cache.cacheLength, Int32(codesPerStep))
+
+        let keyCache = try XCTUnwrap(cache.keyCache)
+        let valueCache = try XCTUnwrap(cache.valueCache)
+        let keyCachePtr = keyCache.dataPointer.bindMemory(to: FloatType.self, capacity: cacheDim * maxSeqLength)
+        let valueCachePtr = valueCache.dataPointer.bindMemory(to: FloatType.self, capacity: cacheDim * maxSeqLength)
+        for dim in 0..<cacheDim {
+            for i in 0..<codesPerStep {
+                let expectedKey = Float(dim) + Float(i) * 0.1
+                let expectedValue = Float(dim) * 10 + Float(i)
+                XCTAssertEqual(Float(keyCachePtr[dim * maxSeqLength + i]), expectedKey, accuracy: 0.01,
+                               "keyCache[\(dim), \(i)]")
+                XCTAssertEqual(Float(valueCachePtr[dim * maxSeqLength + i]), expectedValue, accuracy: 0.01,
+                               "valueCache[\(dim), \(i)]")
+            }
+            // Positions past codesPerStep must still be zero.
+            for j in codesPerStep..<maxSeqLength {
+                XCTAssertEqual(Float(keyCachePtr[dim * maxSeqLength + j]), 0.0, accuracy: 0.001)
+                XCTAssertEqual(Float(valueCachePtr[dim * maxSeqLength + j]), 0.0, accuracy: 0.001)
+            }
+        }
+    }
+
+    func testHiddenContextRollN1M4() throws {
+        // codesPerStep=1 (latency), hiddenContextLen=4: one-step left shift, append new column.
+        let codesPerStep = 1
+        let hiddenContextLen = 4
+        let hiddenDim = 2
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: 16, hiddenDim: hiddenDim, hiddenContextLen: hiddenContextLen, codesPerStep: codesPerStep
+        )
+        // Pre-load the hidden buffer with known values.
+        let hiddenPtr = cache.hiddenContext.dataPointer.bindMemory(
+            to: FloatType.self, capacity: hiddenDim * hiddenContextLen
+        )
+        for dim in 0..<hiddenDim {
+            for t in 0..<hiddenContextLen { hiddenPtr[dim * hiddenContextLen + t] = FloatType(Float(dim) * 10 + Float(t)) }
+        }
+        // Build a synthetic hidden_context_update of shape [1, hiddenDim, 1, codesPerStep].
+        let updateArr = try MLMultiArray(
+            shape: [1, NSNumber(value: hiddenDim), 1, NSNumber(value: codesPerStep)], dataType: .float16
+        )
+        let updatePtr = updateArr.dataPointer.bindMemory(to: FloatType.self, capacity: updateArr.count)
+        for dim in 0..<hiddenDim {
+            updatePtr[dim * codesPerStep] = FloatType(99.0 + Float(dim))
+        }
+        // Synthesize a FeatureProvider that returns empty KV updates + this hidden update.
+        let keyUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        let valueUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        memset(keyUpdates.dataPointer, 0, keyUpdates.count * MemoryLayout<FloatType>.size)
+        memset(valueUpdates.dataPointer, 0, valueUpdates.count * MemoryLayout<FloatType>.size)
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            "key_cache_updates": MLFeatureValue(multiArray: keyUpdates),
+            "value_cache_updates": MLFeatureValue(multiArray: valueUpdates),
+            "hidden_context_update": MLFeatureValue(multiArray: updateArr)
+        ])
+        cache.updateWithHiddenContext(output: provider)
+
+        // Expected: each row shifted left by 1, new value at position hiddenContextLen-1.
+        for dim in 0..<hiddenDim {
+            // Old positions 1, 2, 3 -> 0, 1, 2.
+            XCTAssertEqual(Float(hiddenPtr[dim * hiddenContextLen + 0]), Float(dim) * 10 + 1.0, accuracy: 0.01)
+            XCTAssertEqual(Float(hiddenPtr[dim * hiddenContextLen + 1]), Float(dim) * 10 + 2.0, accuracy: 0.01)
+            XCTAssertEqual(Float(hiddenPtr[dim * hiddenContextLen + 2]), Float(dim) * 10 + 3.0, accuracy: 0.01)
+            // New column appended.
+            XCTAssertEqual(Float(hiddenPtr[dim * hiddenContextLen + 3]), 99.0 + Float(dim), accuracy: 0.01)
+        }
+    }
+
+    func testHiddenContextRollN4M1() throws {
+        // codesPerStep=4 (throughput), hiddenContextLen=1: keep only the last new column.
+        let codesPerStep = 4
+        let hiddenContextLen = 1
+        let hiddenDim = 2
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: 16, hiddenDim: hiddenDim, hiddenContextLen: hiddenContextLen, codesPerStep: codesPerStep
+        )
+        let updateArr = try MLMultiArray(
+            shape: [1, NSNumber(value: hiddenDim), 1, NSNumber(value: codesPerStep)], dataType: .float16
+        )
+        let updatePtr = updateArr.dataPointer.bindMemory(to: FloatType.self, capacity: updateArr.count)
+        for dim in 0..<hiddenDim {
+            for i in 0..<codesPerStep { updatePtr[dim * codesPerStep + i] = FloatType(Float(dim) * 10 + Float(i)) }
+        }
+        let keyUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        let valueUpdates = try MLMultiArray(shape: [1, 4, 1, NSNumber(value: codesPerStep)], dataType: .float16)
+        memset(keyUpdates.dataPointer, 0, keyUpdates.count * MemoryLayout<FloatType>.size)
+        memset(valueUpdates.dataPointer, 0, valueUpdates.count * MemoryLayout<FloatType>.size)
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            "key_cache_updates": MLFeatureValue(multiArray: keyUpdates),
+            "value_cache_updates": MLFeatureValue(multiArray: valueUpdates),
+            "hidden_context_update": MLFeatureValue(multiArray: updateArr)
+        ])
+        cache.updateWithHiddenContext(output: provider)
+
+        let hiddenPtr = cache.hiddenContext.dataPointer.bindMemory(
+            to: FloatType.self, capacity: hiddenDim * hiddenContextLen
+        )
+        for dim in 0..<hiddenDim {
+            // Only the last column (i=codesPerStep-1=3) is retained.
+            XCTAssertEqual(Float(hiddenPtr[dim * hiddenContextLen + 0]), Float(dim) * 10 + Float(codesPerStep - 1), accuracy: 0.01)
+        }
+    }
+
+    // MARK: - SpeechDecoder mode enum
+
+    func testSpeechDecoderModeFunctionNames() {
+        XCTAssertEqual(Qwen3SpeechDecoderMode.latencyOptimized.functionName, "latency")
+        XCTAssertEqual(Qwen3SpeechDecoderMode.throughputOptimized.functionName, "throughput")
+    }
+
+    func testSpeechDecoderModeDefaults() {
+        let decoder = Qwen3SpeechDecoder()
+        XCTAssertEqual(decoder.mode, .latencyOptimized)
+        XCTAssertEqual(decoder.codesPerStep, 1)
+    }
+
+    func testTTSKitConfigSpeechDecoderDefaults() {
+        let config = TTSKitConfig()
+        XCTAssertEqual(config.speechDecoderMode, .latencyOptimized)
+        XCTAssertEqual(config.speechDecoderVariant, "W8A16-multifunction")
     }
 
     // MARK: - Sampler
@@ -584,21 +857,21 @@ final class TTSKitUnitTests: XCTestCase {
     // MARK: - PlaybackStrategy
 
     func testAudioPerStep() {
-        let spf = Qwen3TTSConstants.samplesPerFrame
-        let sr = Qwen3TTSConstants.sampleRate
-        let expected = Double(spf) / Double(sr)
-        XCTAssertEqual(PlaybackStrategy.audioPerStep(samplesPerFrame: spf, sampleRate: sr), expected, accuracy: 0.0001)
+        let samplesPerFrame = Qwen3TTSConstants.samplesPerFrame
+        let sampleRate = Qwen3TTSConstants.sampleRate
+        let expected = Double(samplesPerFrame) / Double(sampleRate)
+        XCTAssertEqual(PlaybackStrategy.audioPerStep(samplesPerFrame: samplesPerFrame, sampleRate: sampleRate), expected, accuracy: 0.0001)
         // ~80ms per frame at 24kHz / 1920 samples
-        XCTAssertEqual(PlaybackStrategy.audioPerStep(samplesPerFrame: spf, sampleRate: sr), 0.08, accuracy: 0.001)
+        XCTAssertEqual(PlaybackStrategy.audioPerStep(samplesPerFrame: samplesPerFrame, sampleRate: sampleRate), 0.08, accuracy: 0.001)
     }
 
     func testRequiredBufferFastDevice() {
         // Step completes in half the frame duration -> device is 2x real-time
         // deficit = max(0, 1 - 2.0) = 0, so result = minimumBufferDuration
-        let spf = Qwen3TTSConstants.samplesPerFrame
-        let sr = Qwen3TTSConstants.sampleRate
-        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: spf, sampleRate: sr) / 2.0
-        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 100, samplesPerFrame: spf, sampleRate: sr)
+        let samplesPerFrame = Qwen3TTSConstants.samplesPerFrame
+        let sampleRate = Qwen3TTSConstants.sampleRate
+        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: samplesPerFrame, sampleRate: sampleRate) / 2.0
+        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 100, samplesPerFrame: samplesPerFrame, sampleRate: sampleRate)
         XCTAssertEqual(buffer, PlaybackStrategy.minimumBufferDuration, accuracy: 0.001)
     }
 
@@ -606,10 +879,10 @@ final class TTSKitUnitTests: XCTestCase {
         // Step takes 2x the frame duration -> device is at 0.5x real-time
         // speedRatio = 0.5, deficit = 0.5, maxAudio = 100 * 0.08 = 8s
         // deficitBuffer = 8 * 0.5 = 4s > minimumBufferDuration
-        let spf = Qwen3TTSConstants.samplesPerFrame
-        let sr = Qwen3TTSConstants.sampleRate
-        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: spf, sampleRate: sr) * 2.0
-        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 100, samplesPerFrame: spf, sampleRate: sr)
+        let samplesPerFrame = Qwen3TTSConstants.samplesPerFrame
+        let sampleRate = Qwen3TTSConstants.sampleRate
+        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: samplesPerFrame, sampleRate: sampleRate) * 2.0
+        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 100, samplesPerFrame: samplesPerFrame, sampleRate: sampleRate)
         XCTAssertGreaterThan(buffer, PlaybackStrategy.minimumBufferDuration)
         // Exact: 100 * 0.08 * 0.5 = 4.0s
         XCTAssertEqual(buffer, 4.0, accuracy: 0.01)
@@ -617,10 +890,10 @@ final class TTSKitUnitTests: XCTestCase {
 
     func testRequiredBufferAtExactRealTime() {
         // Step equals frame duration -> speedRatio = 1, deficit = 0 -> minimum clamp applies
-        let spf = Qwen3TTSConstants.samplesPerFrame
-        let sr = Qwen3TTSConstants.sampleRate
-        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: spf, sampleRate: sr)
-        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 50, samplesPerFrame: spf, sampleRate: sr)
+        let samplesPerFrame = Qwen3TTSConstants.samplesPerFrame
+        let sampleRate = Qwen3TTSConstants.sampleRate
+        let stepTime = PlaybackStrategy.audioPerStep(samplesPerFrame: samplesPerFrame, sampleRate: sampleRate)
+        let buffer = PlaybackStrategy.requiredBuffer(stepTime: stepTime, maxNewTokens: 50, samplesPerFrame: samplesPerFrame, sampleRate: sampleRate)
         XCTAssertEqual(buffer, PlaybackStrategy.minimumBufferDuration, accuracy: 0.001)
     }
 


### PR DESCRIPTION
## Summary

TTSKit's Qwen3-TTS SpeechDecoder now uses an optimized, **multifunction** Core ML asset that bundles two graphs in one bundle and lets you trade time-to-first-audio against throughput:

| Mode | Frames / call | Audio / call | Best for |
|---|---|---|---|
| `.latencyOptimized` (default) | 1 | ~80 ms | Lowest TTFB — streaming UX |
| `.throughputOptimized` | 4 | ~320 ms | Faster overall on longer clips |

The default `.latencyOptimized` path produces the same audio as before, just faster. `.throughputOptimized` batches four frames per call to amortize decoder cost, at the cost of a larger first buffer. The new asset ships on the public [`argmaxinc/ttskit-coreml`](https://huggingface.co/argmaxinc/ttskit-coreml) repo and is picked up by default — no token or repo override needed.

## What's new

- **`Qwen3SpeechDecoderMode`** (`.latencyOptimized` / `.throughputOptimized`), selectable via `TTSKitConfig.speechDecoderMode` (default `.latencyOptimized`).
- **CLI:** `argmax-cli tts --speech-decoder-mode latencyOptimized|throughputOptimized`.
- **Example app:** a Latency / Throughput picker in the sidebar (flipping it reloads the model), plus a waveform fix so throughput-mode playback renders at the right length.
- **Internals:** `KVCache` / `SpeechDecoderCache` are generalized to handle the asset's batched I/O; the number of frames per call is read from the loaded model, so future re-tunings need no code changes.

## Usage

```swift
// Default: latency-optimized (lowest time-to-first-audio)
let tts = try await TTSKit()

// Opt into throughput-optimized generation
let config = TTSKitConfig(speechDecoderMode: .throughputOptimized)
let throughputTTS = try await TTSKit(config)
```

```bash
swift run -c release argmax-cli tts \
  --text "The old café on the corner still smelled like rain and roasted coffee." \
  --speech-decoder-mode throughputOptimized --play
```

## Performance

Apple M4, single chunk, default compute units. `prod` is the previous (`W8A16`) asset on `main`.

| Text | Variant | Inference | TTFB | SD / step | Speed |
|---|---|---|---|---|---|
| short | prod | 2.68 s | 0.11 s | 21.5 ms | 1.13× |
|  | latencyOptimized | 2.56 s | 0.12 s | 7.8 ms | 1.19× |
|  | **throughputOptimized** | **2.30 s** | 0.28 s | **2.2 ms** | **1.32×** |
| medium | prod | 8.64 s | 0.10 s | 23.8 ms | 1.05× |
|  | latencyOptimized | 7.60 s | 0.10 s | 7.8 ms | 1.19× |
|  | **throughputOptimized** | **6.80 s** | 0.28 s | **2.0 ms** | **1.33×** |
| long | prod | 17.59 s | 0.10 s | 22.5 ms | 1.11× |
|  | latencyOptimized | 16.59 s | 0.12 s | 7.8 ms | 1.18× |
|  | **throughputOptimized** | **14.85 s** | 0.32 s | **2.0 ms** | **1.32×** |

- The new asset cuts per-step SpeechDecoder cost ~3× with no TTFB regression.
- `throughputOptimized` adds another ~4× amortization (~11× total vs. the previous asset), trading ~3× higher TTFB.

## Requirements

The multifunction asset requires **iOS 18 / macOS 15** (gated behind `#available`, the same floor TTSKit already targets).

## Breaking changes

- `SpeechDecoding.decodeFrame{Async}` parameter type changes from `codes: [Int32]` to `codes: [[Int32]]` — external conformers must update.
- The default speech-decoder variant changes from `W8A16` to `W8A16-multifunction`. Callers that explicitly pin `speechDecoderVariant: "W8A16"` should remove the override to pick up the new default; the legacy asset is no longer loadable by this SDK version (older SDK releases pinned to it keep working).

---------

Co-authored-by: @EduardoPach 