### PR TITLE
Support incremental file loading

### DIFF
--- a/.github/workflows/development-tests.yml
+++ b/.github/workflows/development-tests.yml
@@ -13,6 +13,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-build-and-test
       cancel-in-progress: true
     uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
     with:
       ios-version: "26.4.1"
       ios-device: "iPhone 17"
@@ -64,6 +65,7 @@ jobs:
             visionos-version: "2.5"
             xcode-version: "16.4"
     uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
     with:
       macos-runner: ${{ matrix.os }}
       ios-version: ${{ matrix.ios-version }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -31,6 +31,7 @@ jobs:
             macos-runner: "macos-26"
             xcode-version: "26.4.1"
     uses: ./.github/workflows/unit-tests.yml
+    secrets: inherit
     with:
       macos-runner: ${{ matrix.os }}
       ios-version: ${{ matrix.ios-version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,9 @@ on:
       xcode-version:
         required: false
         type: string
+    secrets:
+      HF_TOKEN:
+        required: false
 
 jobs:
   unit-tests:
@@ -91,12 +94,19 @@ jobs:
           xcrun simctl boot "$simulator_name" || true
           sleep 15
           xcrun simctl list devices
-      - name: Build and Test - ${{ matrix.run-config['name'] }}
+      - name: Build - ${{ matrix.run-config['name'] }}
         if: ${{ matrix.run-config['condition'] == true }}
         run: |
           set -o pipefail
-          xcodebuild clean build-for-testing -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcpretty
-          xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}'
+          xcodebuild clean build-for-testing -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcbeautify --renderer github-actions
+      - name: Test - ${{ matrix.run-config['name'] }}
+        if: ${{ matrix.run-config['condition'] == true }}
+        env:
+          # xcodebuild strips the TEST_RUNNER_ prefix and forwards HF_TOKEN into the test process
+          TEST_RUNNER_HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -o pipefail
+          xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}' | xcbeautify --renderer github-actions
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/WhisperAX/WhisperAX.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a8a6dfecd55bea90b0d0a0e8397b08130e6515f6bcd2c2fe43b2cd618d264ba9",
+  "originHash" : "319091f8efc39aae86708644ce0b4d9b5dd13c3819ac28a4e2966d2c85154d57",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-        "version" : "1.3.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     }
   ],

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ setup:
 	@echo "Checking for fastlane"
 	@which fastlane > /dev/null || (echo "Installing fastlane..." && brew install fastlane)
 	@echo "fastlane is installed."
+	@echo "Checking for xcbeautify..."
+	@which xcbeautify > /dev/null || (echo "Installing xcbeautify..." && brew install xcbeautify)
+	@echo "xcbeautify is installed."
 	@$(MAKE) generate-xcconfigs
 	@echo "Done 🚀"
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
   - [Homebrew](#homebrew)
 - [WhisperKit](#whisperkit)
   - [Quick Example](#quick-example)
+  - [Memory-Efficient Loading for Large Files](#memory-efficient-loading-for-large-files)
   - [Model Selection](#model-selection)
   - [Generating Models](#generating-models)
   - [Swift CLI](#swift-cli)
@@ -149,10 +150,36 @@ import WhisperKit
 
 // Initialize WhisperKit with default settings
 Task {
-   let pipe = try? await WhisperKit()
-   let transcription = try? await pipe!.transcribe(audioPath: "path/to/your/audio.{wav,mp3,m4a,flac}")?.text
-    print(transcription)
+    let pipe = try? await WhisperKit()
+    let results = try? await pipe?.transcribe(audioPath: "path/to/your/audio.{wav,mp3,m4a,flac}")
+    let transcription = results?.map(\.text).joined(separator: " ")
+    print(transcription ?? "")
 }
+```
+
+### Memory-Efficient Loading for Large Files
+
+By default WhisperKit loads the whole audio file into memory before transcribing. For long recordings, `.incremental` streams it from disk in bounded-memory chunks instead:
+
+```swift
+import WhisperKit
+
+let pipe = try await WhisperKit()
+
+let options = AudioInputOptions(audioLoadingMode: .incremental)
+let results = try await pipe.transcribe(
+    audioPath: "path/to/large-audio.wav",
+    audioInputOptions: options
+)
+print(results.map(\.text).joined(separator: " "))
+```
+
+It splits the audio at silence (VAD) boundaries, so the result matches a full-file transcription run with `chunkingStrategy: .vad` — only peak memory differs. Tune the chunking with `.incremental(chunkDuration:chunkBufferSize:)`, or pick channels with `AudioInputOptions(channelMode:)`.
+
+From the CLI, add `--incremental-loading` (optionally `--incremental-chunk-duration` / `--incremental-chunk-buffer-size`):
+
+```bash
+swift run argmax-cli transcribe --model large-v3-v20240930_626MB --audio-path "path/to/large-audio.wav" --incremental-loading
 ```
 
 ### Model Selection

--- a/Sources/ArgmaxCLI/TranscribeCLI.swift
+++ b/Sources/ArgmaxCLI/TranscribeCLI.swift
@@ -54,6 +54,24 @@ struct TranscribeCLI: AsyncParsableCommand {
         if ChunkingStrategy(rawValue: cliArguments.chunkingStrategy) == nil {
             throw ValidationError("Wrong chunking strategy \"\(cliArguments.chunkingStrategy)\", valid strategies: \(ChunkingStrategy.allCases.map { $0.rawValue })")
         }
+
+        if cliArguments.incrementalLoading {
+            if let duration = cliArguments.incrementalChunkDuration {
+                guard duration.isFinite, duration > 0 else {
+                    throw ValidationError("--incremental-chunk-duration must be greater than 0")
+                }
+            }
+
+            if let bufferSize = cliArguments.incrementalChunkBufferSize {
+                guard bufferSize > 0 else {
+                    throw ValidationError("--incremental-chunk-buffer-size must be greater than 0")
+                }
+            }
+
+            guard cliArguments.clipTimestamps.isEmpty else {
+                throw ValidationError("--clip-timestamps is not supported with --incremental-loading")
+            }
+        }
     }
 
     mutating func run() async throws {
@@ -126,6 +144,18 @@ struct TranscribeCLI: AsyncParsableCommand {
         }
         if cliArguments.verbose {
             print("\nConfiguring decoding options...")
+        }
+        let audioInputOptions = TranscribeCLIUtils.createAudioInputOptions(from: cliArguments)
+        if cliArguments.verbose {
+            switch audioInputOptions.audioLoadingMode {
+            case .fullFile:
+                print("File loading mode: full file")
+            case .incremental(let chunkDurationSeconds, let maxBufferedChunks):
+                print("File loading mode: incremental")
+                print(String(format: "  - Chunk duration: %.2f seconds", chunkDurationSeconds))
+                print("  - Chunk buffer size: \(maxBufferedChunks)")
+                print("  - VAD boundary detection: enabled")
+            }
         }
 
         if let promptText = cliArguments.prompt, promptText.count > 0, let tokenizer = whisperKit.tokenizer {
@@ -216,6 +246,7 @@ struct TranscribeCLI: AsyncParsableCommand {
         // Start the transcription
         let transcribeResult: [Result<[TranscriptionResult], Swift.Error>] = await whisperKit.transcribeWithResults(
             audioPaths: resolvedAudioPaths,
+            audioInputOptions: audioInputOptions,
             decodeOptions: options
         )
 

--- a/Sources/ArgmaxCLI/TranscribeCLIArguments.swift
+++ b/Sources/ArgmaxCLI/TranscribeCLIArguments.swift
@@ -103,6 +103,15 @@ struct TranscribeCLIArguments: ParsableArguments {
     @Flag(help: "Simulate streaming transcription using the input audio file")
     var streamSimulated: Bool = false
 
+    @Flag(help: "Load file audio incrementally in chunks instead of loading each full file into memory")
+    var incrementalLoading: Bool = false
+
+    @Option(help: "Duration, in seconds, for each incrementally loaded audio chunk. Defaults to the library default (AudioLoadingMode.defaultChunkDurationSeconds).")
+    var incrementalChunkDuration: Double? = nil
+
+    @Option(help: "Maximum number of incrementally loaded chunks buffered before back-pressure. Defaults to the library default (AudioLoadingMode.defaultMaxBufferedChunks).")
+    var incrementalChunkBufferSize: Int? = nil
+
     @Option(help: "Maximum concurrent inference, might be helpful when processing more than 1 audio file at the same time. 0 means unlimited. Default: 4")
     var concurrentWorkerCount: Int = 4
 

--- a/Sources/ArgmaxCLI/TranscribeCLIUtils.swift
+++ b/Sources/ArgmaxCLI/TranscribeCLIUtils.swift
@@ -42,7 +42,30 @@ internal class TranscribeCLIUtils {
             useBackgroundDownloadSession: false
         )
     }
-    
+
+    /// Creates the `AudioInputOptions` used by file-based transcription.
+    ///
+    /// The CLI keeps full-file loading as the default for compatibility. When
+    /// `--incremental-loading` is enabled, this helper wires the CLI chunk
+    /// duration and buffer size into WhisperKit's incremental file loader,
+    /// falling back to the library defaults (`AudioLoadingMode.defaultChunkDurationSeconds` /
+    /// `defaultMaxBufferedChunks`) when omitted.
+    /// Additional input options (for example channel selection) can be added here.
+    ///
+    /// - Parameter arguments: Parsed transcribe CLI arguments.
+    /// - Returns: The `AudioInputOptions` to pass to
+    ///   `WhisperKit.transcribeWithResults(audioPaths:audioInputOptions:decodeOptions:callback:)`.
+    static func createAudioInputOptions(from arguments: TranscribeCLIArguments) -> AudioInputOptions {
+        let audioLoadingMode: AudioInputOptions.AudioLoadingMode = arguments.incrementalLoading
+            ? .incremental(
+                chunkDurationSeconds: arguments.incrementalChunkDuration ?? AudioInputOptions.AudioLoadingMode.defaultChunkDurationSeconds,
+                maxBufferedChunks: arguments.incrementalChunkBufferSize ?? AudioInputOptions.AudioLoadingMode.defaultMaxBufferedChunks
+            )
+            : .fullFile
+
+        return AudioInputOptions(audioLoadingMode: audioLoadingMode)
+    }
+
     /// Creates DecodingOptions from CLI arguments and task
     static func createDecodingOptions(from arguments: TranscribeCLIArguments, task: DecodingTask) -> DecodingOptions {
         let options = DecodingOptions(

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor+IncrementalLoading.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor+IncrementalLoading.swift
@@ -1,0 +1,215 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import AVFoundation
+
+/// Actor that manages flow control to prevent memory overuse during incremental file loading
+actor IncrementalLoadController {
+    private let maxBufferedChunks: Int
+    private var activeChunks = 0
+    private var waitingProducers: [CheckedContinuation<Void, Never>] = []
+    /// Set once the stream terminates so a producer that requests a slot afterwards returns
+    /// immediately instead of suspending on a continuation that would never be resumed.
+    private var isTerminated = false
+
+    init(maxBufferedChunks: Int = 2) {
+        self.maxBufferedChunks = maxBufferedChunks
+    }
+
+    /// Request permission to produce a new chunk. Will suspend if buffer is full.
+    func requestChunkSlot() async {
+        guard !isTerminated else { return }
+        if activeChunks >= maxBufferedChunks {
+            await withCheckedContinuation { continuation in
+                waitingProducers.append(continuation)
+            }
+            // Resumed by termination rather than a freed slot; don't claim a slot.
+            guard !isTerminated else { return }
+        }
+        activeChunks += 1
+    }
+
+    /// Signal that a chunk has been consumed, freeing up a slot
+    func signalChunkConsumed() {
+        guard activeChunks > 0 else { return }
+        activeChunks -= 1
+        if !waitingProducers.isEmpty && activeChunks < maxBufferedChunks {
+            let producer = waitingProducers.removeFirst()
+            producer.resume()
+        }
+    }
+
+    /// Marks the controller terminated and resumes any waiting producers so task cancellation
+    /// can unwind promptly. After this, `requestChunkSlot()` returns without suspending.
+    func resumeWaitingProducers() {
+        isTerminated = true
+        let producers = waitingProducers
+        waitingProducers.removeAll()
+        for producer in producers {
+            producer.resume()
+        }
+    }
+}
+
+/// Represents a chunk of audio data from an audio file for incremental loading.
+///
+/// This internal structure is used by the incremental file loading API to deliver audio data
+/// in manageable chunks while maintaining back-pressure control to prevent memory overuse.
+/// Each chunk contains the audio samples and a completion signal that must be called
+/// by the consumer to maintain proper flow control.
+///
+/// - Important: This is an internal structure used by the audio streaming implementation.
+///   The `completionSignal` closure is critical for the back-pressure mechanism and must
+///   be called when the chunk has been processed to allow the next chunk to be loaded.
+struct IncrementalFileChunk: Sendable {
+    /// Audio chunk containing the audio samples and seek offset information
+    let audioChunk: AudioChunk
+
+    /// Completion signal used internally for back-pressure flow control.
+    /// Must be called when chunk processing is complete to signal the producer
+    /// that it can continue loading the next chunk.
+    let completionSignal: @Sendable () -> Void
+
+    init(audioSamples: [Float], seekOffsetIndex: Int, completionSignal: @escaping @Sendable () -> Void) {
+        self.audioChunk = .init(seekOffsetIndex: seekOffsetIndex, audioSamples: audioSamples)
+        self.completionSignal = completionSignal
+    }
+}
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+extension AudioProcessor {
+    typealias IncrementalFileStream = AsyncThrowingStream<IncrementalFileChunk, Error>
+
+    /// Streams an audio file in bounded-memory chunks instead of loading it all at once.
+    ///
+    /// Back-pressure caps how many chunks are buffered: the consumer must call each chunk's
+    /// `completionSignal` when done, or loading pauses once `maxBufferedChunks` chunks are queued.
+    ///
+    /// - Parameters:
+    ///   - audioFilePath: Path to the audio file to stream.
+    ///   - channelMode: How to handle multi-channel audio. Defaults to summing all channels.
+    ///   - chunkDurationSeconds: Seconds of audio to read per staging step.
+    ///   - maxBufferedChunks: Max chunks buffered before back-pressure pauses loading.
+    ///   - maxChunkLength: Model audio-window size used for VAD chunk boundaries.
+    /// - Returns: An async throwing stream of `IncrementalFileChunk`s.
+    /// - Note: Internal API; throws on validation, initialization, or read failure.
+    static func loadFileIncrementally(
+        fromPath audioFilePath: String,
+        channelMode: ChannelMode = .sumChannels(nil),
+        chunkDurationSeconds: Double,
+        maxBufferedChunks: Int,
+        maxChunkLength: Int = Constants.defaultWindowSamples,
+        vad: VoiceActivityDetector = EnergyVAD()
+    ) throws -> IncrementalFileStream {
+        guard chunkDurationSeconds.isFinite, chunkDurationSeconds > 0 else {
+            throw WhisperError.loadAudioFailed("Incremental chunk duration must be greater than 0")
+        }
+        guard maxBufferedChunks > 0 else {
+            throw WhisperError.loadAudioFailed("Incremental chunk buffer size must be greater than 0")
+        }
+        guard FileManager.default.fileExists(atPath: audioFilePath) else {
+            throw WhisperError.loadAudioFailed("Audio file not found at path: \(audioFilePath)")
+        }
+        return AsyncThrowingStream<IncrementalFileChunk, Error> { continuation in
+            let flowController = IncrementalLoadController(maxBufferedChunks: maxBufferedChunks)
+            let producerTask = Task {
+                do {
+                    let audioFileURL = URL(fileURLWithPath: audioFilePath)
+                    let audioFile = try AVAudioFile(forReading: audioFileURL, commonFormat: .pcmFormatFloat32, interleaved: false)
+                    let inputSampleRate = audioFile.fileFormat.sampleRate
+                    // `audioFile.length` is an Int64 frame position; divide directly to avoid
+                    // narrowing to AVAudioFrameCount (UInt32), which overflows on very long files.
+                    let inputDuration = Double(audioFile.length) / inputSampleRate
+
+                    let end = inputDuration
+                    var currentTime = 0.0
+
+                    // Chunk at VAD (silence) boundaries with the same chunker as the full-file `.vad` path,
+                    // so the result matches a `.vad` transcription. `chunkDurationSeconds` only sets the read/staging
+                    // size, not the boundaries; partially-decided chunks carry across staging buffers.
+                    // `maxChunkLength` is the model's audio window, passed in so boundaries track the model.
+                    let chunker = VADAudioChunker(vad: vad)
+                    var audioBuffer: [Float] = []   // audioBuffer[0] corresponds to global sample `bufferStartSample`
+                    var bufferStartSample = 0
+
+                    while true {
+                        try Task.checkCancellation()
+
+                        // Refill with at least one window of lookahead so chunk cuts match the full-file path.
+                        while audioBuffer.count <= maxChunkLength && currentTime < end {
+                            let chunkEnd = min(currentTime + chunkDurationSeconds, end)
+                            try autoreleasepool {
+                                let buffer = try loadAudio(
+                                    fromFile: audioFile,
+                                    channelMode: channelMode,
+                                    startTime: currentTime,
+                                    endTime: chunkEnd
+                                )
+                                audioBuffer.append(contentsOf: Self.convertBufferToArray(buffer: buffer))
+                            }
+                            currentTime = chunkEnd
+                        }
+
+                        if audioBuffer.isEmpty { break }
+                        let atEOF = currentTime >= end
+
+                        let chunks = try await chunker.chunkAll(
+                            audioArray: audioBuffer,
+                            maxChunkLength: maxChunkLength,
+                            decodeOptions: nil
+                        )
+
+                        // A chunk is final once its full decision window is staged; otherwise more
+                        // audio could still move its cut, so carry it forward. At EOF all chunks are final.
+                        var emitCount = chunks.count
+                        if !atEOF {
+                            emitCount = 0
+                            for chunk in chunks {
+                                if chunk.seekOffsetIndex + maxChunkLength <= audioBuffer.count {
+                                    emitCount += 1
+                                } else {
+                                    break
+                                }
+                            }
+                        }
+
+                        var consumed = 0
+                        for chunk in chunks.prefix(emitCount) {
+                            try Task.checkCancellation()
+                            // Acquire a buffer slot per emitted chunk (1:1, released by completionSignal).
+                            await flowController.requestChunkSlot()
+                            try Task.checkCancellation()
+                            continuation.yield(
+                                IncrementalFileChunk(
+                                    audioSamples: chunk.audioSamples,
+                                    seekOffsetIndex: bufferStartSample + chunk.seekOffsetIndex,
+                                    completionSignal: {
+                                        Task { await flowController.signalChunkConsumed() }
+                                    }
+                                )
+                            )
+                            consumed = chunk.seekOffsetIndex + chunk.audioSamples.count
+                        }
+
+                        if atEOF { break }
+                        bufferStartSample += consumed
+                        audioBuffer = Array(audioBuffer[consumed...])
+                    }
+
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    Logging.error("Error loading audio file incrementally: \(error)")
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in
+                producerTask.cancel()
+                Task {
+                    await flowController.resumeWaitingProducers()
+                }
+            }
+        }
+    }
+}

--- a/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
+++ b/Sources/WhisperKit/Core/Audio/AudioProcessor.swift
@@ -12,7 +12,7 @@ public typealias DeviceID = AudioDeviceID
 #else
 public typealias DeviceID = String
 #endif
-public typealias ChannelMode = AudioInputConfig.ChannelMode
+public typealias ChannelMode = AudioInputOptions.ChannelMode
 
 public struct AudioDevice: Identifiable, Hashable, Sendable {
     public let id: DeviceID
@@ -25,7 +25,7 @@ public struct AudioDevice: Identifiable, Hashable, Sendable {
 }
 
 /// Configuration for audio input including device selection and channel processing options.
-public struct AudioInputConfig: Sendable {
+public struct AudioInputOptions: Sendable {
     /// Specifies how to handle audio channels when processing multi-channel audio.
     public enum ChannelMode: Hashable, Codable, Sendable {
         /// Selects a single specific channel by index.
@@ -41,10 +41,47 @@ public struct AudioInputConfig: Sendable {
         case sumChannels([Int]?)
     }
 
+    /// Controls how audio files are loaded and processed during transcription.
+    public enum AudioLoadingMode: Sendable {
+        /// Default seconds of audio read per staging step.
+        public static let defaultChunkDurationSeconds: Double = 120
+
+        /// Default number of chunks buffered ahead of the consumer before back-pressure pauses
+        /// loading.
+        public static let defaultMaxBufferedChunks: Int = 2
+
+        /// Loads the whole file into memory before transcribing (default; higher peak memory).
+        case fullFile
+
+        /// Streams the file in bounded-memory chunks. Best for large files.
+        /// - Parameters:
+        ///   - chunkDurationSeconds: Seconds of audio read per staging step.
+        ///   - maxBufferedChunks: Max chunks buffered before back-pressure pauses loading.
+        case incremental(chunkDurationSeconds: Double, maxBufferedChunks: Int)
+
+        /// Incremental loading with the default chunk duration and buffer size.
+        public static let incremental: AudioLoadingMode = .incremental(
+            chunkDurationSeconds: defaultChunkDurationSeconds,
+            maxBufferedChunks: defaultMaxBufferedChunks
+        )
+    }
+
     /// Specifies how to process channels from multi-channel audio sources.
     /// Defaults to summing all channels if not explicitly set.
     public var channelMode: ChannelMode = .sumChannels(nil)
+
+    /// Specifies how audio files are loaded during transcription. Defaults to `.fullFile`.
+    public var audioLoadingMode: AudioLoadingMode = .fullFile
+
+    public init(channelMode: ChannelMode = .sumChannels(nil), audioLoadingMode: AudioLoadingMode = .fullFile) {
+        self.channelMode = channelMode
+        self.audioLoadingMode = audioLoadingMode
+    }
 }
+
+/// Deprecated name for ``AudioInputOptions``.
+@available(*, deprecated, renamed: "AudioInputOptions")
+public typealias AudioInputConfig = AudioInputOptions
 
 public protocol AudioProcessorOutputType {}
 extension MLMultiArray : AudioProcessorOutputType {}
@@ -269,22 +306,18 @@ open class AudioProcessor: NSObject, AudioProcessing {
         var outputBuffer: AVAudioPCMBuffer?
 
         // If the audio file already meets the desired format, read directly into the output buffer
-        if sampleRate == 16000 && channelCount == 1 {
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: frameCount) else {
-                throw WhisperError.loadAudioFailed("Unable to create audio buffer")
-            }
+        if sampleRate == Double(WhisperKit.sampleRate) && channelCount == 1 {
             do {
-                try audioFile.read(into: buffer, frameCount: frameCount)
+                outputBuffer = try audioFile.readFully(frameCount: frameCount)
             } catch {
                 throw WhisperError.loadAudioFailed("Failed to read audio file: \(error)")
             }
-            outputBuffer = buffer
         } else {
             // Audio needs resampling to 16khz
             let maxReadSize = maxReadFrameSize ?? Constants.defaultAudioReadFrameSize
             outputBuffer = resampleAudio(
                 fromFile: audioFile,
-                toSampleRate: 16000,
+                toSampleRate: Double(WhisperKit.sampleRate),
                 channelCount: 1,
                 channelMode: channelMode,
                 frameCount: frameCount,
@@ -1111,5 +1144,35 @@ public extension AudioProcessor {
             guard let base = ptr.baseAddress else { return }
             vDSP_vclr(base, 1, vDSP_Length(ptr.count))
         }
+    }
+}
+
+private extension AVAudioFile {
+    /// Reads `frameCount` frames into a new buffer, continuing past short reads until the request
+    /// is satisfied or the file ends. Some inputs (observed with 32-bit float PCM near end-of-file)
+    /// return fewer frames than requested from a single `read`, which would otherwise drop frames.
+    func readFully(frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: processingFormat, frameCapacity: frameCount) else {
+            throw WhisperError.loadAudioFailed("Unable to create audio buffer")
+        }
+        try read(into: buffer, frameCount: frameCount)
+        while buffer.frameLength < frameCount {
+            let framesRemaining = frameCount - buffer.frameLength
+            guard let scratch = AVAudioPCMBuffer(pcmFormat: processingFormat, frameCapacity: framesRemaining) else {
+                throw WhisperError.loadAudioFailed("Unable to create audio buffer")
+            }
+            try read(into: scratch, frameCount: framesRemaining)
+            guard scratch.frameLength > 0 else { break }
+            guard let destination = buffer.floatChannelData, let source = scratch.floatChannelData else {
+                throw WhisperError.loadAudioFailed("Audio buffer is missing float channel data")
+            }
+            memcpy(
+                destination[0].advanced(by: Int(buffer.frameLength)),
+                source[0],
+                Int(scratch.frameLength) * MemoryLayout<Float>.size
+            )
+            buffer.frameLength += scratch.frameLength
+        }
+        return buffer
     }
 }

--- a/Sources/WhisperKit/Core/Audio/VoiceActivityDetector.swift
+++ b/Sources/WhisperKit/Core/Audio/VoiceActivityDetector.swift
@@ -5,7 +5,10 @@ import Foundation
 
 /// A base class for Voice Activity Detection (VAD), used to identify and separate segments of audio that contain human speech from those that do not.
 /// Subclasses must implement the `voiceActivity(in:)` method to provide specific voice activity detection functionality.
-open class VoiceActivityDetector {
+///
+/// Conforms to `Sendable` (unchecked): the base type is immutable and `voiceActivity(in:)` is a pure
+/// function, so instances are safe to share across concurrency domains. Subclasses must preserve this.
+open class VoiceActivityDetector: @unchecked Sendable {
     /// The sample rate of the audio signal, in samples per second.
     public let sampleRate: Int
 

--- a/Sources/WhisperKit/Core/Configurations.swift
+++ b/Sources/WhisperKit/Core/Configurations.swift
@@ -22,8 +22,15 @@ open class WhisperKitConfig {
 
     /// Model compute options, see `ModelComputeOptions`
     public var computeOptions: ModelComputeOptions?
-    /// Audio input config to define how to process audio input
-    public var audioInputConfig: AudioInputConfig?
+    /// Backing store for the deprecated ``audioInputConfig``.
+    var audioInputConfigStorage: AudioInputOptions?
+
+    /// Audio input config to define how to process audio input.
+    @available(*, deprecated, message: "Pass audioInputOptions per call to transcribe(audioPath:audioInputOptions:) instead of setting it on WhisperKitConfig.")
+    public var audioInputConfig: AudioInputOptions? {
+        get { audioInputConfigStorage }
+        set { audioInputConfigStorage = newValue }
+    }
     /// Audio processor for the model
     public var audioProcessor: (any AudioProcessing)?
     public var featureExtractor: (any FeatureExtracting)?
@@ -80,7 +87,7 @@ open class WhisperKitConfig {
                 modelFolder: String? = nil,
                 tokenizerFolder: URL? = nil,
                 computeOptions: ModelComputeOptions? = nil,
-                audioInputConfig: AudioInputConfig? = nil,
+                audioInputConfig: AudioInputOptions? = nil,
                 audioProcessor: (any AudioProcessing)? = nil,
                 featureExtractor: (any FeatureExtracting)? = nil,
                 audioEncoder: (any AudioEncoding)? = nil,
@@ -103,7 +110,7 @@ open class WhisperKitConfig {
         self.modelFolder = modelFolder
         self.tokenizerFolder = tokenizerFolder
         self.computeOptions = computeOptions
-        self.audioInputConfig = audioInputConfig
+        self.audioInputConfigStorage = audioInputConfig
         self.audioProcessor = audioProcessor
         self.featureExtractor = featureExtractor
         self.audioEncoder = audioEncoder

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -18,7 +18,13 @@ open class WhisperKit {
     }
 
     public var modelCompute: ModelComputeOptions
-    public var audioInputConfig: AudioInputConfig
+    public var audioInputOptions: AudioInputOptions
+
+    @available(*, deprecated, renamed: "audioInputOptions")
+    public var audioInputConfig: AudioInputOptions {
+        get { audioInputOptions }
+        set { audioInputOptions = newValue }
+    }
     public var tokenizer: WhisperTokenizer? {
         didSet {
             // Always sync the tokenizer to the text decoder when set
@@ -55,7 +61,7 @@ open class WhisperKit {
 
     public init(_ config: WhisperKitConfig = WhisperKitConfig()) async throws {
         modelCompute = config.computeOptions ?? ModelComputeOptions()
-        audioInputConfig = config.audioInputConfig ?? AudioInputConfig()
+        audioInputOptions = config.audioInputConfigStorage ?? AudioInputOptions()
         audioProcessor = config.audioProcessor ?? AudioProcessor()
         featureExtractor = config.featureExtractor ?? FeatureExtractor()
         audioEncoder = config.audioEncoder ?? AudioEncoder()
@@ -583,14 +589,26 @@ open class WhisperKit {
     // MARK: - Transcribe multiple audio files
 
     /// Convenience method to transcribe multiple audio files asynchronously and return the results as an array of optional arrays of `TranscriptionResult`.
+    ///
+    /// - Parameters:
+    ///   - audioPaths: An array of file paths pointing to the audio files to be transcribed.
+    ///   - decodeOptions: Optional decoding options to customize the transcription process.
+    ///   - audioInputOptions: Channel processing and file-loading options. When `nil`, the instance's `audioInputOptions` is used (full-file loading by default).
+    ///   - callback: Optional callback to receive updates during the transcription process.
+    ///
     /// - Returns: An array of optional arrays containing `TranscriptionResult`.
+    ///
+    /// - Note: The default loading mode will change to `.incremental` in a future major version.
+    ///   Consider using `.incremental` for large audio files to reduce memory usage.
     open func transcribe(
         audioPaths: [String],
+        audioInputOptions: AudioInputOptions? = nil,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil
     ) async -> [[TranscriptionResult]?] {
         let transcribeResults = await transcribeWithResults(
             audioPaths: audioPaths,
+            audioInputOptions: audioInputOptions,
             decodeOptions: decodeOptions,
             callback: callback
         )
@@ -606,58 +624,127 @@ open class WhisperKit {
     /// - Parameters:
     ///   - audioPaths: An array of file paths pointing to the audio files to be transcribed.
     ///   - decodeOptions: Optional decoding options to customize the transcription process.
+    ///   - audioInputOptions: Channel processing and file-loading options. When `nil`, the instance's `audioInputOptions` is used (full-file loading by default).
     ///   - callback: Optional callback to receive updates during the transcription process.
     ///
     /// - Returns: An array of `Result` objects with either a successful transcription result or an error.
+    ///
+    /// - Note: The default loading mode will change to `.incremental` in a future major version.
+    ///   Consider using `.incremental` for large audio files to reduce memory usage.
     open func transcribeWithResults(
         audioPaths: [String],
+        audioInputOptions: AudioInputOptions? = nil,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil
     ) async -> [Result<[TranscriptionResult], Swift.Error>] {
-        transcriptionStateCallback?(.convertingAudio)
+        let resolvedOptions = audioInputOptions ?? self.audioInputOptions
+        switch resolvedOptions.audioLoadingMode {
+        case .fullFile:
+            transcriptionStateCallback?(.convertingAudio)
 
-        // Start timing the audio loading and conversion process
-        let loadAudioStart = Date()
+            // Start timing the audio loading and conversion process
+            let loadAudioStart = Date()
 
-        // Load and extract audio data from the provided file paths
-        let loadedAudioResult = await AudioProcessor.loadAudio(at: audioPaths, channelMode: audioInputConfig.channelMode)
-        let audioArrays = loadedAudioResult.compactMap { try? $0.get() }
+            // Load and extract audio data from the provided file paths
+            let loadedAudioResult = await AudioProcessor.loadAudio(at: audioPaths, channelMode: resolvedOptions.channelMode)
+            let audioArrays = loadedAudioResult.compactMap { try? $0.get() }
 
-        // Calculate the time taken to load and convert audio
-        let loadAndConvertTime = Date().timeIntervalSince(loadAudioStart)
-        currentTimings.audioLoading = loadAndConvertTime
-        Logging.debug("Total Audio Loading and Converting Time: \(loadAndConvertTime)")
+            // Calculate the time taken to load and convert audio
+            let loadAndConvertTime = Date().timeIntervalSince(loadAudioStart)
+            currentTimings.audioLoading = loadAndConvertTime
+            Logging.debug("Total Audio Loading and Converting Time: \(loadAndConvertTime)")
 
-        transcriptionStateCallback?(.transcribing)
-        defer {
-            transcriptionStateCallback?(.finished)
-        }
-
-        // Transcribe the loaded audio arrays
-        let transcribeResults = await transcribeWithResults(
-            audioArrays: audioArrays,
-            decodeOptions: decodeOptions,
-            callback: callback
-        )
-
-        // Initialize the result array to hold final transcription results
-        var result = [Result<[TranscriptionResult], Swift.Error>]()
-        var transcribeResultIndex = 0
-
-        // Iterate over loadedAudioResult and map each to the corresponding transcription result
-        for audioResult in loadedAudioResult {
-            switch audioResult {
-                case .success:
-                    // Append transcription result if audio loading was successful (may still contain failure)
-                    result.append(transcribeResults[transcribeResultIndex])
-                    transcribeResultIndex += 1
-                case let .failure(error):
-                    // Append failure result if audio loading failed
-                    result.append(.failure(error))
+            transcriptionStateCallback?(.transcribing)
+            defer {
+                transcriptionStateCallback?(.finished)
             }
+
+            // Transcribe the loaded audio arrays
+            let transcribeResults = await transcribeWithResults(
+                audioArrays: audioArrays,
+                decodeOptions: decodeOptions,
+                callback: callback
+            )
+
+            // Initialize the result array to hold final transcription results
+            var result = [Result<[TranscriptionResult], Swift.Error>]()
+            var transcribeResultIndex = 0
+
+            // Iterate over loadedAudioResult and map each to the corresponding transcription result
+            for audioResult in loadedAudioResult {
+                switch audioResult {
+                    case .success:
+                        // Append transcription result if audio loading was successful (may still contain failure)
+                        result.append(transcribeResults[transcribeResultIndex])
+                        transcribeResultIndex += 1
+                    case let .failure(error):
+                        // Append failure result if audio loading failed
+                        result.append(.failure(error))
+                }
+            }
+
+            return result
+        case .incremental(let chunkDurationSeconds, let maxBufferedChunks):
+            // Start timing the audio streaming and transcription process right away, skip .convertingAudio
+            transcriptionStateCallback?(.transcribing)
+            defer {
+                transcriptionStateCallback?(.finished)
+            }
+            let transcriptionStart = Date()
+            let concurrentWorkerCount = decodeOptions?.concurrentWorkerCount ?? 0
+            let indexedAudioPaths = audioPaths.enumerated().map { (index: $0.offset, path: $0.element) }
+            let batchedAudioPaths = concurrentWorkerCount == 0 ? [indexedAudioPaths] : indexedAudioPaths.batched(into: concurrentWorkerCount)
+
+            var result = [Result<[TranscriptionResult], Swift.Error>]()
+            for audioPathBatch in batchedAudioPaths {
+                let partialResult = await withTaskGroup(of: (index: Int, result: Result<[TranscriptionResult], Swift.Error>).self) { taskGroup -> [Result<[TranscriptionResult], Swift.Error>] in
+                    let weakSelf = WeakSendableWrapper(self)
+                    for indexedAudioPath in audioPathBatch {
+                        taskGroup.addTask {
+                            do {
+                                guard let self = weakSelf.value else {
+                                    return (index: indexedAudioPath.index, result: .failure(WhisperError.transcriptionFailed("WhisperKit instance was deallocated")))
+                                }
+                                let audioStream = try AudioProcessor.loadFileIncrementally(
+                                    fromPath: indexedAudioPath.path,
+                                    channelMode: resolvedOptions.channelMode,
+                                    chunkDurationSeconds: chunkDurationSeconds,
+                                    maxBufferedChunks: maxBufferedChunks,
+                                    maxChunkLength: self.featureExtractor.windowSamples ?? Constants.defaultWindowSamples,
+                                    vad: self.voiceActivityDetector ?? EnergyVAD()
+                                )
+                                let transcriptionResults = try await self.transcribeFileStream(
+                                    audioStream: audioStream,
+                                    decodeOptions: decodeOptions,
+                                    callback: callback,
+                                    emitStateCallbacks: false
+                                )
+                                return (index: indexedAudioPath.index, result: .success(transcriptionResults))
+                            } catch {
+                                return (index: indexedAudioPath.index, result: .failure(error))
+                            }
+                        }
+                    }
+
+                    var batchResults = [(index: Int, result: Result<[TranscriptionResult], Swift.Error>)]()
+                    for await taskResult in taskGroup {
+                        batchResults.append(taskResult)
+                    }
+
+                    batchResults.sort(by: { $0.index < $1.index })
+                    return batchResults.map { $0.result }
+                }
+                result.append(contentsOf: partialResult)
+            }
+
+            let audioProcessTime = Date().timeIntervalSince(transcriptionStart)
+            currentTimings.audioProcessing = audioProcessTime
+            Logging.debug("Total Audio Streaming and Transcription Time: \(audioProcessTime)")
+            return result
         }
 
-        return result
+
+
     }
 
     // MARK: - Transcribe multiple audio arrays
@@ -755,10 +842,9 @@ open class WhisperKit {
                     let batchedSegmentCallback: SegmentDiscoveryCallback? = if let seekOffsets {
                         { [segmentDiscoveryCallback] segments in
                             let windowId = audioIndex + batchIndex * batchSize
-                            let seekOffset = seekOffsets[windowId]
-                            var adjustedSegments = segments
-                            for i in 0..<adjustedSegments.count {
-                                adjustedSegments[i].seek += Int(seekOffset)
+                            let seekTimeOffset = Float(seekOffsets[windowId]) / Float(WhisperKit.sampleRate)
+                            let adjustedSegments = segments.map {
+                                TranscriptionUtilities.updateSegmentTimings(segment: $0, seekTime: seekTimeOffset)
                             }
                             segmentDiscoveryCallback?(adjustedSegments)
                         }
@@ -817,41 +903,75 @@ open class WhisperKit {
     /// - Parameters:
     ///   - audioPath: The file path to the audio file to be transcribed.
     ///   - decodeOptions: Options for how to transcribe audio. Includes a chunking strategy and the number of concurrent workers to parallelize the task.
+    ///   - audioInputOptions: Channel processing and file-loading options. When `nil`, the instance's `audioInputOptions` is used (full-file loading by default).
     ///   - callback: Optional callback to receive updates during the transcription process.
     /// - Returns: An array of `TranscriptionResult`.
     /// - Throws: An error if the transcription fails.
+    ///
+    /// - Note: The default loading mode will change to `.incremental` in a future major version.
+    ///   Consider using `.incremental` for large audio files to reduce memory usage.
     open func transcribe(
         audioPath: String,
+        audioInputOptions: AudioInputOptions? = nil,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil
     ) async throws -> [TranscriptionResult] {
-        transcriptionStateCallback?(.convertingAudio)
+        let resolvedOptions = audioInputOptions ?? self.audioInputOptions
+        switch resolvedOptions.audioLoadingMode {
+        case .fullFile:
+            transcriptionStateCallback?(.convertingAudio)
 
-        // Process input audio file into audio samples
-        let audioArray = try await withThrowingTaskGroup(of: [Float].self) { group -> [Float] in
-            let convertAudioStart = Date()
-            defer {
-                let convertTime = Date().timeIntervalSince(convertAudioStart)
-                currentTimings.audioLoading = convertTime
-                Logging.debug("Audio loading and convert time: \(convertTime)")
-                Logging.logCurrentMemoryUsage("Audio Loading and Convert")
+            // Process input audio file into audio samples
+            let audioArray = try await withThrowingTaskGroup(of: [Float].self) { group -> [Float] in
+                let convertAudioStart = Date()
+                defer {
+                    let convertTime = Date().timeIntervalSince(convertAudioStart)
+                    currentTimings.audioLoading = convertTime
+                    Logging.debug("Audio loading and convert time: \(convertTime)")
+                    Logging.logCurrentMemoryUsage("Audio Loading and Convert")
+                }
+                return try AudioProcessor.loadAudioAsFloatArray(fromPath: audioPath, channelMode: resolvedOptions.channelMode)
             }
-            return try AudioProcessor.loadAudioAsFloatArray(fromPath: audioPath, channelMode: audioInputConfig.channelMode)
+
+            transcriptionStateCallback?(.transcribing)
+            defer {
+                transcriptionStateCallback?(.finished)
+            }
+
+            // Send converted samples to be transcribed
+            let transcribeResults: [TranscriptionResult] = try await transcribe(
+                audioArray: audioArray,
+                decodeOptions: decodeOptions,
+                callback: callback
+            )
+
+            return transcribeResults
+        case .incremental(let chunkDurationSeconds, let maxBufferedChunks):
+            let audioLoadStart = Date()
+            defer {
+                let audioLoadTime = Date().timeIntervalSince(audioLoadStart)
+                currentTimings.audioLoading = audioLoadTime
+                Logging.debug("Audio streaming and transcription time: \(audioLoadTime)")
+                Logging.logCurrentMemoryUsage("Audio Streaming")
+            }
+
+            // Create audio stream for memory-efficient processing
+            let audioStream = try AudioProcessor.loadFileIncrementally(
+                fromPath: audioPath,
+                channelMode: resolvedOptions.channelMode,
+                chunkDurationSeconds: chunkDurationSeconds,
+                maxBufferedChunks: maxBufferedChunks,
+                maxChunkLength: featureExtractor.windowSamples ?? Constants.defaultWindowSamples,
+                vad: voiceActivityDetector ?? EnergyVAD()
+            )
+
+            // Process audio stream
+            return try await transcribeFileStream(
+                audioStream: audioStream,
+                decodeOptions: decodeOptions,
+                callback: callback
+            )
         }
-
-        transcriptionStateCallback?(.transcribing)
-        defer {
-            transcriptionStateCallback?(.finished)
-        }
-
-        // Send converted samples to be transcribed
-        let transcribeResults: [TranscriptionResult] = try await transcribe(
-            audioArray: audioArray,
-            decodeOptions: decodeOptions,
-            callback: callback
-        )
-
-        return transcribeResults
     }
 
     // MARK: - Transcribe single audio sample array
@@ -859,6 +979,7 @@ open class WhisperKit {
     /// Main entry point for transcribing audio
     /// - Parameters:
     ///   - audioArray: Array of 16khz raw float audio samples
+    ///   - audioArrayOffset: Offset of input Array if it's a subarray of a larger array, used to align segment callback
     ///   - decodeOptions: Options for how to transcribe audio. Including a chunking strategy and the number of concurrent workers will paralleize this task.
     ///   - callback: Optional callback to receive updates during the transcription process.
     ///   - segmentCallback: Optional callback to receive segment discovery updates during transcription.
@@ -866,6 +987,7 @@ open class WhisperKit {
     /// - Throws: An error if the transcription fails.
     open func transcribe(
         audioArray: [Float],
+        audioArrayOffset: Int = 0,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil,
         segmentCallback: SegmentDiscoveryCallback? = nil
@@ -898,7 +1020,7 @@ open class WhisperKit {
                 let chunkedResults: [Result<[TranscriptionResult], Swift.Error>] = await transcribeWithOptions(
                     audioArrays: audioChunks.map { $0.audioSamples },
                     decodeOptionsArray: chunkedDecodeOptions,
-                    seekOffsets: audioChunks.map { $0.seekOffsetIndex },
+                    seekOffsets: audioChunks.map { audioArrayOffset + $0.seekOffsetIndex },
                     callback: callback
                 )
 
@@ -911,11 +1033,29 @@ open class WhisperKit {
                 transcribeResults = updatedTranscriptionResults
             default:
                 // Audio is short enough to transcribe in a single window and doesn't require chunking
+                // Adjust discovered segment offsets when this audio array represents a slice of a larger file.
+                let decoratedSegmentCallback: SegmentDiscoveryCallback? = {
+                    guard audioArrayOffset > 0 else {
+                        return segmentCallback ?? self.segmentDiscoveryCallback
+                    }
+
+                    guard let actualCallback = segmentCallback ?? self.segmentDiscoveryCallback else {
+                        return nil
+                    }
+
+                    let seekTimeOffset = Float(audioArrayOffset) / Float(WhisperKit.sampleRate)
+                    return { segments in
+                        let adjustedSegments = segments.map {
+                            TranscriptionUtilities.updateSegmentTimings(segment: $0, seekTime: seekTimeOffset)
+                        }
+                        actualCallback(adjustedSegments)
+                    }
+                }()
                 transcribeResults = try await runTranscribeTask(
                     audioArray: audioArray,
                     decodeOptions: decodeOptions,
                     callback: callback,
-                    segmentCallback: segmentCallback ?? self.segmentDiscoveryCallback
+                    segmentCallback: decoratedSegmentCallback
                 )
         }
 
@@ -1016,5 +1156,75 @@ open class WhisperKit {
             }
             throw error
         }
+    }
+
+
+    /// Transcribes audio data from an async throwing stream of audio chunks, optimizing memory usage for large files.
+    /// This function processes audio chunks as they become available rather than loading entire files into memory.
+    /// - Parameters:
+    ///   - audioStream: Async throwing stream yielding audio chunks with position information
+    ///   - decodeOptions: Options for how to transcribe audio. Includes a chunking strategy and the number of concurrent workers to parallelize the task.
+    ///   - callback: Optional callback to receive updates during the transcription process.
+    /// - Returns: An array of `TranscriptionResult` sorted by timestamp.
+    /// - Throws: An error if the transcription fails.
+    private func transcribeFileStream(
+        audioStream: AudioProcessor.IncrementalFileStream,
+        decodeOptions: DecodingOptions? = nil,
+        callback: TranscriptionCallback? = nil,
+        emitStateCallbacks: Bool = true
+    ) async throws -> [TranscriptionResult] {
+        // clipTimestamps are file-relative, but each streamed chunk decodes from its own sample 0, so
+        // they cannot be honored per chunk. Reject explicitly rather than produce incorrect output.
+        if let clipTimestamps = decodeOptions?.clipTimestamps, !clipTimestamps.isEmpty {
+            throw WhisperError.transcriptionFailed(
+                "clipTimestamps is not supported with AudioLoadingMode.incremental. Use .fullFile, or transcribe the desired range as a separate call."
+            )
+        }
+
+        var allResults = [TranscriptionResult]()
+
+        if emitStateCallbacks {
+            transcriptionStateCallback?(.transcribing)
+        }
+        defer {
+            if emitStateCallbacks {
+                transcriptionStateCallback?(.finished)
+            }
+        }
+
+        for try await chunk in audioStream {
+            defer {
+                chunk.completionSignal()
+            }
+
+            // Process each chunk using the main transcribe function
+            let chunkResults: [TranscriptionResult] = try await transcribe(
+                audioArray: chunk.audioChunk.audioSamples,
+                audioArrayOffset: chunk.audioChunk.seekOffsetIndex,
+                decodeOptions: decodeOptions,
+                callback: callback
+            )
+
+            // Update timestamps based on chunk's seek offset
+            let seekTimeOffset = Float(chunk.audioChunk.seekOffsetIndex) / Float(WhisperKit.sampleRate)
+            let adjustedResults = chunkResults.map { result in
+                let adjustedSegments = result.segments.map { segment in
+                    TranscriptionUtilities.updateSegmentTimings(segment: segment, seekTime: seekTimeOffset)
+                }
+
+                return TranscriptionResult(
+                    text: result.text,
+                    segments: adjustedSegments,
+                    language: result.language,
+                    timings: result.timings,
+                    seekTime: seekTimeOffset + (result.seekTime ?? 0)
+                )
+            }
+
+            allResults.append(contentsOf: adjustedResults)
+        }
+
+        // Sort by absolute seek time for a stable total order, including chunks with no segments.
+        return allResults.sorted { ($0.seekTime ?? 0) < ($1.seekTime ?? 0) }
     }
 }

--- a/Sources/WhisperKit/Core/WhisperKit.swift
+++ b/Sources/WhisperKit/Core/WhisperKit.swift
@@ -842,9 +842,8 @@ open class WhisperKit {
                     let batchedSegmentCallback: SegmentDiscoveryCallback? = if let seekOffsets {
                         { [segmentDiscoveryCallback] segments in
                             let windowId = audioIndex + batchIndex * batchSize
-                            let seekTimeOffset = Float(seekOffsets[windowId]) / Float(WhisperKit.sampleRate)
                             let adjustedSegments = segments.map {
-                                TranscriptionUtilities.updateSegmentTimings(segment: $0, seekTime: seekTimeOffset)
+                                TranscriptionUtilities.updateSegmentTimings(segment: $0, seekOffsetIndex: seekOffsets[windowId])
                             }
                             segmentDiscoveryCallback?(adjustedSegments)
                         }
@@ -979,6 +978,29 @@ open class WhisperKit {
     /// Main entry point for transcribing audio
     /// - Parameters:
     ///   - audioArray: Array of 16khz raw float audio samples
+    ///   - decodeOptions: Options for how to transcribe audio. Including a chunking strategy and the number of concurrent workers will paralleize this task.
+    ///   - callback: Optional callback to receive updates during the transcription process.
+    ///   - segmentCallback: Optional callback to receive segment discovery updates during transcription.
+    /// - Returns: An array of sorted `TranscriptionResult`.
+    /// - Throws: An error if the transcription fails.
+    open func transcribe(
+        audioArray: [Float],
+        decodeOptions: DecodingOptions? = nil,
+        callback: TranscriptionCallback? = nil,
+        segmentCallback: SegmentDiscoveryCallback? = nil
+    ) async throws -> [TranscriptionResult] {
+        try await transcribe(
+            audioArray: audioArray,
+            audioArrayOffset: 0,
+            decodeOptions: decodeOptions,
+            callback: callback,
+            segmentCallback: segmentCallback
+        )
+    }
+
+    /// Transcribes an audio array that is a slice of a larger source, aligning discovered segments to the source.
+    /// - Parameters:
+    ///   - audioArray: Array of 16khz raw float audio samples
     ///   - audioArrayOffset: Offset of input Array if it's a subarray of a larger array, used to align segment callback
     ///   - decodeOptions: Options for how to transcribe audio. Including a chunking strategy and the number of concurrent workers will paralleize this task.
     ///   - callback: Optional callback to receive updates during the transcription process.
@@ -987,7 +1009,7 @@ open class WhisperKit {
     /// - Throws: An error if the transcription fails.
     open func transcribe(
         audioArray: [Float],
-        audioArrayOffset: Int = 0,
+        audioArrayOffset: Int,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil,
         segmentCallback: SegmentDiscoveryCallback? = nil
@@ -1043,10 +1065,9 @@ open class WhisperKit {
                         return nil
                     }
 
-                    let seekTimeOffset = Float(audioArrayOffset) / Float(WhisperKit.sampleRate)
                     return { segments in
                         let adjustedSegments = segments.map {
-                            TranscriptionUtilities.updateSegmentTimings(segment: $0, seekTime: seekTimeOffset)
+                            TranscriptionUtilities.updateSegmentTimings(segment: $0, seekOffsetIndex: audioArrayOffset)
                         }
                         actualCallback(adjustedSegments)
                     }
@@ -1207,21 +1228,14 @@ open class WhisperKit {
 
             // Update timestamps based on chunk's seek offset
             let seekTimeOffset = Float(chunk.audioChunk.seekOffsetIndex) / Float(WhisperKit.sampleRate)
-            let adjustedResults = chunkResults.map { result in
-                let adjustedSegments = result.segments.map { segment in
-                    TranscriptionUtilities.updateSegmentTimings(segment: segment, seekTime: seekTimeOffset)
+            for result in chunkResults {
+                result.segments = result.segments.map { segment in
+                    TranscriptionUtilities.updateSegmentTimings(segment: segment, seekOffsetIndex: chunk.audioChunk.seekOffsetIndex)
                 }
-
-                return TranscriptionResult(
-                    text: result.text,
-                    segments: adjustedSegments,
-                    language: result.language,
-                    timings: result.timings,
-                    seekTime: seekTimeOffset + (result.seekTime ?? 0)
-                )
+                result.seekTime = seekTimeOffset + (result.seekTime ?? 0)
             }
 
-            allResults.append(contentsOf: adjustedResults)
+            allResults.append(contentsOf: chunkResults)
         }
 
         // Sort by absolute seek time for a stable total order, including chunks with no segments.

--- a/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
+++ b/Sources/WhisperKit/Utilities/TranscriptionUtilities.swift
@@ -47,6 +47,29 @@ public struct TranscriptionUtilities {
         return Array(remainingWords)
     }
 
+    /// Updates the timings of a transcription segment by adding an exact sample offset.
+    /// Prefer this over the `seekTime:` variant when the sample offset is known, since
+    /// `Float` seconds cannot represent all sample indices in long audio.
+    /// - Parameters:
+    ///   - segment: The transcription segment to update
+    ///   - seekOffsetIndex: The sample offset to add to `seek`; time-based fields are offset by the equivalent seconds
+    /// - Returns: Updated transcription segment with adjusted timings
+    public static func updateSegmentTimings(segment: TranscriptionSegment, seekOffsetIndex: Int) -> TranscriptionSegment {
+        var updatedSegment = segment
+        let seekTime = Float(seekOffsetIndex) / Float(WhisperKit.sampleRate)
+        updatedSegment.seek += seekOffsetIndex
+        updatedSegment.start += seekTime
+        updatedSegment.end += seekTime
+        if var words = updatedSegment.words {
+            for wordIndex in 0..<words.count {
+                words[wordIndex].start += seekTime
+                words[wordIndex].end += seekTime
+            }
+            updatedSegment.words = words
+        }
+        return updatedSegment
+    }
+
     /// Updates the timings of a transcription segment by adding a seek time offset
     /// - Parameters:
     ///   - segment: The transcription segment to update

--- a/Tests/WhisperKitTests/AudioProcessorTests.swift
+++ b/Tests/WhisperKitTests/AudioProcessorTests.swift
@@ -1,0 +1,530 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2024 Argmax, Inc. All rights reserved.
+
+import AVFoundation
+import os.lock
+import XCTest
+@testable import WhisperKit
+
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+final class AudioProcessorTests: XCTestCase {
+
+    /// The incremental loader emits VAD windows (each ≤ one model window) and the concatenation
+    /// of all chunks reconstructs the original audio with contiguous seek offsets — no samples
+    /// lost, duplicated, or reordered.
+    func testIncrementalChunksAreVadWindowsAndReconstructAudio() async throws {
+        let mockAudioPath = try createMockAudioFile16k(duration: 100.0)
+        defer { try? FileManager.default.removeItem(atPath: mockAudioPath) }
+
+        let fullAudio = try AudioProcessor.loadAudioAsFloatArray(fromPath: mockAudioPath)
+        let result = try await collectIncrementalChunks(path: mockAudioPath, chunkDurationSeconds: 30.0)
+        assertChunksAreVadWindowsAndReconstruct(result, fullAudio: fullAudio)
+    }
+
+    /// Streams `path` incrementally and returns each emitted chunk's (seek offset, sample count)
+    /// plus the concatenation of all emitted samples.
+    private func collectIncrementalChunks(
+        path: String,
+        chunkDurationSeconds: Double
+    ) async throws -> (chunks: [(offset: Int, count: Int)], samples: [Float]) {
+        var chunks: [(offset: Int, count: Int)] = []
+        var samples: [Float] = []
+        let stream = try AudioProcessor.loadFileIncrementally(
+            fromPath: path,
+            chunkDurationSeconds: chunkDurationSeconds,
+            maxBufferedChunks: 2
+        )
+        for try await chunk in stream {
+            chunks.append((chunk.audioChunk.seekOffsetIndex, chunk.audioChunk.audioSamples.count))
+            samples.append(contentsOf: chunk.audioChunk.audioSamples)
+            chunk.completionSignal()
+        }
+        return (chunks, samples)
+    }
+
+    private func assertChunksAreVadWindowsAndReconstruct(
+        _ result: (chunks: [(offset: Int, count: Int)], samples: [Float]),
+        fullAudio: [Float],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let maxChunkLength = Constants.defaultWindowSamples
+        XCTAssertFalse(result.chunks.isEmpty, "expected at least one chunk", file: file, line: line)
+
+        var expectedOffset = 0
+        for (i, chunk) in result.chunks.enumerated() {
+            XCTAssertGreaterThan(chunk.count, 0, "chunk \(i) is empty", file: file, line: line)
+            XCTAssertLessThanOrEqual(chunk.count, maxChunkLength, "chunk \(i) exceeds one model window", file: file, line: line)
+            XCTAssertEqual(chunk.offset, expectedOffset, "chunk \(i) seek offset is not contiguous", file: file, line: line)
+            expectedOffset += chunk.count
+        }
+        XCTAssertEqual(result.samples.count, fullAudio.count, "reconstructed sample count differs from source", file: file, line: line)
+        XCTAssertEqual(result.samples, fullAudio, "reconstructed audio differs from source", file: file, line: line)
+    }
+
+    /// Same property on audio with explicit silence regions: chunks remain VAD windows and the
+    /// concatenation reconstructs the source exactly.
+    func testIncrementalChunksReconstructAudioWithSilence() async throws {
+        let mockAudioPath = try createMockAudioFile16k(
+            duration: 300.0,
+            silenceRanges: [(80.0, 90.0), (180.0, 190.0), (280.0, 290.0)]
+        )
+        defer { try? FileManager.default.removeItem(atPath: mockAudioPath) }
+
+        let fullAudio = try AudioProcessor.loadAudioAsFloatArray(fromPath: mockAudioPath)
+        let result = try await collectIncrementalChunks(path: mockAudioPath, chunkDurationSeconds: 120.0)
+        assertChunksAreVadWindowsAndReconstruct(result, fullAudio: fullAudio)
+    }
+
+    /// The emitted chunk boundaries must be identical regardless of the read/staging size
+    /// (`chunkDurationSeconds`): buffering in 7 s, 30 s, or 120 s reads must still yield the same model
+    /// chunks. Read size only affects peak memory, never the chunks fed to the model.
+    func testIncrementalChunkBoundariesAreIndependentOfReadSize() async throws {
+        let mockAudioPath = try createMockAudioFile16k(
+            duration: 300.0,
+            silenceRanges: [(80.0, 90.0), (180.0, 190.0), (280.0, 290.0)]
+        )
+        defer { try? FileManager.default.removeItem(atPath: mockAudioPath) }
+
+        let readSizes: [Double] = [7.0, 30.0, 120.0]
+        var boundariesPerReadSize: [[Int]] = []
+        for readSize in readSizes {
+            let result = try await collectIncrementalChunks(path: mockAudioPath, chunkDurationSeconds: readSize)
+            // Running boundaries: each chunk's start offset, plus the final end offset.
+            let bounds = result.chunks.map { $0.offset } + [result.chunks.last.map { $0.offset + $0.count } ?? 0]
+            boundariesPerReadSize.append(bounds)
+        }
+
+        let reference = boundariesPerReadSize[0]
+        for (i, bounds) in boundariesPerReadSize.enumerated() {
+            XCTAssertEqual(bounds, reference, "chunk boundaries differ at read size \(readSizes[i]) s (must be independent of read size)")
+        }
+    }
+
+    /// Tests incremental loading with single partial chunk.
+    /// Verifies that audio shorter than chunk duration produces exactly 1 chunk
+    func testIncrementalLoadSinglePartialChunk() async throws {
+        // Create a mock audio file of 5 seconds (less than 10 second chunk duration)
+        let mockAudioPath = try createMockAudioFile16k(duration: 5.0)
+        let chunkDurationSeconds: Double = 10.0
+        let partialChunkSize = 5 * WhisperKit.sampleRate
+
+        defer {
+            try? FileManager.default.removeItem(atPath: mockAudioPath)
+        }
+
+        var processedChunks = 0
+
+        let stream = try AudioProcessor.loadFileIncrementally(
+            fromPath: mockAudioPath,
+            chunkDurationSeconds: chunkDurationSeconds,
+            maxBufferedChunks: 2
+        )
+
+        for try await chunk in stream {
+            processedChunks += 1
+            let actualSize = chunk.audioChunk.audioSamples.count
+
+            // Chunk should be partial-sized
+            // For 5 second audio with 10 second chunks, chunk should be 5 seconds
+            assertChunkSizeWithinTolerance(
+                actualSize: actualSize,
+                expectedSize: partialChunkSize
+            )
+            chunk.completionSignal()
+        }
+
+        XCTAssertEqual(processedChunks, 1, "Should process exactly 1 chunk for 5 second audio with 10 second chunks")
+    }
+
+    /// Tests incremental loading with zero-length audio.
+    /// Verifies that empty audio files are handled gracefully
+    func testIncrementalLoadZeroLength() async throws {
+        // Create a mock audio file of 0 seconds
+        let mockAudioPath = try createMockAudioFile16k(duration: 0.0)
+        let chunkDurationSeconds: Double = 10.0
+
+        defer {
+            try? FileManager.default.removeItem(atPath: mockAudioPath)
+        }
+
+        var processedChunks = 0
+
+        let stream = try AudioProcessor.loadFileIncrementally(
+            fromPath: mockAudioPath,
+            chunkDurationSeconds: chunkDurationSeconds,
+            maxBufferedChunks: 2
+        )
+
+        for try await chunk in stream {
+            processedChunks += 1
+            chunk.completionSignal()
+        }
+
+        XCTAssertEqual(processedChunks, 0, "Should process 0 chunks for zero-length audio")
+    }
+
+    /// Tests incremental loading with non-existent file.
+    /// Verifies that missing files are handled with appropriate error
+    func testIncrementalLoadNonExistentFile() async throws {
+        let nonExistentPath = "/tmp/non_existent_audio_file.wav"
+
+        let chunkDurationSeconds: Double = 10.0
+
+        XCTAssertThrowsError(
+            try AudioProcessor.loadFileIncrementally(
+                fromPath: nonExistentPath,
+                chunkDurationSeconds: chunkDurationSeconds,
+                maxBufferedChunks: 2
+            )
+        ) { error in
+            XCTAssertTrue(error is WhisperError, "Should throw WhisperError when audio file does not exist")
+        }
+    }
+
+    /// Verifies incremental multi-file transcription respects
+    /// `concurrentWorkerCount` while keeping results aligned with the original
+    /// path list, including failures that complete before successful files.
+    func testIncrementalMultiFileTranscriptionRespectsConcurrentWorkerCountAndOrder() async throws {
+        let firstAudioPath = try createMockAudioFile16k(duration: 1.0)
+        let secondAudioPath = try createMockAudioFile16k(duration: 2.0)
+        let thirdAudioPath = try createMockAudioFile16k(duration: 3.0)
+        let missingAudioPath = "/path/to/missing-incremental-audio.wav"
+        defer {
+            try? FileManager.default.removeItem(atPath: firstAudioPath)
+            try? FileManager.default.removeItem(atPath: secondAudioPath)
+            try? FileManager.default.removeItem(atPath: thirdAudioPath)
+        }
+
+        let tracker = ConcurrentTranscriptionTracker()
+        let whisperKit = try await ConcurrencyTrackingWhisperKit(
+            tracker: tracker,
+            delayNanoseconds: 100_000_000
+        )
+        let transcriptionResults = await whisperKit.transcribeWithResults(
+            audioPaths: [
+                firstAudioPath,
+                missingAudioPath,
+                secondAudioPath,
+                thirdAudioPath,
+            ],
+            audioInputOptions: AudioInputOptions(audioLoadingMode: .incremental(chunkDurationSeconds: 600, maxBufferedChunks: 2)),
+            decodeOptions: DecodingOptions(concurrentWorkerCount: 2)
+        )
+
+        XCTAssertEqual(transcriptionResults.count, 4)
+        let firstSampleCount = try sampleCount(from: transcriptionResults[0])
+        XCTAssertEqual(
+            transcriptionResults[1].whisperError(),
+            .loadAudioFailed("Audio file not found at path: \(missingAudioPath)")
+        )
+        let secondSampleCount = try sampleCount(from: transcriptionResults[2])
+        let thirdSampleCount = try sampleCount(from: transcriptionResults[3])
+        XCTAssertLessThan(firstSampleCount, secondSampleCount)
+        XCTAssertLessThan(secondSampleCount, thirdSampleCount)
+
+        let concurrencySnapshot = await tracker.snapshot()
+        XCTAssertEqual(concurrencySnapshot.maxActiveCount, 2)
+        XCTAssertEqual(concurrencySnapshot.totalStartedCount, 3)
+    }
+
+    /// Tests incremental loading with invalid chunk configuration
+    /// Verifies that values which cannot make progress are rejected before stream creation
+    func testIncrementalLoadRejectsInvalidParameters() throws {
+        let mockAudioPath = try createMockAudioFile16k(duration: 1.0)
+        defer {
+            try? FileManager.default.removeItem(atPath: mockAudioPath)
+        }
+
+        XCTAssertThrowsError(
+            try AudioProcessor.loadFileIncrementally(
+                fromPath: mockAudioPath,
+                chunkDurationSeconds: 0,
+                maxBufferedChunks: 2
+            )
+        ) { error in
+            XCTAssertTrue(error is WhisperError, "Should throw WhisperError when chunk duration is invalid")
+        }
+
+        XCTAssertThrowsError(
+            try AudioProcessor.loadFileIncrementally(
+                fromPath: mockAudioPath,
+                chunkDurationSeconds: 10.0,
+                maxBufferedChunks: 0
+            )
+        ) { error in
+            XCTAssertTrue(error is WhisperError, "Should throw WhisperError when chunk buffer size is invalid")
+        }
+    }
+
+    /// On stream termination a producer suspended waiting for a slot must be resumed (not orphaned),
+    /// and any subsequent slot request must return immediately instead of suspending forever.
+    func testIncrementalLoadControllerTerminationResumesWaitingProducer() async throws {
+        let controller = IncrementalLoadController(maxBufferedChunks: 1)
+        await controller.requestChunkSlot() // fill the only slot
+
+        // A second request suspends because the buffer is full.
+        let waiter = Task { await controller.requestChunkSlot() }
+        try? await Task.sleep(nanoseconds: 50_000_000) // let the waiter suspend
+
+        // Termination must resume the suspended producer.
+        await controller.resumeWaitingProducers()
+        let waiterTimedOut = await withTimeout(seconds: 2) { await waiter.value }
+        XCTAssertFalse(waiterTimedOut, "Waiting producer should be resumed on termination")
+
+        // After termination a fresh request returns immediately rather than suspending.
+        let nextTimedOut = await withTimeout(seconds: 2) { await controller.requestChunkSlot() }
+        XCTAssertFalse(nextTimedOut, "requestChunkSlot should return immediately after termination")
+    }
+
+    /// Verifies the VAD windows fed to the model are identical in full-file and incremental modes,
+    /// so the loading strategy does not change the chunks provided to inference.
+    func testIncrementalVsFullFileModelChunkParity() async throws {
+        // 5 minutes of tone with a 0.8 s silence every 12 s so VAD has boundaries to cut on.
+        var silences: [(start: Double, end: Double)] = []
+        var t = 12.0
+        while t < 300.0 { silences.append((t, t + 0.8)); t += 12.0 }
+        let path = try createMockAudioFile16k(duration: 300.0, silenceRanges: silences)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let maxLen = Constants.defaultWindowSamples
+        let opts = DecodingOptions()
+
+        // FULL-FILE: load the whole file and VAD-chunk once (what transcribe(.fullFile) feeds the model).
+        let full = try AudioProcessor.loadAudioAsFloatArray(fromPath: path)
+        let fullChunks = try await VADAudioChunker(vad: EnergyVAD())
+            .chunkAll(audioArray: full, maxChunkLength: maxLen, decodeOptions: opts)
+        let fullWindows = fullChunks.map { ($0.seekOffsetIndex, $0.audioSamples.count) }
+
+        // INCREMENTAL: stream file-chunks, VAD-chunk each independently, map to global offsets.
+        var incWindows: [(Int, Int)] = []
+        let stream = try AudioProcessor.loadFileIncrementally(fromPath: path, chunkDurationSeconds: 120, maxBufferedChunks: 8)
+        for try await chunk in stream {
+            defer { chunk.completionSignal() }
+            let subs = try await VADAudioChunker(vad: EnergyVAD())
+                .chunkAll(audioArray: chunk.audioChunk.audioSamples, maxChunkLength: maxLen, decodeOptions: opts)
+            for s in subs {
+                incWindows.append((chunk.audioChunk.seekOffsetIndex + s.seekOffsetIndex, s.audioSamples.count))
+            }
+        }
+
+        // The model windows must be identical between full-file and incremental modes: the same
+        // audio chunks in, the same results out, with peak memory the only intended difference.
+        XCTAssertEqual(incWindows.map { $0.0 }, fullWindows.map { $0.0 }, "window start offsets must be identical (full vs incremental)")
+        XCTAssertEqual(incWindows.map { $0.1 }, fullWindows.map { $0.1 }, "window lengths must be identical (full vs incremental)")
+    }
+
+    /// Tests incremental loading with a file that exists but cannot be decoded as audio
+    /// Verifies that async file initialization errors are surfaced through the throwing stream
+    func testIncrementalLoadUnreadableFileThrows() async throws {
+        let audioURL = FileManager.default.temporaryDirectory.appendingPathComponent("invalid_audio_\(UUID().uuidString).wav")
+        try "not an audio file".write(to: audioURL, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: audioURL)
+        }
+
+        let stream = try AudioProcessor.loadFileIncrementally(
+            fromPath: audioURL.path,
+            chunkDurationSeconds: 10.0,
+            maxBufferedChunks: 2
+        )
+
+        do {
+            for try await chunk in stream {
+                chunk.completionSignal()
+            }
+            XCTFail("Unreadable audio should throw from the incremental stream")
+        } catch {
+            XCTAssertFalse(error is CancellationError, "Unreadable audio should fail with an audio loading error")
+        }
+    }
+
+    /// Tests back-pressure mechanism by not calling completionSignal
+    /// and verifying the stream gets stuck after receiving maxBufferSize chunks
+    func testIncrementalLoadBackPressureBlocking() async throws {
+        // 100 s produces several VAD windows (> maxBufferSize), so back-pressure can engage.
+        let mockAudioPath = try createMockAudioFile16k(duration: 100.0)
+        defer {
+            try? FileManager.default.removeItem(atPath: mockAudioPath)
+        }
+
+        let maxBufferSize = 2
+        let receivedChunks = OSAllocatedUnfairLock(initialState: 0)
+
+        let stream = try AudioProcessor.loadFileIncrementally(
+            fromPath: mockAudioPath,
+            chunkDurationSeconds: 10.0,
+            maxBufferedChunks: maxBufferSize
+        )
+
+        // Use withTimeout to test blocking behavior
+        let didTimeout = await withTimeout(seconds: 1) {
+            for try await _ in stream {
+                receivedChunks.withLock { count in
+                    count += 1
+                }
+                // Deliberately NOT calling completionSignal() to test blocking
+            }
+        }
+
+        // Verify that we received exactly maxBufferSize chunks before blocking
+        XCTAssertEqual(receivedChunks.withLock { $0 }, maxBufferSize, "Should receive exactly \(maxBufferSize) chunks before blocking due to back-pressure")
+
+        // Verify that the operation timed out (indicating incremental loading was blocked)
+        XCTAssertTrue(didTimeout, "Incremental loading should block after \(maxBufferSize) chunks, causing timeout")
+    }
+
+    /// Validates that a chunk size is within the expected range with 10% tolerance
+    /// - Parameters:
+    ///   - actualSize: The actual chunk size in samples
+    ///   - expectedSize: The theoretical expected size in samples
+    private func assertChunkSizeWithinTolerance(
+        actualSize: Int,
+        expectedSize: Int
+    ) {
+        let tolerancePercent = 0.1
+        let tolerance = Double(expectedSize) * tolerancePercent
+        let lowerBound = expectedSize - Int(tolerance)
+        let upperBound = expectedSize + Int(tolerance)
+
+        XCTAssertTrue(
+            actualSize >= lowerBound && actualSize <= upperBound,
+            "Chunk size \(actualSize) is outside expected range [\(lowerBound)-\(upperBound)] (theoretical: \(expectedSize))"
+        )
+    }
+
+    /// Creates a mock audio file at 16kHz sample rate.
+    /// - Parameters:
+    ///   - duration: Duration in seconds.
+    ///   - silenceRanges: Optional start/end second ranges to write as silence. Samples outside these ranges use a sine wave so EnergyVAD can distinguish speech from boundary silence.
+    /// - Returns: File path to the created audio file
+    private func createMockAudioFile16k(
+        duration: Double,
+        silenceRanges: [(start: Double, end: Double)] = []
+    ) throws -> String {
+        let documentsPath = FileManager.default.temporaryDirectory
+        let audioURL = documentsPath.appendingPathComponent("test_audio_16k_\(UUID().uuidString).wav")
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: Double(WhisperKit.sampleRate),
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsFloatKey: true
+        ]
+
+        let audioFile = try AVAudioFile(forWriting: audioURL, settings: settings)
+
+        let frameCount = AVAudioFrameCount(duration * Double(WhisperKit.sampleRate))
+        let buffer = AVAudioPCMBuffer(pcmFormat: audioFile.processingFormat, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+
+        // Fill with simple sine wave, leaving configured ranges silent.
+        let samples = buffer.floatChannelData![0]
+        for i in 0..<Int(frameCount) {
+            let seconds = Double(i) / Double(WhisperKit.sampleRate)
+            let isSilent = silenceRanges.contains { range in
+                seconds >= range.start && seconds < range.end
+            }
+            samples[i] = isSilent ? 0.0 : sin(2.0 * .pi * 440.0 * Float(i) / Float(WhisperKit.sampleRate)) * 0.5
+        }
+
+        try audioFile.write(from: buffer)
+        return audioURL.path
+    }
+
+    /// Extracts the deterministic sample-count payload emitted by
+    /// `ConcurrencyTrackingWhisperKit` from a transcription result.
+    private func sampleCount(from result: Result<[TranscriptionResult], Swift.Error>) throws -> Int {
+        let text = try XCTUnwrap(try result.get().first?.text)
+        let prefix = "samples-"
+        XCTAssertTrue(text.hasPrefix(prefix))
+        return try XCTUnwrap(Int(text.dropFirst(prefix.count)))
+    }
+}
+
+/// Tracks overlapping calls to the mocked transcription entry point so tests can
+/// assert that file-level batching limits active work.
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+private actor ConcurrentTranscriptionTracker {
+    private var activeCount = 0
+    private var maxActiveCount = 0
+    private var totalStartedCount = 0
+
+    /// Records that a transcription unit started and updates the observed peak
+    /// active count.
+    func recordStart() {
+        activeCount += 1
+        totalStartedCount += 1
+        maxActiveCount = max(maxActiveCount, activeCount)
+    }
+
+    /// Records that a transcription unit completed and removes it from the
+    /// active count.
+    func recordFinish() {
+        activeCount -= 1
+    }
+
+    /// Returns immutable counters for assertions after the transcription run
+    /// has completed.
+    func snapshot() -> (maxActiveCount: Int, totalStartedCount: Int) {
+        (maxActiveCount, totalStartedCount)
+    }
+}
+
+/// WhisperKit test double that bypasses model inference while preserving the
+/// incremental file-loading flow used by `transcribeWithResults(audioPaths:)`.
+@available(macOS 13, iOS 16, watchOS 10, visionOS 1, *)
+private final class ConcurrencyTrackingWhisperKit: WhisperKit {
+    private let tracker: ConcurrentTranscriptionTracker
+    private let delayNanoseconds: UInt64
+
+    /// Creates a model-free WhisperKit instance that records concurrent
+    /// `transcribe(audioArray:)` calls and delays each call long enough for
+    /// overlapping task-group work to become observable.
+    init(
+        tracker: ConcurrentTranscriptionTracker,
+        delayNanoseconds: UInt64
+    ) async throws {
+        self.tracker = tracker
+        self.delayNanoseconds = delayNanoseconds
+        try await super.init(WhisperKitConfig(verbose: false, logLevel: .error, load: false, download: false))
+    }
+
+    /// Records concurrency and returns a deterministic result derived from the
+    /// loaded audio sample count instead of running Core ML inference.
+    override func transcribe(
+        audioArray: [Float],
+        audioArrayOffset: Int = 0,
+        decodeOptions: DecodingOptions? = nil,
+        callback: TranscriptionCallback? = nil,
+        segmentCallback: SegmentDiscoveryCallback? = nil
+    ) async throws -> [TranscriptionResult] {
+        await tracker.recordStart()
+        do {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+            await tracker.recordFinish()
+            let text = "samples-\(audioArray.count)"
+            return [
+                TranscriptionResult(
+                    text: text,
+                    segments: [
+                        TranscriptionSegment(
+                            start: 0,
+                            end: Float(audioArray.count) / Float(WhisperKit.sampleRate),
+                            text: text
+                        )
+                    ],
+                    language: "en",
+                    timings: TranscriptionTimings(),
+                    // Relative (chunk-local); transcribeFileStream adds the chunk's absolute offset.
+                    seekTime: 0
+                )
+            ]
+        } catch {
+            await tracker.recordFinish()
+            throw error
+        }
+    }
+}

--- a/Tests/WhisperKitTests/AudioProcessorTests.swift
+++ b/Tests/WhisperKitTests/AudioProcessorTests.swift
@@ -496,7 +496,7 @@ private final class ConcurrencyTrackingWhisperKit: WhisperKit {
     /// loaded audio sample count instead of running Core ML inference.
     override func transcribe(
         audioArray: [Float],
-        audioArrayOffset: Int = 0,
+        audioArrayOffset: Int,
         decodeOptions: DecodingOptions? = nil,
         callback: TranscriptionCallback? = nil,
         segmentCallback: SegmentDiscoveryCallback? = nil

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -305,7 +305,7 @@ extension XCTestCase {
     }
 
     /// Helper to measure channel processing operations
-    func measureChannelProcessing(buffer: AVAudioPCMBuffer, mode: AudioInputConfig.ChannelMode, iterations: Int = 5) -> Double {
+    func measureChannelProcessing(buffer: AVAudioPCMBuffer, mode: AudioInputOptions.ChannelMode, iterations: Int = 5) -> Double {
         // Add warm-up iterations
         for _ in 0..<3 {
             _ = AudioProcessor.convertToMono(buffer, mode: mode)
@@ -321,6 +321,33 @@ extension XCTestCase {
         }
 
         return totalTime / Double(iterations)
+    }
+
+    /// Helper function to run an operation with a timeout
+    /// - Parameters:
+    ///   - seconds: Timeout duration in seconds
+    ///   - operation: The async operation to run
+    /// - Returns: true if the operation timed out, false if it completed
+    func withTimeout<T>(seconds: TimeInterval, operation: @escaping @Sendable () async throws -> T) async -> Bool {
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    _ = try await operation()
+                    return false // Operation completed
+                } catch {
+                    return false // Operation failed but didn't timeout
+                }
+            }
+
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds))
+                return true // Timeout occurred
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
     }
 }
 

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -3034,7 +3034,7 @@ final class UnitTests: XCTestCase {
         )
         let modelPath = try await tinyModelPath()
 
-        // .sumChannels is default for AudioInputConfig
+        // .sumChannels is default for AudioInputOptions
         let config = WhisperKitConfig(modelFolder: modelPath, verbose: true, logLevel: .debug)
         let whisperKit = try await WhisperKit(config)
 
@@ -3052,10 +3052,12 @@ final class UnitTests: XCTestCase {
         )
         let modelPath = try await tinyModelPath()
 
-        let config = WhisperKitConfig(modelFolder: modelPath, audioInputConfig: AudioInputConfig(channelMode: .sumChannels([1, 3, 5])), verbose: true, logLevel: .debug)
-        let whisperKit = try await WhisperKit(config)
+        let whisperKit = try await WhisperKit(WhisperKitConfig(modelFolder: modelPath, verbose: true, logLevel: .debug))
 
-        let result: TranscriptionResult = try await whisperKit.transcribe(audioPath: audioPath).first!
+        let result: TranscriptionResult = try await whisperKit.transcribe(
+            audioPath: audioPath,
+            audioInputOptions: AudioInputOptions(channelMode: .sumChannels([1, 3, 5]))
+        ).first!
         let expectedText = "front left"
         let containsExpectedText = result.text.normalized.contains(expectedText)
         XCTAssert(containsExpectedText, "Expected text not found in transcription and the transcription was \(result)")
@@ -3069,10 +3071,12 @@ final class UnitTests: XCTestCase {
         )
         let modelPath = try await tinyModelPath()
 
-        let config = WhisperKitConfig(modelFolder: modelPath, audioInputConfig: AudioInputConfig(channelMode: .specificChannel(0)), verbose: true, logLevel: .debug)
-        let whisperKit = try await WhisperKit(config)
+        let whisperKit = try await WhisperKit(WhisperKitConfig(modelFolder: modelPath, verbose: true, logLevel: .debug))
 
-        let result: TranscriptionResult = try await whisperKit.transcribe(audioPath: audioPath).first!
+        let result: TranscriptionResult = try await whisperKit.transcribe(
+            audioPath: audioPath,
+            audioInputOptions: AudioInputOptions(channelMode: .specificChannel(0))
+        ).first!
         let expectedText = "center"
         let containsExpectedText = result.text.normalized.contains(expectedText)
         XCTAssert(containsExpectedText, "Expected text not found in transcription and the transcription was \(result)")


### PR DESCRIPTION
Add incremental audio file loading so long-form transcription reads files in bounded-memory chunks rather than loading the entire file into memory. Full-file loading stays the default, so existing behavior is unchanged.

## Incremental file loading

- `AudioProcessor.loadFileIncrementally` streams a file as an `AsyncThrowingStream` with backpressure — at most `chunkBufferSize` chunks are queued before the producer suspends (`IncrementalLoadController`).
- Chunk boundaries reuse the full-file `VADAudioChunker` + internal `EnergyVAD`, carrying partially-decided chunks across staging buffers, so incremental output matches a single full-file load exactly; time-based cutting is the fallback.
- The 16 kHz mono read path tops up short reads (seen with 32-bit float PCM near EOF) so segmented reads are byte-identical to a full-file read.
- Multi-file incremental transcription honors `concurrentWorkerCount`.

## `AudioInputOptions`

- Renamed `AudioInputConfig` → `AudioInputOptions` (old name kept as a deprecated typealias); it bundles `channelMode` and `audioLoadingMode`.
- `AudioInputOptions.AudioLoadingMode`: `.fullFile` (default) and `.incremental(chunkDuration:chunkBufferSize:)`, plus an `.incremental` shorthand using the default duration/buffer size.
- File-path `transcribe` / `transcribeWithResults` take `audioInputOptions: AudioInputOptions? = nil`, right after the audio path and above `decodeOptions`.
- `WhisperKitConfig.audioInputConfig` is deprecated — pass `audioInputOptions` per call instead.