### PR TITLE
Fix decode loop aborting on EOT sampled during prompt prefill

### DIFF
--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -665,8 +665,13 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 } else {
                     false
                 }
+            // A sampled EOT during the forced prompt prefill is a throwaway
+            // prediction (the next token is forced regardless) — completing the
+            // segment on it would end decoding before any content token is
+            // produced, yielding an empty transcription whenever promptTokens
+            // are set. Only honor EOT once prefill has been fully consumed.
             let isSegmentCompleted =
-                sampleResult.completed ||
+                (sampleResult.completed && !isPrefill) ||
                 currentTokens.count >= Constants.maxTokenContext - 1 ||
                 isFirstTokenLogProbTooLow
 


### PR DESCRIPTION
Fixes #501.

When `DecodingOptions.promptTokens` is set, the decode loop force-feeds the prompt one token per step, and the token sampled at each of those steps is discarded on the next iteration. The completion check still honored a sampled `<|endoftext|>` during that forced prefill. With `large-v3 turbo` the model reliably samples EOT while the SOT sequence is being forced, so the loop broke before decoding any content token, and every transcription with a prompt came back as an empty segment with no error.

This change gates `sampleResult.completed` on `!isPrefill`, so a throwaway EOT cannot complete the segment. A real EOT sampled at or after the last prefill token still ends decoding exactly as before.

Verified on `openai_whisper-large-v3-v20240930_turbo` (macOS 15, Apple Silicon): with this change, transcription with `promptTokens` produces correct text and the prompt biases spelling as intended. Without it, the same runs return an empty string. Full analysis and a decoder trace are in #501.
