### PR TITLE
Add inputDeviceID passthrough to AudioStreamTranscriber

### DIFF
--- a/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
@@ -39,6 +39,10 @@ public actor AudioStreamTranscriber {
     private let transcribeTask: TranscribeTask
     private let audioProcessor: any AudioProcessing
     private let decodingOptions: DecodingOptions
+    /// Optional input device to capture from. nil = system default input.
+    /// Lets callers stream from a specific device (e.g. a virtual device) instead
+    /// of always using the system default. Passed through to startRecordingLive.
+    private let inputDeviceID: DeviceID?
 
     public init(
         audioEncoder: any AudioEncoding,
@@ -52,6 +56,7 @@ public actor AudioStreamTranscriber {
         silenceThreshold: Float = 0.3,
         compressionCheckWindow: Int = 60,
         useVAD: Bool = true,
+        inputDeviceID: DeviceID? = nil,
         stateChangeCallback: AudioStreamTranscriberCallback?
     ) {
         self.transcribeTask = TranscribeTask(
@@ -70,6 +75,7 @@ public actor AudioStreamTranscriber {
         self.silenceThreshold = silenceThreshold
         self.compressionCheckWindow = compressionCheckWindow
         self.useVAD = useVAD
+        self.inputDeviceID = inputDeviceID
         self.stateChangeCallback = stateChangeCallback
     }
 
@@ -80,7 +86,7 @@ public actor AudioStreamTranscriber {
             return
         }
         state.isRecording = true
-        try audioProcessor.startRecordingLive { [weak self] _ in
+        try audioProcessor.startRecordingLive(inputDeviceID: inputDeviceID) { [weak self] _ in
             Task { [weak self] in
                 await self?.onAudioBufferCallback()
             }

--- a/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioStreamTranscriber.swift
@@ -86,10 +86,17 @@ public actor AudioStreamTranscriber {
             return
         }
         state.isRecording = true
-        try audioProcessor.startRecordingLive(inputDeviceID: inputDeviceID) { [weak self] _ in
-            Task { [weak self] in
-                await self?.onAudioBufferCallback()
+        do {
+            try audioProcessor.startRecordingLive(inputDeviceID: inputDeviceID) { [weak self] _ in
+                Task { [weak self] in
+                    await self?.onAudioBufferCallback()
+                }
             }
+        } catch {
+            // Reset the flag so a failed start (e.g. an unavailable inputDeviceID)
+            // does not leave the actor stuck in a recording state that blocks retries.
+            state.isRecording = false
+            throw error
         }
         await realtimeLoop()
         Logging.info("Realtime transcription has started")


### PR DESCRIPTION
## Summary

Adds an optional `inputDeviceID` parameter to `AudioStreamTranscriber` and forwards it to the existing `AudioProcessor.startRecordingLive(inputDeviceID:)` API.

Today, streaming transcription always records from the system default input because `AudioStreamTranscriber` calls `startRecordingLive()` without passing a device. Lower-level recording already supports a specific input device, but the streaming wrapper does not expose it.

This is additive and keeps existing behavior unchanged when `inputDeviceID` is `nil`.

## Why

This unblocks macOS apps that let users select an input device for streaming transcription, such as virtual or aggregate devices. For example, routing meeting audio into BlackHole works for non-streaming recording, but streaming transcription currently ignores the selected BlackHole device and captures the system default input instead.

I verified this fix in a local downstream app by routing audio into BlackHole and passing its device ID through `AudioStreamTranscriber`; streaming transcription then captured the selected device as expected.

Fixes #493.

## Testing

- `git diff --check HEAD~1..HEAD`
- `make build`

Note: `make build` required running outside the Codex sandbox because SwiftPM's own `sandbox-exec` fails with `sandbox_apply: Operation not permitted` inside the Codex sandbox. The build completed successfully outside that sandbox.
