### PR TITLE
TTSKit: decode-path performance improvements for Qwen3 streaming

### DIFF
--- a/Sources/ArgmaxCore/External/Hub/BinaryDistinct.swift
+++ b/Sources/ArgmaxCore/External/Hub/BinaryDistinct.swift
@@ -58,7 +58,14 @@ public struct BinaryDistinctString: Equatable, Hashable, Sendable, Comparable, C
     ///
     /// - Parameter str: The NSString to convert
     public init(_ str: NSString) {
-        value = Array(str as String).flatMap { $0.utf16 }
+        // Copy the underlying UTF-16 code units directly. Going through
+        // `Array(String)` walks Swift extended grapheme clusters and then
+        // expands them back to UTF-16, which is needlessly expensive while
+        // loading large tokenizer vocabularies and can lose the exact
+        // NSString representation this type is intended to preserve.
+        var codeUnits = [UInt16](repeating: 0, count: str.length)
+        str.getCharacters(&codeUnits, range: NSRange(location: 0, length: str.length))
+        value = codeUnits
     }
 
     /// Creates a binary-distinct string from a Swift String.

--- a/Sources/TTSKit/Qwen3TTS/Qwen3CodeDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3CodeDecoder.swift
@@ -118,7 +118,13 @@ public class Qwen3CodeDecoder: CodeDecoding, @unchecked Sendable {
         }
 
         let cacheUpdateStart = CFAbsoluteTimeGetCurrent()
-        await cache.update(keyTensor: keyTensor, valueTensor: valueTensor)
+        if let _ = state as? MLState, isStateful {
+            // Stateful MLState already received the materialized outputs above;
+            // only advance the host-side position and masks here.
+            cache.update()
+        } else {
+            await cache.update(keyTensor: keyTensor, valueTensor: valueTensor)
+        }
         let cacheTime = CFAbsoluteTimeGetCurrent() - cacheUpdateStart
 
         guard let logitsTensor = outputs["logits"],

--- a/Sources/TTSKit/Qwen3TTS/Qwen3CodeDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3CodeDecoder.swift
@@ -118,9 +118,12 @@ public class Qwen3CodeDecoder: CodeDecoding, @unchecked Sendable {
         }
 
         let cacheUpdateStart = CFAbsoluteTimeGetCurrent()
-        if let _ = state as? MLState, isStateful {
+        if state is MLState, isStateful, cache.isStateful {
             // Stateful MLState already received the materialized outputs above;
-            // only advance the host-side position and masks here.
+            // only advance the host-side position and masks here. Guarding on
+            // cache.isStateful keeps a mismatched external-cache KVCache on the
+            // materializing path below instead of silently skipping its
+            // key/value writes.
             cache.update()
         } else {
             await cache.update(keyTensor: keyTensor, valueTensor: valueTensor)

--- a/Sources/TTSKit/Utilities/KVCache.swift
+++ b/Sources/TTSKit/Utilities/KVCache.swift
@@ -239,9 +239,10 @@ public extension KVCache {
 
     /// Async update from MLTensor outputs - materializes without blocking the cooperative pool.
     func update(keyTensor: MLTensor, valueTensor: MLTensor) async {
-        let keyArr = await keyTensor.toMLMultiArray()
-        let valArr = await valueTensor.toMLMultiArray()
-        update(keyCacheUpdates: keyArr, valueCacheUpdates: valArr)
+        async let keyArr = keyTensor.toMLMultiArray()
+        async let valArr = valueTensor.toMLMultiArray()
+        let (keyMaterialized, valueMaterialized) = await (keyArr, valArr)
+        update(keyCacheUpdates: keyMaterialized, valueCacheUpdates: valueMaterialized)
     }
 }
 
@@ -440,9 +441,12 @@ public extension SpeechDecoderCache {
         else {
             return
         }
-        let keyArr = await keyUpdateTensor.toMLMultiArray()
-        let valArr = await valueUpdateTensor.toMLMultiArray()
-        update(keyCacheUpdates: keyArr, valueCacheUpdates: valArr)
+        // Key and value outputs are independent. Materialize them concurrently
+        // to avoid serializing two blocking conversions on the cooperative pool.
+        async let keyArr = keyUpdateTensor.toMLMultiArray()
+        async let valArr = valueUpdateTensor.toMLMultiArray()
+        let (keyMaterialized, valueMaterialized) = await (keyArr, valArr)
+        update(keyCacheUpdates: keyMaterialized, valueCacheUpdates: valueMaterialized)
 
         guard let hiddenUpdateTensor = tensorOutputs["hidden_context_update"] else { return }
         let updateArr = await hiddenUpdateTensor.toMLMultiArray()
@@ -473,9 +477,17 @@ public extension KVCache {
         valueTensor: MLTensor,
         position: Int
     ) async {
-        let keyArr = await keyTensor.toMLMultiArray()
-        let valArr = await valueTensor.toMLMultiArray()
-        updateStateCache(state: state, keyCacheUpdates: keyArr, valueCacheUpdates: valArr, position: position)
+        // Key and value outputs are independent. Materialize them concurrently;
+        // the state writes below remain ordered and use the same position.
+        async let keyArr = keyTensor.toMLMultiArray()
+        async let valArr = valueTensor.toMLMultiArray()
+        let (keyMaterialized, valueMaterialized) = await (keyArr, valArr)
+        updateStateCache(
+            state: state,
+            keyCacheUpdates: keyMaterialized,
+            valueCacheUpdates: valueMaterialized,
+            position: position
+        )
     }
 
     static func updateStateCache(

--- a/Sources/TTSKit/Utilities/Sampling.swift
+++ b/Sources/TTSKit/Utilities/Sampling.swift
@@ -223,6 +223,27 @@ public class GreedyTokenSampler: TokenSampling, @unchecked Sendable {
         if temperature == 0 {
             return Int32(await headLogits.cast(to: Float.self).argmax(alongAxis: -1).toIntArray()[0])
         }
+        if topK > 0 && topK < vocabSize {
+            // Selecting top-k logits before softmax is mathematically equivalent
+            // to the old full-softmax-then-top-k path after renormalization, but
+            // avoids computing probabilities for the entire vocabulary.
+            let scaledLogits = headLogits.cast(to: Float.self) / temperature
+            let (topKLogits, topKIndices) = scaledLogits.topK(topK)
+            let logitsArray = await topKLogits.toFloatArray()
+            let idxArray = await topKIndices.toIntArray()
+            let maxLogit = logitsArray.max() ?? 0
+            let weights = logitsArray.map { exp($0 - maxLogit) }
+            let weightSum = weights.reduce(0, +)
+            let randomValue = Float.random(in: 0..<weightSum, using: &rng)
+            var cumulativeWeight: Float = 0
+            for (index, weight) in weights.enumerated() {
+                cumulativeWeight += weight
+                if cumulativeWeight >= randomValue {
+                    return Int32(idxArray[index])
+                }
+            }
+            return idxArray.last.map(Int32.init) ?? Int32(vocabSize - 1)
+        }
         let probs = (headLogits.cast(to: Float.self) / temperature).softmax(alongAxis: -1)
         return await sampleFromProbs(probs, vocabSize: vocabSize, topK: topK)
     }

--- a/Sources/TTSKit/Utilities/Sampling.swift
+++ b/Sources/TTSKit/Utilities/Sampling.swift
@@ -234,6 +234,13 @@ public class GreedyTokenSampler: TokenSampling, @unchecked Sendable {
             let maxLogit = logitsArray.max() ?? 0
             let weights = logitsArray.map { exp($0 - maxLogit) }
             let weightSum = weights.reduce(0, +)
+            guard weightSum.isFinite, weightSum > 0 else {
+                // Degenerate distribution (e.g. NaN logits, or every logit
+                // -inf). Float.random would trap on an empty/invalid range;
+                // fall back to the highest-scoring index deterministically
+                // (topK returns values sorted descending).
+                return idxArray.first.map(Int32.init) ?? 0
+            }
             let randomValue = Float.random(in: 0..<weightSum, using: &rng)
             var cumulativeWeight: Float = 0
             for (index, weight) in weights.enumerated() {

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -210,8 +210,10 @@ final class TTSKitUnitTests: XCTestCase {
         cache.update()
 
         XCTAssertEqual(cache.cacheLength, 1)
-        let updateMask = cache.kvCacheUpdateMask.dataPointer.bindMemory(to: FloatType.self, capacity: 8)
-        let paddingMask = cache.keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: 8)
+        let updateMask = cache.kvCacheUpdateMask.dataPointer.bindMemory(
+            to: FloatType.self, capacity: cache.kvCacheUpdateMask.count)
+        let paddingMask = cache.keyPaddingMask.dataPointer.bindMemory(
+            to: FloatType.self, capacity: cache.keyPaddingMask.count)
         XCTAssertEqual(updateMask[0], 0)
         XCTAssertEqual(updateMask[1], 1)
         XCTAssertEqual(paddingMask[1], 0)

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -204,6 +204,19 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(cache.freePositions, 5) // 8 - 1 - 2
     }
 
+    func testStatefulKVCacheUpdateWithoutTensorsAdvancesPositionAndMasks() throws {
+        let cache = try KVCache(cacheDim: 4, maxSeqLength: 8, isStateful: true)
+
+        cache.update()
+
+        XCTAssertEqual(cache.cacheLength, 1)
+        let updateMask = cache.kvCacheUpdateMask.dataPointer.bindMemory(to: FloatType.self, capacity: 8)
+        let paddingMask = cache.keyPaddingMask.dataPointer.bindMemory(to: FloatType.self, capacity: 8)
+        XCTAssertEqual(updateMask[0], 0)
+        XCTAssertEqual(updateMask[1], 1)
+        XCTAssertEqual(paddingMask[1], 0)
+    }
+
     func testKVCacheIsFull() throws {
         let cache = try KVCache(cacheDim: 4, maxSeqLength: 4)
         // codesPerStep == 1 (default): isFull when cacheLength >= maxSeqLength - 1 == 3.


### PR DESCRIPTION
Four small optimizations to the Qwen3 TTS decode hot path, found while profiling on-device streaming synthesis in a production app (A19 iPhone, 12Hz 0.6B models):

- **Stateful decoders no longer copy K/V updates into the host-side cache.** For stateful models the MLState buffers already received this step's key/value updates during prediction, but the decode path still materialized the update tensors into the host-side cache arrays on every step. Only the cache position and attention masks need to advance. Adds `KVCache.update()` for that, with a unit test covering the position/mask bookkeeping.
- **K/V tensor materialization is concurrent.** The key and value MLTensor outputs are independent, but the async update paths materialized them sequentially — two round trips per decode step. `async let` runs both `toMLMultiArray()` calls concurrently in `update(keyTensor:valueTensor:)`, `updateStateCache`, and `updateWithHiddenContext`.
- **`BinaryDistinctString.init(NSString)` copies UTF-16 code units directly.** Converting through `Array(String)` walks Swift extended grapheme clusters and re-expands them to UTF-16 — needlessly expensive while loading large tokenizer vocabularies, and it can lose the exact NSString representation the type exists to preserve. `getCharacters(_:range:)` copies the code units as-is.
- **Top-k sampling selects the top-k logits before softmax** instead of computing probabilities over the entire vocabulary each step. Equivalent after renormalization, and avoids materializing full-vocabulary probabilities on the host.

## Measurements

A/B on an Apple silicon Mac (CLI, v1.0.0 vs v1.0.0 + these changes only, same seed/text/models, W8A16 0.6B, temperature 0.7 / top-k 20, 3 runs each):

| Metric | Before | After | Δ |
|---|---|---|---|
| Tokenizer load (Qwen3 151k vocab) | 0.95 s | 0.64 s | **−32%** |
| MultiCodeDecoder sampling | 0.91 ms/step | 0.81 ms/step | **−11%** |
| Total process CPU (16.5 s generation) | ~9.9 s | ~9.6 s | −2.5% |
| Throughput / RTF / peak RSS | — | — | unchanged |

End-to-end throughput is unchanged on the Mac because generation there is ANE-bound; the host-side savings are aimed at phone-class devices, where the decode loop shares CPU and memory bandwidth with the host app. The original motivation was an Instruments capture on an A19 iPhone during streaming synthesis, which attributed ~16% of captured cycles to the sampling path that these changes shrink.

All changes are behavior-preserving. `swift build` and the TTSKit unit tests (86) pass; the changes have been validated in continuous day-to-day on-device streaming use.