### PR TITLE
Support multifunction MultiCodeDecoder for Qwen3-TTS (stepped + fused)

### DIFF
--- a/Examples/TTS/TTSKitExample/TTSKitExample/MultiCodeDecoderModeView.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/MultiCodeDecoderModeView.swift
@@ -1,0 +1,48 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import SwiftUI
+import TTSKit
+
+/// Sidebar picker for the MultiCodeDecoder mode: `.stepped` (one position per
+/// call) or `.fused` (whole RVQ frame in one call). Changing it triggers a
+/// model reload.
+struct MultiCodeDecoderModeView: View {
+    @Environment(ViewModel.self) private var viewModel
+
+    var body: some View {
+        @Bindable var vm = viewModel
+
+        HStack(spacing: 8) {
+            Text("Multi Code Decoder Mode")
+                .font(.headline)
+                .lineLimit(1)
+                .minimumScaleFactor(0.85)
+                .layoutPriority(1)
+
+            Spacer(minLength: 4)
+
+            Picker("", selection: Binding(
+                get: { vm.multiCodeDecoderMode },
+                set: {
+                    vm.multiCodeDecoderMode = $0
+                    reloadIfNeeded()
+                }
+            )) {
+                Text("Stepped").tag(Qwen3MultiCodeDecoderMode.stepped)
+                Text("Fused").tag(Qwen3MultiCodeDecoderMode.fused)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .fixedSize()
+        }
+        .disabled(viewModel.modelState.isBusy)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private func reloadIfNeeded() {
+        guard viewModel.modelState == .loaded else { return }
+        viewModel.reloadModelForComputeUnitChange()
+    }
+}

--- a/Examples/TTS/TTSKitExample/TTSKitExample/SidebarView.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/SidebarView.swift
@@ -16,8 +16,9 @@ struct SidebarView: View {
 
             Divider()
 
-            // SpeechDecoder mode — a model-loading choice
+            // Decoder modes — model-loading choices
             SpeechDecoderModeView()
+            MultiCodeDecoderModeView()
 
             Divider()
 

--- a/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
@@ -159,6 +159,9 @@ private class Settings {
 
     /// Which function of the multifunction SpeechDecoder asset to load.
     @AppStorage("speechDecoderMode") var speechDecoderModeRaw: String = Qwen3SpeechDecoderMode.latencyOptimized.rawValue
+
+    /// Which function of the multifunction MultiCodeDecoder asset to load.
+    @AppStorage("multiCodeDecoderMode") var multiCodeDecoderModeRaw: String = Qwen3MultiCodeDecoderMode.stepped.rawValue
 }
 
 // MARK: - View Model
@@ -260,6 +263,12 @@ final class ViewModel: @unchecked Sendable {
         didSet { settings.speechDecoderModeRaw = speechDecoderMode.rawValue }
     }
 
+    /// Which function of the multifunction MultiCodeDecoder asset to load
+    /// (`.stepped` for one position per call; `.fused` for the whole RVQ frame in one call).
+    var multiCodeDecoderMode: Qwen3MultiCodeDecoderMode {
+        didSet { settings.multiCodeDecoderModeRaw = multiCodeDecoderMode.rawValue }
+    }
+
     var computeOptions: ComputeOptions {
         ComputeOptions(
             embedderComputeUnits: embedderComputeUnits,
@@ -296,6 +305,7 @@ final class ViewModel: @unchecked Sendable {
         multiCodeDecoderComputeUnits = MLComputeUnits(rawValue: settings.multiCodeDecoderComputeUnitsRaw) ?? .cpuAndNeuralEngine
         speechDecoderComputeUnits = MLComputeUnits(rawValue: settings.speechDecoderComputeUnitsRaw) ?? .cpuAndNeuralEngine
         speechDecoderMode = Qwen3SpeechDecoderMode(rawValue: settings.speechDecoderModeRaw) ?? .latencyOptimized
+        multiCodeDecoderMode = Qwen3MultiCodeDecoderMode(rawValue: settings.multiCodeDecoderModeRaw) ?? .stepped
     }
 
     // MARK: - Generation output
@@ -514,6 +524,7 @@ final class ViewModel: @unchecked Sendable {
                 model: selectedPreset,
                 modelFolder: localModelPaths[selectedPreset].map { URL(fileURLWithPath: $0) },
                 speechDecoderMode: speechDecoderMode,
+                multiCodeDecoderMode: multiCodeDecoderMode,
                 computeOptions: computeOptions,
                 verbose: true
             )

--- a/Sources/ArgmaxCLI/TTSCLI.swift
+++ b/Sources/ArgmaxCLI/TTSCLI.swift
@@ -13,6 +13,7 @@ extension Qwen3Speaker: ExpressibleByArgument {}
 extension Qwen3Language: ExpressibleByArgument {}
 extension TTSModelVariant: ExpressibleByArgument {}
 extension Qwen3SpeechDecoderMode: ExpressibleByArgument {}
+extension Qwen3MultiCodeDecoderMode: ExpressibleByArgument {}
 
 // MARK: - CLI Command
 
@@ -113,6 +114,9 @@ struct TTSCLI: AsyncParsableCommand {
     @Option(name: .long, help: "SpeechDecoder mode: latencyOptimized (default, lowest time-to-first-audio, 1 frame/call) or throughputOptimized (higher throughput, ~4x larger pre-buffer, 4 frames/call)")
     var speechDecoderMode: Qwen3SpeechDecoderMode = .latencyOptimized
 
+    @Option(name: .long, help: "MultiCodeDecoder mode for multifunction assets: stepped (default, one position/call) or fused (whole 15-code frame in one call with in-graph sampling)")
+    var multiCodeDecoderMode: Qwen3MultiCodeDecoderMode = .stepped
+
     // MARK: - Compute unit options
 
     @Option(name: .long, help: "Compute units for embedders (TextProjector, CodeEmbedder, MultiCodeEmbedder) {all,cpuOnly,cpuAndGPU,cpuAndNeuralEngine}")
@@ -171,6 +175,7 @@ struct TTSCLI: AsyncParsableCommand {
             multiCodeDecoderVariant: multiCodeDecoderVariant,
             speechDecoderVariant: speechDecoderVariant,
             speechDecoderMode: speechDecoderMode,
+            multiCodeDecoderMode: multiCodeDecoderMode,
             computeOptions: ComputeOptions(
                 embedderComputeUnits: embedderComputeUnits.asMLComputeUnits,
                 codeDecoderComputeUnits: codeDecoderComputeUnits.asMLComputeUnits,
@@ -212,7 +217,7 @@ struct TTSCLI: AsyncParsableCommand {
             }
             print("  Version: \(config.versionDir)")
             print("  CodeDecoder: \(config.codeDecoderVariant)")
-            print("  MultiCodeDecoder: \(config.multiCodeDecoderVariant)")
+            print("  MultiCodeDecoder: \(config.multiCodeDecoderVariant) (\(config.multiCodeDecoderMode.rawValue))")
             print("  SpeechDecoder: \(config.speechDecoderVariant) (\(config.speechDecoderMode.rawValue))")
             print("  Embedder compute: \(embedderComputeUnits.rawValue)")
             print("  CodeDecoder compute: \(codeDecoderComputeUnits.rawValue)")

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
@@ -105,7 +105,7 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
 /// Default quantization variant strings matching the standard model repository layout.
 public enum Qwen3VariantDefaults {
     public static let codeDecoder = "W8A16-stateful"
-    public static let multiCodeDecoder = "W8A16"
+    public static let multiCodeDecoder = "W8A16-multifunction"
     public static let codeEmbedder = "W16A16"
     public static let multiCodeEmbedder = "W16A16"
     public static let textProjector = "W8A16"
@@ -194,6 +194,10 @@ open class TTSKitConfig {
     /// (default) decodes one frame per call; `.throughputOptimized` decodes four.
     public var speechDecoderMode: Qwen3SpeechDecoderMode
 
+    /// Which multifunction MultiCodeDecoder function to load. `.stepped` (default)
+    /// decodes one position per call; `.fused` decodes the whole frame in one call.
+    public var multiCodeDecoderMode: Qwen3MultiCodeDecoderMode
+
     // MARK: - Compute
 
     /// Compute unit configuration per model component.
@@ -279,6 +283,7 @@ open class TTSKitConfig {
         textProjectorVariant: String? = nil,
         speechDecoderVariant: String? = nil,
         speechDecoderMode: Qwen3SpeechDecoderMode = .latencyOptimized,
+        multiCodeDecoderMode: Qwen3MultiCodeDecoderMode = .stepped,
         computeOptions: ComputeOptions = ComputeOptions(),
         verbose: Bool = true,
         logLevel: Logging.LogLevel = .info,
@@ -305,6 +310,7 @@ open class TTSKitConfig {
         self.textProjectorVariant = textProjectorVariant ?? model.textProjectorVariant
         self.speechDecoderVariant = speechDecoderVariant ?? model.speechDecoderVariant
         self.speechDecoderMode = speechDecoderMode
+        self.multiCodeDecoderMode = multiCodeDecoderMode
         self.computeOptions = computeOptions
         self.verbose = verbose
         self.logLevel = logLevel

--- a/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
@@ -399,38 +399,62 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 guard let hiddenStatesTensor = lastCdOutput.hiddenStates as? MLTensor else {
                     throw TTSError.generationFailed("Expected MLTensor hidden states on async path")
                 }
-                let mcdResult = try await multiCodeDecoder.generateMultiCodes(
-                    hiddenStatesTensor: hiddenStatesTensor,
-                    code0EmbedTensor: code0EmbedTensor,
-                    multiCodeEmbedder: multiCodeEmbedder,
-                    sampler: sampler, options: options
-                )
-                timings.multiCodeDecoder += CFAbsoluteTimeGetCurrent() - mcdStart
-                timings.multiCodeDecoderPredictions += mcdResult.timings.multiCodeDecoderPredictions
-                timings.multiCodeDecoderSampling += mcdResult.timings.multiCodeDecoderSampling
-                timings.multiCodeDecoderEmbedding += mcdResult.timings.multiCodeDecoderEmbedding
-                timings.decodingKvCaching += mcdResult.timings.decodingKvCaching
-                timings.totalMultiCodeDecoderPredictions += mcdResult.timings.totalMultiCodeDecoderPredictions
-
                 // Captured before `code0` is resampled below; ingested into the writer
                 // after sampling (nothing between here and then reads the buffer).
-                let rvqFrame = [code0] + mcdResult.codes
+                let rvqFrame: [Int32]
+                let codecHiddenTensor: MLTensor
+                if multiCodeDecoder.isFused {
+                    // Whole 15-code frame in ONE CoreML call: prediction,
+                    // in-graph sampling, and embedding lookups fused - no
+                    // per-code host round-trips. embed_sum already holds the
+                    // 15 code embeddings; add code0's to complete the codec
+                    // hidden input for the next talker step.
+                    let fused = try await multiCodeDecoder.generateMultiCodesFused(
+                        hiddenStatesTensor: hiddenStatesTensor,
+                        code0EmbedTensor: code0EmbedTensor,
+                        sampler: sampler,
+                        options: options
+                    )
+                    timings.multiCodeDecoder += CFAbsoluteTimeGetCurrent() - mcdStart
+                    timings.multiCodeDecoderPredictions += fused.predictionTime
+                    timings.totalMultiCodeDecoderPredictions += 1
+                    rvqFrame = [code0] + fused.codes
 
-                let codecHiddenStart = CFAbsoluteTimeGetCurrent()
-                guard let lastMcdCode = mcdResult.codes.last else {
-                    throw TTSError.generationFailed("Multi-code generation result has no codes")
-                }
-                let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
-                let code15EmbedTensor: MLTensor = try await multiCodeEmbedder.embed(tokenId: code15OffsetId)
-                var allCodeEmbedTensors: [MLTensor] = [code0EmbedTensor]
-                if let tensorEmbeds = mcdResult.offsetCodeEmbedTensors {
-                    allCodeEmbedTensors += tensorEmbeds
+                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
+                    codecHiddenTensor = EmbedUtilities.addEmbeddings(code0EmbedTensor, fused.embedSum)
+                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
                 } else {
-                    allCodeEmbedTensors += mcdResult.offsetCodeEmbeds.map { $0.asMLTensor() }
+                    let mcdResult = try await multiCodeDecoder.generateMultiCodes(
+                        hiddenStatesTensor: hiddenStatesTensor,
+                        code0EmbedTensor: code0EmbedTensor,
+                        multiCodeEmbedder: multiCodeEmbedder,
+                        sampler: sampler, options: options
+                    )
+                    timings.multiCodeDecoder += CFAbsoluteTimeGetCurrent() - mcdStart
+                    timings.multiCodeDecoderPredictions += mcdResult.timings.multiCodeDecoderPredictions
+                    timings.multiCodeDecoderSampling += mcdResult.timings.multiCodeDecoderSampling
+                    timings.multiCodeDecoderEmbedding += mcdResult.timings.multiCodeDecoderEmbedding
+                    timings.decodingKvCaching += mcdResult.timings.decodingKvCaching
+                    timings.totalMultiCodeDecoderPredictions += mcdResult.timings.totalMultiCodeDecoderPredictions
+
+                    rvqFrame = [code0] + mcdResult.codes
+
+                    let codecHiddenStart = CFAbsoluteTimeGetCurrent()
+                    guard let lastMcdCode = mcdResult.codes.last else {
+                        throw TTSError.generationFailed("Multi-code generation result has no codes")
+                    }
+                    let code15OffsetId = lastMcdCode + Int32(multiCodeDecoder.codecVocabSize * 14)
+                    let code15EmbedTensor: MLTensor = try await multiCodeEmbedder.embed(tokenId: code15OffsetId)
+                    var allCodeEmbedTensors: [MLTensor] = [code0EmbedTensor]
+                    if let tensorEmbeds = mcdResult.offsetCodeEmbedTensors {
+                        allCodeEmbedTensors += tensorEmbeds
+                    } else {
+                        allCodeEmbedTensors += mcdResult.offsetCodeEmbeds.map { $0.asMLTensor() }
+                    }
+                    allCodeEmbedTensors.append(code15EmbedTensor)
+                    codecHiddenTensor = EmbedUtilities.sumEmbeddings(allCodeEmbedTensors)
+                    timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
                 }
-                allCodeEmbedTensors.append(code15EmbedTensor)
-                let codecHiddenTensor = EmbedUtilities.sumEmbeddings(allCodeEmbedTensors)
-                timings.codecHidden += CFAbsoluteTimeGetCurrent() - codecHiddenStart
 
                 let textProjStart = CFAbsoluteTimeGetCurrent()
                 let textEmbedTensor: MLTensor =
@@ -498,6 +522,12 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 let mcdStart = CFAbsoluteTimeGetCurrent()
                 guard let hiddenStates = lastCdOutput.hiddenStates as? [FloatType] else {
                     throw TTSError.generationFailed("Expected [FloatType] hidden states on legacy path")
+                }
+                guard !multiCodeDecoder.isFused else {
+                    throw TTSError.generationFailed(
+                        "Fused MultiCodeDecoder assets require macOS 15 / iOS 18; " +
+                        "use a stepped variant on this OS"
+                    )
                 }
                 let mcdResult = try await multiCodeDecoder.generateMultiCodes(
                     hiddenStates: hiddenStates, code0Embed: code0Embed,

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
@@ -34,6 +34,8 @@ public enum Qwen3TTSConstants {
 
     /// Vocabulary size for the multi-code decoder heads (codes 1-15).
     public static let codecVocabSize: Int = 2048
+    /// Number of code_predictor lm_heads (codes 1-15 of an RVQ frame).
+    public static let mcdHeads: Int = 15
 
     // MARK: Audio format
 
@@ -190,4 +192,20 @@ public enum Qwen3SpeechDecoderMode: String, Sendable, CaseIterable {
             case .throughputOptimized: return "throughput"
         }
     }
+}
+
+// MARK: - MultiCodeDecoder Mode
+
+/// Selects which MultiCodeDecoder graph expands a talker frame into its 15
+/// residual codes. `.stepped` decodes one position per prediction; `.fused`
+/// decodes the whole frame in one prediction with in-graph sampling.
+/// Loading requires a multifunction asset exposing both functions; legacy
+/// single-function assets fail to load with a function-selection error.
+@frozen
+public enum Qwen3MultiCodeDecoderMode: String, Sendable, CaseIterable {
+    case stepped
+    case fused
+
+    /// CoreML function name corresponding to this mode.
+    public var functionName: String { rawValue }
 }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
@@ -125,7 +125,9 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
             temperature = 1
             noise = [FloatType](repeating: 0, count: noiseCount)
         } else {
-            // The graph divides logits by temperature; keep it strictly positive.
+            // The graph divides fp16 logits by an fp16 temperature, so the floor is an fp16
+            // range guard: small values overflow and anything under
+            // 0.05 is a safe value that is practically greedy.
             temperature = max(options.temperature, 0.05)
             // Bare `FloatType.init` is ambiguous on x86_64 where `FloatType == Float`.
             noise = sampler.gumbelNoise(count: noiseCount).map { FloatType($0) }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
@@ -43,17 +43,44 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
     /// Codec vocabulary size per head (codes 1-15), detected from model output
     public private(set) var codecVocabSize: Int = Qwen3TTSConstants.codecVocabSize
 
+    /// Which function of the multifunction asset to load. Set before `loadModel`;
+    /// legacy single-function assets cannot be loaded (function selection fails).
+    public var mode: Qwen3MultiCodeDecoderMode = .stepped
+
     public init() {}
 
     public func loadModel(at url: URL, computeUnits: MLComputeUnits, prewarmMode: Bool = false) async throws {
         let modelConfig = MLModelConfiguration()
         modelConfig.computeUnits = computeUnits
-        let loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
+        // The MultiCodeDecoder ships as a multifunction asset carrying both the
+        // `stepped` and `fused` graphs; `mode.functionName` selects one. Function
+        // selection is iOS 18+ / macOS 15+, and the asset requires the same minimum,
+        // so callers on older OS cannot load it.
+        guard #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) else {
+            throw TTSError.modelLoadingFailed(
+                "MultiCodeDecoder requires macOS 15 / iOS 18 (multifunction CoreML model)"
+            )
+        }
+        modelConfig.functionName = mode.functionName
+        let loaded: MLModel
+        do {
+            loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
+        } catch {
+            throw TTSError.modelLoadingFailed(
+                "MultiCodeDecoder: failed to load function '\(mode.functionName)' from " +
+                "\(url.lastPathComponent). This must be a multifunction CoreML asset " +
+                "with 'stepped' and 'fused' functions, running on macOS 15 / iOS 18 " +
+                "or newer. (\(error.localizedDescription))"
+            )
+        }
 
         // In prewarm mode, compilation is complete - discard to free memory before next model compiles
         guard !prewarmMode else { return }
 
         self.model = loaded
+        // The selected function determines the graph: `fused` samples the whole
+        // frame in-graph, `stepped` decodes one position per prediction.
+        self.isFused = mode == .fused
 
         // Detect dimensions from model description
         if let dim = ModelUtilities.getModelOutputDimension(model, named: "key_cache_updates", position: 1) {
@@ -74,6 +101,57 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
 
     /// Embedding dimension for `input_embeds`, detected from the model at load time.
     public private(set) var inputEmbedDim: Int = Qwen3TTSConstants.embedDim
+
+    /// True when the loaded model is the fused one-call-per-frame variant.
+    public private(set) var isFused = false
+
+    /// One CoreML call for the whole 15-code frame. Sampling runs in-graph via
+    /// the Gumbel-max trick (`argmax(logits/T + G)` draws from `softmax(logits/T)`)
+    /// with noise from `sampler`'s RNG, so seeded generation reproduces.
+    /// `embed_sum` is the sum of the sampled codes' MultiCodeEmbedder rows.
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    public func generateMultiCodesFused(
+        hiddenStatesTensor: MLTensor,
+        code0EmbedTensor: MLTensor,
+        sampler: any TokenSampling,
+        options: GenerationOptions
+    ) async throws -> (codes: [Int32], embedSum: MLTensor, predictionTime: TimeInterval) {
+        guard let model else { throw TTSError.generationFailed("MultiCodeDecoder model not loaded") }
+        let noiseCount = Qwen3TTSConstants.mcdHeads * codecVocabSize
+        let temperature: Float
+        let noise: [FloatType]
+        if options.temperature <= 0 {
+            // Exact greedy: argmax(logits / 1 + 0) == argmax(logits)
+            temperature = 1
+            noise = [FloatType](repeating: 0, count: noiseCount)
+        } else {
+            // The graph divides logits by temperature; keep it strictly positive.
+            temperature = max(options.temperature, 0.05)
+            // Bare `FloatType.init` is ambiguous on x86_64 where `FloatType == Float`.
+            noise = sampler.gumbelNoise(count: noiseCount).map { FloatType($0) }
+        }
+        var inputs: [String: MLTensor] = [
+            "code0_hidden_states": hiddenStatesTensor,
+            "code0_embed": code0EmbedTensor,
+            "gumbel": MLTensor(shape: [Qwen3TTSConstants.mcdHeads, codecVocabSize], scalars: noise),
+            "temperature": MLTensor(shape: [1], scalars: [FloatType(temperature)]),
+        ]
+        if model.modelDescription.inputDescriptionsByName["top_k"] != nil {
+            // topK <= 0 means "no top-k"; the graph saturates at its compiled candidate count.
+            let topK = options.topK > 0 ? options.topK : codecVocabSize
+            inputs["top_k"] = MLTensor(shape: [1], scalars: [Int32(topK)])
+        }
+        let predictionStart = CFAbsoluteTimeGetCurrent()
+        let outputs = try await model.prediction(from: inputs)
+        guard let codesTensor = outputs["codes"], let embedSum = outputs["embed_sum"] else {
+            throw TTSError.generationFailed("Fused MultiCodeDecoder: missing codes/embed_sum outputs")
+        }
+        let codes = await codesTensor.toIntArray().map(Int32.init)
+        guard codes.count == Qwen3TTSConstants.mcdHeads else {
+            throw TTSError.generationFailed("Fused MultiCodeDecoder: expected 15 codes, got \(codes.count)")
+        }
+        return (codes, embedSum, CFAbsoluteTimeGetCurrent() - predictionStart)
+    }
 
     public var isStateful: Bool {
         guard let model else { return false }
@@ -103,6 +181,23 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
     public func prewarmInference() async throws {
         guard let model else { return }
+        if isFused {
+            // Full-frame dummy calls pipeline the ANE the same way as the stepped loop.
+            let dummyHidden = MLTensor(zeros: [1, inputEmbedDim, 1, 1], scalarType: FloatType.self)
+            let dummyGumbel = MLTensor(zeros: [Qwen3TTSConstants.mcdHeads, codecVocabSize], scalarType: FloatType.self)
+            let dummyTemp = MLTensor(shape: [1], scalars: [FloatType(1)])
+            var dummyInputs: [String: MLTensor] = [
+                "code0_hidden_states": dummyHidden, "code0_embed": dummyHidden,
+                "gumbel": dummyGumbel, "temperature": dummyTemp,
+            ]
+            if model.modelDescription.inputDescriptionsByName["top_k"] != nil {
+                dummyInputs["top_k"] = MLTensor(shape: [1], scalars: [Int32(1)])
+            }
+            for _ in 0..<4 {
+                _ = try await model.prediction(from: dummyInputs)
+            }
+            return
+        }
         let sequenceLength = kvCacheMaxSequenceLength
         let dummyInput = MLTensor(zeros: [1, inputEmbedDim, 1, 1], scalarType: FloatType.self)
         for _ in 0..<4 {

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -476,6 +476,9 @@ open class TTSKit: @unchecked Sendable {
         if let qwen3SD = speechDecoder as? Qwen3SpeechDecoder {
             qwen3SD.mode = config.speechDecoderMode
         }
+        if let qwen3MCD = multiCodeDecoder as? Qwen3MultiCodeDecoder {
+            qwen3MCD.mode = config.multiCodeDecoderMode
+        }
 
         // Load the six CoreML models.
         // Prewarm: sequential to serialize compilation -> lower peak memory.

--- a/Sources/TTSKit/Utilities/Sampling.swift
+++ b/Sources/TTSKit/Utilities/Sampling.swift
@@ -43,7 +43,8 @@ public extension TokenSampling {
     }
 
     static func gumbelNoise(count: Int, using rng: inout any RandomNumberGenerator) -> [Float] {
-        (0..<count).map { _ in
+        guard count > 0 else { return [] }
+        return (0..<count).map { _ in
             // The uniform draw excludes 0 and 1 so both logs stay finite.
             -log(-log(Float.random(in: Float.leastNormalMagnitude..<1, using: &rng)))
         }

--- a/Sources/TTSKit/Utilities/Sampling.swift
+++ b/Sources/TTSKit/Utilities/Sampling.swift
@@ -29,6 +29,25 @@ public protocol TokenSampling {
         temperature: Float,
         topK: Int
     ) async -> Int32
+
+    /// Pre-drawn Gumbel(0,1) noise (`-log(-log(U))`) for models that sample in-graph
+    /// via the Gumbel-max trick, drawn from the sampler's RNG so seeded runs reproduce.
+    func gumbelNoise(count: Int) -> [Float]
+}
+
+public extension TokenSampling {
+    /// Unseeded default from the system RNG.
+    func gumbelNoise(count: Int) -> [Float] {
+        var rng: any RandomNumberGenerator = SystemRandomNumberGenerator()
+        return Self.gumbelNoise(count: count, using: &rng)
+    }
+
+    static func gumbelNoise(count: Int, using rng: inout any RandomNumberGenerator) -> [Float] {
+        (0..<count).map { _ in
+            // The uniform draw excludes 0 and 1 so both logs stay finite.
+            -log(-log(Float.random(in: Float.leastNormalMagnitude..<1, using: &rng)))
+        }
+    }
 }
 
 // MARK: - Greedy / Top-k Sampler
@@ -49,6 +68,10 @@ public class GreedyTokenSampler: TokenSampling, @unchecked Sendable {
         } else {
             self.rng = SystemRandomNumberGenerator()
         }
+    }
+
+    public func gumbelNoise(count: Int) -> [Float] {
+        Self.gumbelNoise(count: count, using: &rng)
     }
 
     public func sampleCodec0(

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -506,6 +506,45 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(config.speechDecoderVariant, "W8A16-multifunction")
     }
 
+    // MARK: - MultiCodeDecoder mode enum
+
+    func testMultiCodeDecoderModeFunctionNames() {
+        XCTAssertEqual(Qwen3MultiCodeDecoderMode.stepped.functionName, "stepped")
+        XCTAssertEqual(Qwen3MultiCodeDecoderMode.fused.functionName, "fused")
+    }
+
+    func testMultiCodeDecoderModeDefaults() {
+        let decoder = Qwen3MultiCodeDecoder()
+        XCTAssertEqual(decoder.mode, .stepped)
+        XCTAssertFalse(decoder.isFused)
+    }
+
+    func testTTSKitConfigMultiCodeDecoderModeDefault() {
+        let config = TTSKitConfig()
+        XCTAssertEqual(config.multiCodeDecoderMode, .stepped)
+        XCTAssertEqual(config.multiCodeDecoderVariant, "W8A16-multifunction")
+    }
+
+    // MARK: - Gumbel noise (fused MultiCodeDecoder sampling input)
+
+    func testGumbelNoiseSeededDeterminism() {
+        let noise1 = GreedyTokenSampler(seed: 42).gumbelNoise(count: 256)
+        let noise2 = GreedyTokenSampler(seed: 42).gumbelNoise(count: 256)
+        let noise3 = GreedyTokenSampler(seed: 43).gumbelNoise(count: 256)
+
+        XCTAssertEqual(noise1, noise2, "Same seed should produce identical Gumbel noise")
+        XCTAssertNotEqual(noise1, noise3, "Different seeds should produce different Gumbel noise")
+        XCTAssertEqual(noise1.count, 256)
+        XCTAssertTrue(noise1.allSatisfy(\.isFinite), "Gumbel noise must be finite")
+    }
+
+    func testGumbelNoiseConsumesSamplerRNG() {
+        let sampler = GreedyTokenSampler(seed: 7)
+        let first = sampler.gumbelNoise(count: 64)
+        let second = sampler.gumbelNoise(count: 64)
+        XCTAssertNotEqual(first, second, "Consecutive draws should consume the RNG stream")
+    }
+
     // MARK: - Sampler
 
     func testGreedySamplerDeterministic() async throws {


### PR DESCRIPTION
## Summary

This lands the fused MultiCodeDecoder from @mjfrey's #506. The approach
— collapsing the frame into one call and doing the sampling in-graph with Gumbel-max — is his,
and it's what made this worth shipping. Thanks for the contribution. On our side we've packaged
both graphs into a single multifunction asset, converted the CustomVoice checkpoints, and made
the mode selectable from the SDK.

A talker frame expands into 15 residual codes. Stepped does that in 16 CoreML calls with host
sampling and an embedding lookup between each one; fused does the whole frame in a single call
with the sampling and lookups inside the graph. `.stepped` stays the default, so nothing changes
unless you opt in.

## What's new

- `Qwen3MultiCodeDecoderMode` (`.stepped` / `.fused`) via `TTSKitConfig.multiCodeDecoderMode`,
  mirroring `Qwen3SpeechDecoderMode`.
- CLI: `argmax-cli tts --multi-code-decoder-mode stepped|fused`.
- Example app: a Stepped / Fused picker in the sidebar (flipping it reloads the model).
- Fused Gumbel noise comes from the task's `GreedyTokenSampler` RNG (new
  `TokenSampling.gumbelNoise(count:)`), so `GenerationOptions.seed` reproduces fused audio the
  same way it does on the stepped path.
- `temperature <= 0` uses zero noise at temperature 1, which reduces `argmax(logits/T + G)` to
  `argmax(logits)` — exact greedy.
- Assets converted with a `top_k` input get `GenerationOptions.topK` at runtime instead of
  having k baked in at conversion time.
- Default variant moves from `W8A16` to `W8A16-multifunction`.

## Usage

```swift
// Default: stepped, same output as before
let tts = try await TTSKit()

// Fused
let config = TTSKitConfig(multiCodeDecoderMode: .fused)
let fusedTTS = try await TTSKit(config)
```

```bash
swift run -c release argmax-cli tts \
  --text "The old café on the corner still smelled like rain and roasted coffee." \
  --multi-code-decoder-mode fused --play
```

## Asset download

The default variant changes to `W8A16-multifunction`, so this triggers a new model download.
It's already on [`argmaxinc/ttskit-coreml`](https://huggingface.co/argmaxinc/ttskit-coreml) and
comes down automatically on your next `setupModels()` / first launch — no token, repo override,
or code change needed.

It's a new download rather than a replacement, so the old `W8A16` folder stays on disk:

| Model | old `W8A16` | new `W8A16-multifunction` |
|---|---|---|
| `12hz-0.6b-customvoice` | 110 MB | 144 MB |
| `12hz-1.7b-customvoice` | 113 MB | 178 MB |

One bundle carries both graphs, hence the larger size (trunk weights are shared across the two
functions, so it's well under two separate assets).

Once you're on the new default, the old `W8A16` folder is no longer used and can be deleted to
reclaim the space.

## Performance

Apple M4, 0.6B W8A16, `latencyOptimized` SpeechDecoder, single worker, same text and seed.
Median of 7 runs of ~220 frames each:

| | `.stepped` | `.fused` | |
|---|---|---|---|
| MultiCodeDecoder | 51.5 ms/frame | 35.7 ms/frame | ~1.4× |
| End-to-end | 15.3 steps/s | 19.8 steps/s | +29% |
| Time to first buffer | 100 ms | 80 ms | -20% |

<details>
<summary>Reproduce</summary>

```bash
swift build -c release

T="The old café on the corner still smelled like rain and roasted coffee. Every morning the same man sat by the window with a newspaper he never seemed to finish. The owner knew his order by heart and poured it before he asked. Outside, the tram rattled past on its way to the harbour."

for M in stepped fused; do
  echo "===== $M ====="
  ./.build/release/argmax-cli tts --text "$T" \
    --seed 42 \
    --speech-decoder-mode latencyOptimized \
    --multi-code-decoder-mode $M \
    --concurrent-worker-count 1 \
    --output-path /tmp/mcd_$M --output-format wav --verbose \
    | grep -E "^MultiCodeDecoder:|Steps per Second|Time to first buffer|Total Steps"
done
```

Read `MultiCodeDecoder` (ms/run), `Steps per Second`, and `Time to first buffer` from the timing
block. The table above is the median of 7 runs per mode, alternating the order of the two modes
between rounds; single runs vary by a few ms/frame, and fused is the more variable of the two.

`--concurrent-worker-count 1` forces sequential decoding so per-frame timings are clean, and
`--play` is omitted because playback contention adds noise. The long text is only there to get
~220 frames per run, which averages out per-frame jitter.

Note the two modes don't produce identical audio — fused sampling draws a different (equally
valid) sequence, so the same text comes out as 226 frames stepped vs 219 fused. The figures above
are per-frame and per-step rates, so that difference doesn't distort them.

</details>

## Breaking changes

- If you explicitly pin `multiCodeDecoderVariant: "W8A16"`, drop the override. The loader now
  always selects a function by name, so single-function assets fail to load. Older SDK releases
  pinned to `W8A16` are unaffected — that asset stays published.
- `TokenSampling` gains `gumbelNoise(count:)`, but with a default implementation in a protocol
  extension, so existing conformers still compile. Override it only if you want fused sampling
  to use your own RNG.

---

Co-authored-by: @mjfrey
