### PR TITLE
fix(TextDecoder): don't early-exit the decode loop on predictions sampled during promptTokens prefill

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -570,12 +570,25 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         let windowUUID = UUID()
         await earlyStopActor.set(false, for: windowUUID)
 
+        // With `promptTokens`, the initial prompt is
+        // `[<|startofprev|>, ...prompt..., <|sot|>, ...]` and every one of those
+        // tokens is force-fed through the loop below. The model's sampled
+        // predictions at those positions are placeholders (the forced token wins),
+        // so they must not drive the early-exit checks: a mid-prompt EOT
+        // prediction would otherwise end the segment before any audio token is
+        // decoded, returning an empty transcript. The first REAL prediction is
+        // the one sampled at the last prefill index. The no-prompt path keeps its
+        // existing behavior (checks from `prefilledIndex`) untouched.
+        let hasPromptTokens = !(options.promptTokens?.isEmpty ?? true)
+        let firstSampledIndex = hasPromptTokens ? max(prefilledIndex, initialPromptIndex - 1) : prefilledIndex
+
         for tokenIndex in prefilledIndex..<loopCount {
             let loopStart = Date()
 
             let isPrefill = tokenIndex < initialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
             let isLastPrefillToken = tokenIndex == initialPromptIndex - 1
-            let isFirstToken = tokenIndex == prefilledIndex
+            let isFirstToken = tokenIndex == firstSampledIndex
+            let ignoresSampledPrediction = hasPromptTokens && isPrefill
 
             // Check if current index is part of the initial prompt
             if tokenIndex < initialPromptIndex {
@@ -666,7 +679,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                     false
                 }
             let isSegmentCompleted =
-                sampleResult.completed ||
+                (sampleResult.completed && !ignoresSampledPrediction) ||
                 currentTokens.count >= Constants.maxTokenContext - 1 ||
                 isFirstTokenLogProbTooLow
 


### PR DESCRIPTION
## Problem

Fixes #372.

With `DecodingOptions.promptTokens`, the initial prompt becomes `[<|startofprev|>, ...prompt..., <|startoftranscript|>, ...]` and `decodeText` force-feeds every one of those tokens through the main loop. The model's sampled prediction at each forced step is discarded (the forced token wins), but it still drives the early-exit checks:

1. If the model's top prediction at **any mid-prompt position** is `<|endoftext|>`, `sampleResult.completed` ends the segment before a single audio token is decoded → **empty transcript**.
2. `isFirstToken` points at `prefilledIndex` (the `<|startofprev|>` step), so `firstTokenLogProbThreshold` is evaluated against a forced-prompt placeholder prediction instead of the first real token — this is the spurious `Fallback #1 (firstTokenLogProbThreshold)` reported in #372.

Whether a model predicts EOT at those positions is model-dependent, which is why `large-v3-v20240930_turbo` and `base.en` reproduce while `base` appears fine — but the checks shouldn't be consulting forced-prefill predictions on any model. The reference implementation feeds the prompt without sampling checks and only starts them at `sample_begin`.

## Fix

When `promptTokens` are present, ignore `sampleResult.completed` during prefill steps and evaluate the first-token check at the first genuinely sampled position (the last prefill index). The no-prompt path is untouched — checks keep their existing indices, so default behavior is unchanged.

## Verification

Standalone harness against the real `openai_whisper-large-v3-v20240930_turbo_632MB` CoreML model on recordings that reproduced the empty decode:

| case | before | after |
|---|---|---|
| no prompt | ok | ok (unchanged) |
| 19-token prompt (stripped to content tokens) | **empty** | ok |
| single content token | **empty** (2/3 clips) | ok |

With the fix, the prompt also demonstrably conditions the output (a punctuated prompt yields punctuated transcripts), i.e. the channel now works as intended rather than merely not crashing.