### PR TITLE
Fix empty transcription when `promptTokens` are set

### DIFF
--- a/Sources/ArgmaxCore/MLMultiArrayExtensions.swift
+++ b/Sources/ArgmaxCore/MLMultiArrayExtensions.swift
@@ -104,8 +104,8 @@ public extension MLMultiArray {
         let strideInts = strides.map { $0.intValue }
         let shapeInts = shape.map { $0.intValue }
         for index in indexes {
-            // Skip indices outside the array's shape, they would write out of bounds
-            guard zip(index, shapeInts).allSatisfy({ $0 >= 0 && $0 < $1 }) else {
+            guard index.count == shapeInts.count,
+                  zip(index, shapeInts).allSatisfy({ $0 >= 0 && $0 < $1 }) else {
                 continue
             }
             let linearOffset = linearOffset(for: index, strides: strideInts)

--- a/Sources/ArgmaxCore/MLMultiArrayExtensions.swift
+++ b/Sources/ArgmaxCore/MLMultiArrayExtensions.swift
@@ -102,7 +102,12 @@ public extension MLMultiArray {
     func fill<Value>(indexes: [[Int]], with value: Value) {
         let pointer = UnsafeMutablePointer<Value>(OpaquePointer(dataPointer))
         let strideInts = strides.map { $0.intValue }
+        let shapeInts = shape.map { $0.intValue }
         for index in indexes {
+            // Skip indices outside the array's shape, they would write out of bounds
+            guard zip(index, shapeInts).allSatisfy({ $0 >= 0 && $0 < $1 }) else {
+                continue
+            }
             let linearOffset = linearOffset(for: index, strides: strideInts)
             pointer[linearOffset] = value
         }

--- a/Sources/WhisperKit/Core/Text/LogitsFilter.swift
+++ b/Sources/WhisperKit/Core/Text/LogitsFilter.swift
@@ -15,6 +15,12 @@ open class SuppressTokensFilter: LogitsFiltering {
 
     public init(suppressTokens: [Int]) {
         self.suppressTokens = suppressTokens
+        // Out-of-range ids are ignored by `fill`'s bounds check, including the
+        // `-1` sentinel ("suppress the default non-speech tokens"), which is
+        // not supported here.
+        if suppressTokens.contains(where: { $0 < 0 }) {
+            Logging.debug("SuppressTokensFilter: ignoring negative ids in suppressTokens; the -1 sentinel (suppress default non-speech tokens) is not supported")
+        }
         self.suppressTokenIndexes = suppressTokens.map { [0, 0, $0] }
     }
 

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -208,7 +208,9 @@ public extension TextDecoding {
 
             // Add prefix tokens
             if let prefixTokens = options.prefixTokens {
-                let trimmedPrefixTokens = Array(prefixTokens.suffix(Constants.maxTokenContext / 2)).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
+                // Cap prefix so combined prefill leaves room for at least one sampled token.
+                let maxPrefixLen = min(Constants.maxTokenContext / 2, Constants.maxTokenContext - 2 - prefillTokens.count)
+                let trimmedPrefixTokens = Array(prefixTokens.suffix(max(0, maxPrefixLen))).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
                 prefillTokens.append(contentsOf: trimmedPrefixTokens)
             }
         }
@@ -340,7 +342,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         languageLogitsFilter = nil
     }
 
-    func debugCaches(decoderInputs: DecodingInputs, tokenIndex: Int, prefillSize: Int) {
+    func debugCaches(decoderInputs: DecodingInputs, tokenIndex: Int) {
         Logging.debug("--------------- DECODER INPUTS DEBUG ---------------")
         Logging.debug(
             String(
@@ -351,7 +353,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         )
         Logging.debug("Key Cache | Val Cache | Align Cache | Update Mask | Decoder Mask | Position")
 
-        for i in 0..<min(prefillSize + 4, Constants.maxTokenContext) {
+        // First 4 positions only; alignment stride is hardcoded to 1500 frames.
+        for i in 0..<4 {
             let formattedString = String(format: "%9.6f | %9.6f | %9.6f | %11.0f | %12.0f | %d",
                                          decoderInputs.keyCache[i].floatValue,
                                          decoderInputs.valueCache[i].floatValue,
@@ -441,15 +444,14 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
         }
 
         var timings = TranscriptionTimings()
-        let prefilledIndex = 0
         let currentTokens: [Int] = [tokenizer.specialTokens.startOfTranscriptToken]
-        var logProbs: [Float] = Array(repeating: 0, count: prefilledIndex + 1)
+        var logProbs: [Float] = [0.0]
 
         // Logits filters
         let languageLogitsFilter = self.languageLogitsFilter ?? LanguageLogitsFilter(
             allLanguageTokens: tokenizer.allLanguageTokens,
             logitsDim: logitsSize,
-            sampleBegin: prefilledIndex
+            sampleBegin: 0
         )
         self.languageLogitsFilter = languageLogitsFilter
 
@@ -555,39 +557,36 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             throw WhisperError.tokenizerUnavailable()
         }
 
+        guard let lastPromptToken = decoderInputs.initialPrompt.last else {
+            throw WhisperError.prepareDecoderInputsFailed("Initial prompt must not be empty")
+        }
+
         // Single loop variables
         var timings = TranscriptionTimings()
-        let prefilledIndex = decoderInputs.cacheLength[0].intValue
         let initialPromptIndex = decoderInputs.initialPrompt.count
         var currentTokens: [Int] = decoderInputs.initialPrompt
-        var nextToken: Int = decoderInputs.initialPrompt.last!
+        var nextToken: Int = lastPromptToken
         var logProbs: [Float] = Array(repeating: 0, count: currentTokens.count)
 
         // Logits filters
-        let logitsFilters = createLogitsFilters(options: options, prefilledIndex: prefilledIndex, initialPromptIndex: initialPromptIndex, tokenizer: tokenizer)
+        let logitsFilters = createLogitsFilters(options: options, initialPromptIndex: initialPromptIndex, tokenizer: tokenizer)
 
         // MARK: Main loop
 
-        let loopCount = min(options.sampleLength, Constants.maxTokenContext - 1)
-        Logging.debug("Running main loop for a maximum of \(loopCount) iterations, starting at index \(prefilledIndex)")
-        if initialPromptIndex > loopCount || initialPromptIndex >= Constants.maxTokenContext - 1 {
-            Logging.error("Initial prompt (\(initialPromptIndex) tokens) exceeds the decoding budget (sampleLength: \(options.sampleLength)); this window will decode no new tokens")
-        }
+        // sampleLength counts sampled tokens only, not prefill steps.
+        let loopCount = min(initialPromptIndex - 1 + options.sampleLength, Constants.maxTokenContext - 1)
+        Logging.debug("Running main loop for a maximum of \(loopCount) iterations")
         var hasAlignment = false
         var isFirstTokenLogProbTooLow = false
         let windowUUID = UUID()
         await earlyStopActor.set(false, for: windowUUID)
 
-        for tokenIndex in prefilledIndex..<loopCount {
+        for tokenIndex in 0..<loopCount {
             let loopStart = Date()
 
             let isPrefill = tokenIndex < initialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
             let isLastPrefillToken = tokenIndex == initialPromptIndex - 1
-            // The first prediction that actually matters is the one sampled at the last
-            // prefill step; everything sampled before that is discarded and replaced by
-            // the forced prompt tokens. `prefilledIndex` alone can't identify that step:
-            // it is 0 whenever the KV cache is not prefilled, e.g. when promptTokens are set.
-            let isFirstToken = tokenIndex == max(prefilledIndex, initialPromptIndex - 1)
+            let isFirstToken = tokenIndex == max(0, initialPromptIndex - 1)
 
             // Check if current index is part of the initial prompt
             if tokenIndex < initialPromptIndex {
@@ -613,8 +612,8 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             decoderInputs.inputIds[0] = NSNumber(value: nextToken)
             decoderInputs.cacheLength[0] = NSNumber(value: tokenIndex)
 
-            if tokenIndex <= prefilledIndex + 3 {
-                debugCaches(decoderInputs: decoderInputs, tokenIndex: tokenIndex, prefillSize: prefilledIndex)
+            if tokenIndex <= 3 {
+                debugCaches(decoderInputs: decoderInputs, tokenIndex: tokenIndex)
             }
 
             // MARK: Decoding Inference
@@ -761,7 +760,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             timings.decodingLoop += Date().timeIntervalSince(loopStart)
             timings.totalDecodingLoops += 1
 
-            if tokenIndex == prefilledIndex {
+            if tokenIndex == 0 {
                 Logging.debug("Found first token at: \(Date())")
                 timings.firstTokenTime = CFAbsoluteTimeGetCurrent()
             }
@@ -872,7 +871,6 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
     
     internal func createLogitsFilters(
         options: DecodingOptions,
-        prefilledIndex: Int,
         initialPromptIndex: Int,
         tokenizer: WhisperTokenizer
     ) -> [any LogitsFiltering] {
@@ -885,7 +883,6 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 SuppressBlankFilter(
                     specialTokens: tokenizer.specialTokens,
                     // The first sampled token comes after the initial prompt
-                    // `prefilledIndex` is always 0 here and would leave the filter inactive.
                     sampleBegin: initialPromptIndex
                 )
             )

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -198,7 +198,12 @@ public extension TextDecoding {
             if let promptTokens = options.promptTokens {
                 let maxPromptLen = (Constants.maxTokenContext / 2) - 1
                 let trimmedPromptTokens = Array(promptTokens.suffix(maxPromptLen)).filter { $0 < tokenizer.specialTokens.specialTokenBegin }
-                prefillTokens = [tokenizer.specialTokens.startOfPreviousToken] + trimmedPromptTokens + prefillTokens
+                // If nothing is left after trimming, skip the prompt entirely.
+                // A bare <|startofprev|> with no content tokens biases the model
+                // toward ending the segment early.
+                if !trimmedPromptTokens.isEmpty {
+                    prefillTokens = [tokenizer.specialTokens.startOfPreviousToken] + trimmedPromptTokens + prefillTokens
+                }
             }
 
             // Add prefix tokens
@@ -565,6 +570,9 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
         let loopCount = min(options.sampleLength, Constants.maxTokenContext - 1)
         Logging.debug("Running main loop for a maximum of \(loopCount) iterations, starting at index \(prefilledIndex)")
+        if initialPromptIndex > loopCount || initialPromptIndex >= Constants.maxTokenContext - 1 {
+            Logging.error("Initial prompt (\(initialPromptIndex) tokens) exceeds the decoding budget (sampleLength: \(options.sampleLength)); this window will decode no new tokens")
+        }
         var hasAlignment = false
         var isFirstTokenLogProbTooLow = false
         let windowUUID = UUID()
@@ -575,7 +583,11 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
             let isPrefill = tokenIndex < initialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
             let isLastPrefillToken = tokenIndex == initialPromptIndex - 1
-            let isFirstToken = tokenIndex == prefilledIndex
+            // The first prediction that actually matters is the one sampled at the last
+            // prefill step; everything sampled before that is discarded and replaced by
+            // the forced prompt tokens. `prefilledIndex` alone can't identify that step:
+            // it is 0 whenever the KV cache is not prefilled, e.g. when promptTokens are set.
+            let isFirstToken = tokenIndex == max(prefilledIndex, initialPromptIndex - 1)
 
             // Check if current index is part of the initial prompt
             if tokenIndex < initialPromptIndex {
@@ -665,8 +677,12 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                 } else {
                     false
                 }
+            // Ignore an EOT sampled while the prompt is still being force-fed: that
+            // prediction is discarded anyway, and stopping on it would return an empty
+            // transcription. An EOT sampled at or after the last prefill token is a
+            // real prediction and ends the segment as usual.
             let isSegmentCompleted =
-                sampleResult.completed ||
+                (sampleResult.completed && !isPrefill) ||
                 currentTokens.count >= Constants.maxTokenContext - 1 ||
                 isFirstTokenLogProbTooLow
 
@@ -868,7 +884,9 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
             allFilters.append(
                 SuppressBlankFilter(
                     specialTokens: tokenizer.specialTokens,
-                    sampleBegin: prefilledIndex
+                    // The first sampled token comes after the initial prompt
+                    // `prefilledIndex` is always 0 here and would leave the filter inactive.
+                    sampleBegin: initialPromptIndex
                 )
             )
         }

--- a/Sources/WhisperKit/Core/TranscribeTask.swift
+++ b/Sources/WhisperKit/Core/TranscribeTask.swift
@@ -267,9 +267,9 @@ open class TranscribeTask {
                 timings.decodingWindowing += Date().timeIntervalSince(windowingStart)
                 timings.totalDecodingWindows += 1
 
-                // Reset cache and move on to the next window
+                // Reset cache for next window (full context, not sampleLength)
                 decoderInputs.reset(
-                    maxTokenContext: decodeOptions?.sampleLength ?? Constants.maxTokenContext
+                    maxTokenContext: Constants.maxTokenContext
                 )
 
                 // Update the progress
@@ -395,8 +395,9 @@ open class TranscribeTask {
                 // Reset decoder inputs for fallback
                 timings.decodingFallback += Date().timeIntervalSince(decodeWithFallbackStart)
                 timings.totalDecodingFallbacks = Double(i)
+                // Same full-window reset as above
                 decoderInputs.reset(
-                    maxTokenContext: options.sampleLength
+                    maxTokenContext: Constants.maxTokenContext
                 )
                 Logging.info("Fallback #\(i + 1) (\(fallback.fallbackReason))")
             } else {

--- a/Tests/WhisperKitTests/TestUtils.swift
+++ b/Tests/WhisperKitTests/TestUtils.swift
@@ -426,3 +426,77 @@ public extension Publisher {
             .eraseToAnyPublisher()
     }
 }
+
+// MARK: - MockTextDecoder
+
+/// Deterministic `TextDecoder` stub: replays scripted logits through the real `decodeText`
+/// loop, so decode-loop behavior can be tested without a model. Only the Core ML boundary
+/// is stubbed (`predictLogits` and the model-dimension accessors).
+final class MockTextDecoder: TextDecoder {
+    struct Prediction {
+        let token: Int
+        /// Confident predictions have a log probability near 0,
+        /// unconfident ones near -log(vocabSize) ≈ -6.9.
+        let confident: Bool
+    }
+
+    /// Token to predict at each successive `predictLogits` call.
+    /// The last entry repeats if the decode loop runs longer than the script.
+    var script: [Prediction] = []
+    private(set) var predictionCount = 0
+
+    private let vocabSize = 1024
+
+    override var logitsSize: Int? { vocabSize }
+    override var kvCacheEmbedDim: Int? { 2 }
+    override var kvCacheMaxSequenceLength: Int? { 64 }
+    // `debugCaches` indexes alignmentWeights with a hardcoded stride of 1500,
+    // so the window size must match the real encoder output length
+    override var windowSize: Int? { 1500 }
+    override var embedSize: Int? { 2 }
+
+    override func predictLogits(_ inputs: TextDecoderInputType) async throws -> TextDecoderOutputType? {
+        guard !script.isEmpty else {
+            throw WhisperError.decodingLogitsFailed("MockTextDecoder.script is empty; set a script before decoding")
+        }
+        let prediction = script[min(predictionCount, script.count - 1)]
+        predictionCount += 1
+
+        let logits = try MLMultiArray(shape: [1, 1, NSNumber(value: vocabSize)], dataType: .float16, initialValue: FloatType(0))
+        // Keep the spike below ~11 so exp() stays within Float16 range on the BNNS sampling path
+        logits[prediction.token] = NSNumber(value: prediction.confident ? 10.0 : 0.1)
+
+        let cache = DecodingCache(
+            keyCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
+            valueCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
+            alignmentWeights: nil
+        )
+        return TextDecoderMLMultiArrayOutputType(logits: logits, cache: cache)
+    }
+
+    /// Timestamps stay disabled: `CustomTokenizer` puts `timeTokenBegin` at 7, below the
+    /// content ids these tests use, so a timestamp-enabled run would misread them.
+    static func makePromptDecodingContext(
+        promptTokens: [Int]? = nil,
+        prefixTokens: [Int]? = nil,
+        sampleLength: Int = 20,
+        firstTokenLogProbThreshold: Float? = nil
+    ) async throws -> (decoder: MockTextDecoder, inputs: any DecodingInputsType, sampler: GreedyTokenSampler, encoderOutput: MLMultiArray, options: DecodingOptions) {
+        let options = DecodingOptions(
+            sampleLength: sampleLength,
+            withoutTimestamps: true,
+            promptTokens: promptTokens,
+            prefixTokens: prefixTokens,
+            firstTokenLogProbThreshold: firstTokenLogProbThreshold
+        )
+        let decoder = MockTextDecoder()
+        decoder.isModelMultilingual = true
+        decoder.tokenizer = CustomTokenizer(specialTokenBegin: 1000)
+
+        let sotPrompt = try decoder.prepareDecoderInputs(withPrompt: [decoder.tokenizer!.specialTokens.startOfTranscriptToken])
+        let inputs = try await decoder.prefillDecoderInputs(sotPrompt, withOptions: options)
+        let sampler = GreedyTokenSampler(temperature: 0, eotToken: decoder.tokenizer!.specialTokens.endToken, decodingOptions: options)
+        let encoderOutput = try MLMultiArray(shape: [1, 2, 1, 4], dataType: .float16, initialValue: FloatType(0))
+        return (decoder, inputs, sampler, encoderOutput, options)
+    }
+}

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -813,6 +813,202 @@ final class UnitTests: XCTestCase {
         XCTAssertTrue(fallback.needsFallback)
     }
 
+    // MARK: - Prompt prefill decode loop tests
+
+    /// Prepares a scripted decoder and decoding inputs equivalent to a window decoded with `promptTokens` set,
+    /// mirroring the prefill setup in `TranscribeTask` but without requiring a model.
+    private func makePromptDecodingContext(options: DecodingOptions) async throws -> (decoder: ScriptedTextDecoder, inputs: any DecodingInputsType, sampler: GreedyTokenSampler, encoderOutput: MLMultiArray) {
+        let decoder = ScriptedTextDecoder()
+        decoder.isModelMultilingual = true
+        decoder.tokenizer = CustomTokenizer(specialTokenBegin: 1000)
+
+        let sotPrompt = try decoder.prepareDecoderInputs(withPrompt: [decoder.tokenizer!.specialTokens.startOfTranscriptToken])
+        let inputs = try await decoder.prefillDecoderInputs(sotPrompt, withOptions: options)
+        let sampler = GreedyTokenSampler(temperature: 0, eotToken: decoder.tokenizer!.specialTokens.endToken, decodingOptions: options)
+        let encoderOutput = try MLMultiArray(shape: [1, 2, 1, 4], dataType: .float16, initialValue: FloatType(0))
+        return (decoder, inputs, sampler, encoderOutput)
+    }
+
+    func testDecodeTextWithPromptTokensIgnoresEOTSampledDuringPrefill() async throws {
+        // Regression test for #501/#489: an EOT sampled while the prompt prefill is being
+        // force-fed is a throwaway prediction and must not complete the segment.
+        let options = DecodingOptions(
+            sampleLength: 20,
+            withoutTimestamps: true,
+            promptTokens: [200, 201],
+            firstTokenLogProbThreshold: nil
+        )
+        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let specialTokens = decoder.tokenizer!.specialTokens
+
+        // initialPrompt = [startOfPrev, 200, 201, SOT, language, task, noTimestamps]
+        XCTAssertEqual(inputs.initialPrompt.count, 7, "Unexpected prefill prompt shape")
+
+        // The model predicts EOT at every prefill step (as observed with large-v3 turbo),
+        // then two content tokens, then a real EOT.
+        let prefillSteps = inputs.initialPrompt.count - 1
+        decoder.script =
+            Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
+                ScriptedTextDecoder.Prediction(token: 100, confident: true),
+                ScriptedTextDecoder.Prediction(token: 101, confident: true),
+                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            ]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        XCTAssertEqual(
+            result.tokens,
+            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, 101, specialTokens.endToken],
+            "Decoding should consume the full prefill and decode the content tokens"
+        )
+        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 2, "Decode loop should not stop during prefill")
+    }
+
+    func testDecodeTextWithPrefixTokensIgnoresEOTSampledDuringPrefill() async throws {
+        // `prefixTokens` extend the forced prompt the same way `promptTokens` do, and the
+        // prefill gates are unconditional. A promptTokens-only guard would miss this path.
+        let options = DecodingOptions(
+            sampleLength: 20,
+            withoutTimestamps: true,
+            prefixTokens: [300, 301],
+            firstTokenLogProbThreshold: nil
+        )
+        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let specialTokens = decoder.tokenizer!.specialTokens
+
+        // initialPrompt = [SOT, language, task, noTimestamps, 300, 301]
+        XCTAssertEqual(inputs.initialPrompt.count, 6, "Unexpected prefill prompt shape")
+
+        let prefillSteps = inputs.initialPrompt.count - 1
+        decoder.script =
+            Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
+                ScriptedTextDecoder.Prediction(token: 100, confident: true),
+                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            ]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        XCTAssertEqual(
+            result.tokens,
+            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 300, 301, 100, specialTokens.endToken],
+            "Decoding should consume the full prefix prefill and decode the content token"
+        )
+        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 1, "Decode loop should not stop during prefill")
+    }
+
+    func testDecodeTextWithPromptTokensStopsOnEOTAtFirstDecodedToken() async throws {
+        // An EOT sampled at the last prefill step is the first real prediction (e.g. silence)
+        // and must still complete the segment immediately, without appending extra tokens.
+        let options = DecodingOptions(
+            sampleLength: 20,
+            withoutTimestamps: true,
+            promptTokens: [200, 201],
+            firstTokenLogProbThreshold: nil
+        )
+        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let specialTokens = decoder.tokenizer!.specialTokens
+
+        decoder.script = [ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true)]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        XCTAssertEqual(
+            result.tokens,
+            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, specialTokens.endToken],
+            "A real EOT at the first decoded token should produce an empty segment"
+        )
+        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count, "Decoding should stop exactly at the first decoded token")
+    }
+
+    func testDecodeTextWithPromptTokensChecksFirstTokenLogProbAtFirstDecodedToken() async throws {
+        // Regression test for #489/#428: low-confidence throwaway predictions during the
+        // forced prompt prefill must not trigger the firstTokenLogProbThreshold fallback.
+        let options = DecodingOptions(
+            sampleLength: 20,
+            withoutTimestamps: true,
+            promptTokens: [200, 201],
+            firstTokenLogProbThreshold: -1.5
+        )
+        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let specialTokens = decoder.tokenizer!.specialTokens
+
+        // Unconfident throwaway predictions while the prompt is being forced,
+        // then a confident content token and a confident EOT.
+        let prefillSteps = inputs.initialPrompt.count - 1
+        decoder.script =
+            Array(repeating: ScriptedTextDecoder.Prediction(token: 100, confident: false), count: prefillSteps) + [
+                ScriptedTextDecoder.Prediction(token: 100, confident: true),
+                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            ]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        XCTAssertNotEqual(result.fallback?.fallbackReason, "firstTokenLogProbThreshold", "Throwaway prefill predictions should not trigger the first token fallback")
+        XCTAssertEqual(
+            result.tokens,
+            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, specialTokens.endToken],
+            "Decoding should complete normally when the first decoded token is confident"
+        )
+    }
+
+    func testDecodeTextWithEmptyPromptTokensDecodesNormally() async throws {
+        // An empty `promptTokens` array, or one containing only special tokens (which are
+        // filtered out), must not prepend a bare `<|startofprev|>` and must decode normally.
+        let specialOnlyPrompt = [1500] // >= specialTokenBegin (1000), filtered out during prefill
+        for promptTokens in [[Int](), specialOnlyPrompt] {
+            let options = DecodingOptions(
+                sampleLength: 20,
+                withoutTimestamps: true,
+                promptTokens: promptTokens,
+                firstTokenLogProbThreshold: nil
+            )
+            let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+            let specialTokens = decoder.tokenizer!.specialTokens
+
+            XCTAssertEqual(
+                inputs.initialPrompt,
+                [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken],
+                "An empty prompt should not add <|startofprev|> to the prefill"
+            )
+
+            let prefillSteps = inputs.initialPrompt.count - 1
+            decoder.script =
+                Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
+                    ScriptedTextDecoder.Prediction(token: 100, confident: true),
+                    ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+                ]
+
+            let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+            XCTAssertEqual(
+                result.tokens,
+                [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, specialTokens.endToken],
+                "Empty promptTokens (\(promptTokens)) should decode like a promptless run"
+            )
+        }
+    }
+
+    func testDecodeTextWithPromptTokensTriggersFirstTokenLogProbFallbackOnFirstDecodedToken() async throws {
+        // The firstTokenLogProbThreshold fallback must still fire when the first
+        // actually decoded token (after the prompt) is low-confidence.
+        let options = DecodingOptions(
+            sampleLength: 20,
+            withoutTimestamps: true,
+            promptTokens: [200, 201],
+            firstTokenLogProbThreshold: -1.5
+        )
+        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+
+        decoder.script = [ScriptedTextDecoder.Prediction(token: 100, confident: false)]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        let fallback = try XCTUnwrap(result.fallback, "Fallback should not be `nil`")
+        XCTAssertEqual(fallback.fallbackReason, "firstTokenLogProbThreshold")
+        XCTAssertTrue(fallback.needsFallback)
+        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count, "Decoding should stop at the first decoded token")
+    }
+
     func testDecodingFallbackInit() throws {
         let fallback1 = try XCTUnwrap(
             DecodingFallback(
@@ -2036,6 +2232,19 @@ final class UnitTests: XCTestCase {
         let logits3 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result3 = tokensFilter3.filterLogits(logits3, withTokens: [])
         XCTAssertEqual(result3.data(for: 2), [-FloatType.infinity, 0.2, -FloatType.infinity, 0.4, 0.5, -FloatType.infinity, -FloatType.infinity])
+
+        // The -1 sentinel ("suppress the default non-speech tokens") must be
+        // ignored, not written at index -1
+        let tokensFilter4 = SuppressTokensFilter(suppressTokens: [-1])
+        let logits4 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+        let result4 = tokensFilter4.filterLogits(logits4, withTokens: [])
+        XCTAssertEqual(result4.data(for: 2), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+
+        // Out-of-range ids (negative or beyond the vocabulary) are dropped, valid ids still apply
+        let tokensFilter5 = SuppressTokensFilter(suppressTokens: [-1, 0, 7, 100])
+        let logits5 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+        let result5 = tokensFilter5.filterLogits(logits5, withTokens: [])
+        XCTAssertEqual(result5.data(for: 2), [-FloatType.infinity, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
     }
 
     func testSuppressBlankFilter() throws {
@@ -3435,5 +3644,47 @@ class CustomTokenizer: WhisperTokenizer {
 
     func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
         return (["mock"], [[1, 2, 3]])
+    }
+}
+
+/// A `TextDecoder` that returns scripted logits instead of running a model,
+/// allowing deterministic tests of the `decodeText` loop.
+private final class ScriptedTextDecoder: TextDecoder {
+    struct Prediction {
+        let token: Int
+        /// Confident predictions have a log probability near 0,
+        /// unconfident ones near -log(vocabSize) ≈ -6.9.
+        let confident: Bool
+    }
+
+    /// Token to predict at each successive `predictLogits` call.
+    /// The last entry repeats if the decode loop runs longer than the script.
+    var script: [Prediction] = []
+    private(set) var predictionCount = 0
+
+    private let vocabSize = 1024
+
+    override var logitsSize: Int? { vocabSize }
+    override var kvCacheEmbedDim: Int? { 2 }
+    override var kvCacheMaxSequenceLength: Int? { 64 }
+    // `debugCaches` indexes alignmentWeights with a hardcoded stride of 1500,
+    // so the window size must match the real encoder output length
+    override var windowSize: Int? { 1500 }
+    override var embedSize: Int? { 2 }
+
+    override func predictLogits(_ inputs: TextDecoderInputType) async throws -> TextDecoderOutputType? {
+        let prediction = script[min(predictionCount, script.count - 1)]
+        predictionCount += 1
+
+        let logits = try MLMultiArray(shape: [1, 1, NSNumber(value: vocabSize)], dataType: .float16, initialValue: FloatType(0))
+        // Keep the spike below ~11 so exp() stays within Float16 range on the BNNS sampling path
+        logits[prediction.token] = NSNumber(value: prediction.confident ? 10.0 : 0.1)
+
+        let cache = DecodingCache(
+            keyCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
+            valueCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
+            alignmentWeights: nil
+        )
+        return TextDecoderMLMultiArrayOutputType(logits: logits, cache: cache)
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -815,42 +815,10 @@ final class UnitTests: XCTestCase {
 
     // MARK: - Prompt prefill decode loop tests
 
-    /// Prepares a scripted decoder and decoding inputs equivalent to a window decoded with the
-    /// given prompt options, mirroring the prefill setup in `TranscribeTask` but without a model.
-    ///
-    /// Timestamps are always disabled here. `CustomTokenizer` packs its special tokens into a
-    /// tiny range (`timeTokenBegin` is 7), so the content token ids these tests use (100, 200,
-    /// 300, ...) all read as timestamp tokens. A timestamp-enabled test needs a tokenizer whose
-    /// content ids sit below `timeTokenBegin`, otherwise the prefill takes the timestamp-skip
-    /// branch in `decodeText` for every step.
-    private func makePromptDecodingContext(
-        promptTokens: [Int]? = nil,
-        prefixTokens: [Int]? = nil,
-        sampleLength: Int = 20,
-        firstTokenLogProbThreshold: Float? = nil
-    ) async throws -> (decoder: ScriptedTextDecoder, inputs: any DecodingInputsType, sampler: GreedyTokenSampler, encoderOutput: MLMultiArray, options: DecodingOptions) {
-        let options = DecodingOptions(
-            sampleLength: sampleLength,
-            withoutTimestamps: true,
-            promptTokens: promptTokens,
-            prefixTokens: prefixTokens,
-            firstTokenLogProbThreshold: firstTokenLogProbThreshold
-        )
-        let decoder = ScriptedTextDecoder()
-        decoder.isModelMultilingual = true
-        decoder.tokenizer = CustomTokenizer(specialTokenBegin: 1000)
-
-        let sotPrompt = try decoder.prepareDecoderInputs(withPrompt: [decoder.tokenizer!.specialTokens.startOfTranscriptToken])
-        let inputs = try await decoder.prefillDecoderInputs(sotPrompt, withOptions: options)
-        let sampler = GreedyTokenSampler(temperature: 0, eotToken: decoder.tokenizer!.specialTokens.endToken, decodingOptions: options)
-        let encoderOutput = try MLMultiArray(shape: [1, 2, 1, 4], dataType: .float16, initialValue: FloatType(0))
-        return (decoder, inputs, sampler, encoderOutput, options)
-    }
-
-    func testDecodeTextWithPromptTokensIgnoresEOTSampledDuringPrefill() async throws {
-        // Regression test for #501/#489: an EOT sampled while the prompt prefill is being
-        // force-fed is a throwaway prediction and must not complete the segment.
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201])
+    func testEOTDuringPromptPrefillIsIgnored() async throws {
+        // An EOT sampled while the prompt is force-fed is a throwaway prediction
+        // and must not complete the segment
+        let (decoder, inputs, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext(promptTokens: [200, 201])
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // initialPrompt = [startOfPrev, 200, 201, SOT, language, task, noTimestamps]
@@ -860,10 +828,10 @@ final class UnitTests: XCTestCase {
         // then two content tokens, then a real EOT.
         let prefillSteps = inputs.initialPrompt.count - 1
         decoder.script =
-            Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
-                ScriptedTextDecoder.Prediction(token: 100, confident: true),
-                ScriptedTextDecoder.Prediction(token: 101, confident: true),
-                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            Array(repeating: MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
+                MockTextDecoder.Prediction(token: 100, confident: true),
+                MockTextDecoder.Prediction(token: 101, confident: true),
+                MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
             ]
 
         let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
@@ -876,10 +844,10 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 2, "Decode loop should not stop during prefill")
     }
 
-    func testDecodeTextWithPrefixTokensIgnoresEOTSampledDuringPrefill() async throws {
-        // `prefixTokens` extend the forced prompt the same way `promptTokens` do, and the
-        // prefill gates are unconditional. A promptTokens-only guard would miss this path.
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(prefixTokens: [300, 301])
+    func testEOTDuringPrefixPrefillIsIgnored() async throws {
+        // `prefixTokens` extend the forced prompt the same way `promptTokens` do;
+        // a promptTokens-only guard would miss this path
+        let (decoder, inputs, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext(prefixTokens: [300, 301])
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // initialPrompt = [SOT, language, task, noTimestamps, 300, 301]
@@ -887,9 +855,9 @@ final class UnitTests: XCTestCase {
 
         let prefillSteps = inputs.initialPrompt.count - 1
         decoder.script =
-            Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
-                ScriptedTextDecoder.Prediction(token: 100, confident: true),
-                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            Array(repeating: MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
+                MockTextDecoder.Prediction(token: 100, confident: true),
+                MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
             ]
 
         let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
@@ -902,28 +870,10 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 1, "Decode loop should not stop during prefill")
     }
 
-    func testDecodeTextWithPromptTokensSampleLengthBudgetsSampledTokens() async throws {
-        // sampleLength excludes prefill steps
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], sampleLength: 2)
-        let specialTokens = decoder.tokenizer!.specialTokens
-
-        decoder.script = [ScriptedTextDecoder.Prediction(token: 100, confident: true)]
-
-        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
-
-        XCTAssertEqual(
-            result.tokens,
-            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, 100, specialTokens.endToken],
-            "The full prefill should be consumed and exactly sampleLength tokens decoded"
-        )
-        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 1, "Loop should run the full prefill plus sampleLength sampled tokens")
-    }
-
-    func testPrefillWithMaxPromptAndPrefixLeavesRoomToSample() async throws {
-        // Max prompt + prefix must still leave room to sample
+    func testMaxPromptAndPrefixLeaveRoomToSample() async throws {
         let promptTokens = Array(0..<((Constants.maxTokenContext / 2) - 1))
         let prefixTokens = Array(500..<(500 + Constants.maxTokenContext / 2))
-        let (_, inputs, _, _, _) = try await makePromptDecodingContext(promptTokens: promptTokens, prefixTokens: prefixTokens)
+        let (_, inputs, _, _, _) = try await MockTextDecoder.makePromptDecodingContext(promptTokens: promptTokens, prefixTokens: prefixTokens)
 
         XCTAssertEqual(inputs.initialPrompt.count, Constants.maxTokenContext - 2, "Combined prefill should be capped below the decoding window")
 
@@ -936,10 +886,9 @@ final class UnitTests: XCTestCase {
         )
     }
 
-    func testDecodeTextWithEmptyInitialPromptThrows() async throws {
-        // The decode loop needs at least one prompt token to start from. An empty initial
-        // prompt is caller error, so it must surface as an error rather than trapping.
-        let (decoder, _, sampler, encoderOutput, options) = try await makePromptDecodingContext()
+    func testEmptyInitialPromptThrows() async throws {
+        // Caller error must surface as an error, not a trap
+        let (decoder, _, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext()
         let emptyInputs = try decoder.prepareDecoderInputs(withPrompt: [])
 
         do {
@@ -952,13 +901,13 @@ final class UnitTests: XCTestCase {
         }
     }
 
-    func testDecodeTextWithPromptTokensStopsOnEOTAtFirstDecodedToken() async throws {
-        // An EOT sampled at the last prefill step is the first real prediction (e.g. silence)
-        // and must still complete the segment immediately, without appending extra tokens.
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201])
+    func testEOTAtFirstDecodedTokenCompletesSegment() async throws {
+        // The sample at the last prefill step is the first real prediction (e.g. silence);
+        // a real EOT there must still end the segment immediately
+        let (decoder, inputs, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext(promptTokens: [200, 201])
         let specialTokens = decoder.tokenizer!.specialTokens
 
-        decoder.script = [ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true)]
+        decoder.script = [MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true)]
 
         let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
 
@@ -970,19 +919,19 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count, "Decoding should stop exactly at the first decoded token")
     }
 
-    func testDecodeTextWithPromptTokensChecksFirstTokenLogProbAtFirstDecodedToken() async throws {
-        // Regression test for #489/#428: low-confidence throwaway predictions during the
-        // forced prompt prefill must not trigger the firstTokenLogProbThreshold fallback.
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
+    func testFirstTokenLogProbIgnoresPrefillPredictions() async throws {
+        // Low-confidence throwaway predictions during the forced prompt must not
+        // trigger the firstTokenLogProbThreshold fallback
+        let (decoder, inputs, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // Unconfident throwaway predictions while the prompt is being forced,
         // then a confident content token and a confident EOT.
         let prefillSteps = inputs.initialPrompt.count - 1
         decoder.script =
-            Array(repeating: ScriptedTextDecoder.Prediction(token: 100, confident: false), count: prefillSteps) + [
-                ScriptedTextDecoder.Prediction(token: 100, confident: true),
-                ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
+            Array(repeating: MockTextDecoder.Prediction(token: 100, confident: false), count: prefillSteps) + [
+                MockTextDecoder.Prediction(token: 100, confident: true),
+                MockTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
             ]
 
         let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
@@ -995,43 +944,11 @@ final class UnitTests: XCTestCase {
         )
     }
 
-    func testDecodeTextWithEmptyPromptTokensDecodesNormally() async throws {
-        // An empty `promptTokens` array, or one containing only special tokens (which are
-        // filtered out), must not prepend a bare `<|startofprev|>` and must decode normally.
-        let specialOnlyPrompt = [1500] // >= specialTokenBegin (1000), filtered out during prefill
-        for promptTokens in [[Int](), specialOnlyPrompt] {
-            let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: promptTokens)
-            let specialTokens = decoder.tokenizer!.specialTokens
+    func testFirstTokenLogProbFallbackFiresOnFirstDecodedToken() async throws {
+        // The fallback must still fire when the first decoded token is low-confidence
+        let (decoder, inputs, sampler, encoderOutput, options) = try await MockTextDecoder.makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
 
-            XCTAssertEqual(
-                inputs.initialPrompt,
-                [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken],
-                "An empty prompt should not add <|startofprev|> to the prefill"
-            )
-
-            let prefillSteps = inputs.initialPrompt.count - 1
-            decoder.script =
-                Array(repeating: ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true), count: prefillSteps) + [
-                    ScriptedTextDecoder.Prediction(token: 100, confident: true),
-                    ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true),
-                ]
-
-            let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
-
-            XCTAssertEqual(
-                result.tokens,
-                [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, specialTokens.endToken],
-                "Empty promptTokens (\(promptTokens)) should decode like a promptless run"
-            )
-        }
-    }
-
-    func testDecodeTextWithPromptTokensTriggersFirstTokenLogProbFallbackOnFirstDecodedToken() async throws {
-        // The firstTokenLogProbThreshold fallback must still fire when the first
-        // actually decoded token (after the prompt) is low-confidence.
-        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
-
-        decoder.script = [ScriptedTextDecoder.Prediction(token: 100, confident: false)]
+        decoder.script = [MockTextDecoder.Prediction(token: 100, confident: false)]
 
         let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
 
@@ -1655,6 +1572,8 @@ final class UnitTests: XCTestCase {
             (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: false), 4 + desiredDecodingLoops + 1),
             (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: false, skipSpecialTokens: true), 1 + desiredDecodingLoops + 1),
             (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: true), 4 + desiredDecodingLoops + 1),
+            // A prompt is prefill, not sampling, so it must not shrink the output
+            (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: false, promptTokens: [1000, 1001, 1002]), 4 + desiredDecodingLoops + 1),
         ]
 
         for (option, expectedTokenCount) in optionsAndExpectedCounts {
@@ -1971,6 +1890,25 @@ final class UnitTests: XCTestCase {
         XCTAssertFalse(result.text.contains(promptText), "Prompt text should not be present in the result")
     }
 
+    func testEmptyPromptTokens() async throws {
+        // Empty prompts, including ones reduced to nothing by the special-token filter,
+        // should transcribe exactly like a promptless run
+        let baseline = try await XCTUnwrapAsync(
+            await transcribe(with: .tiny, options: DecodingOptions(skipSpecialTokens: true)),
+            "Failed to transcribe"
+        )
+        XCTAssertFalse(baseline.text.isEmpty)
+
+        let specialOnlyPrompt = [50365] // above specialTokenBegin, filtered out during prefill
+        for promptTokens in [[Int](), specialOnlyPrompt] {
+            let result = try await XCTUnwrapAsync(
+                await transcribe(with: .tiny, options: DecodingOptions(skipSpecialTokens: true, promptTokens: promptTokens)),
+                "Failed to transcribe"
+            )
+            XCTAssertEqual(result.text, baseline.text, "promptTokens \(promptTokens) should not change the transcription")
+        }
+    }
+
     func testPrefixTokens() async throws {
         let config = WhisperKitConfig(model: "tiny", verbose: true, logLevel: .debug, load: true)
         let whisperKit = try await WhisperKit(config)
@@ -2277,6 +2215,13 @@ final class UnitTests: XCTestCase {
         let logits5 = try MLMultiArray.logits([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
         let result5 = tokensFilter5.filterLogits(logits5, withTokens: [])
         XCTAssertEqual(result5.data(for: 2), [-FloatType.infinity, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7])
+    }
+
+    func testFillSkipsInvalidIndexes() throws {
+        // Rank-mismatched indexes are skipped rather than written at a partial offset
+        let logits = try MLMultiArray.logits([0.1, 0.2, 0.3])
+        logits.fill(indexes: [[1], [0, 0, 1], [0, 0, 2, 9]], with: -FloatType.infinity)
+        XCTAssertEqual(logits.data(for: 2), [0.1, -FloatType.infinity, 0.3])
     }
 
     func testSuppressBlankFilter() throws {
@@ -3671,47 +3616,5 @@ class CustomTokenizer: WhisperTokenizer {
 
     func splitToWordTokens(tokenIds: [Int]) -> (words: [String], wordTokens: [[Int]]) {
         return (["mock"], [[1, 2, 3]])
-    }
-}
-
-/// A `TextDecoder` that returns scripted logits instead of running a model,
-/// allowing deterministic tests of the `decodeText` loop.
-private final class ScriptedTextDecoder: TextDecoder {
-    struct Prediction {
-        let token: Int
-        /// Confident predictions have a log probability near 0,
-        /// unconfident ones near -log(vocabSize) ≈ -6.9.
-        let confident: Bool
-    }
-
-    /// Token to predict at each successive `predictLogits` call.
-    /// The last entry repeats if the decode loop runs longer than the script.
-    var script: [Prediction] = []
-    private(set) var predictionCount = 0
-
-    private let vocabSize = 1024
-
-    override var logitsSize: Int? { vocabSize }
-    override var kvCacheEmbedDim: Int? { 2 }
-    override var kvCacheMaxSequenceLength: Int? { 64 }
-    // `debugCaches` indexes alignmentWeights with a hardcoded stride of 1500,
-    // so the window size must match the real encoder output length
-    override var windowSize: Int? { 1500 }
-    override var embedSize: Int? { 2 }
-
-    override func predictLogits(_ inputs: TextDecoderInputType) async throws -> TextDecoderOutputType? {
-        let prediction = script[min(predictionCount, script.count - 1)]
-        predictionCount += 1
-
-        let logits = try MLMultiArray(shape: [1, 1, NSNumber(value: vocabSize)], dataType: .float16, initialValue: FloatType(0))
-        // Keep the spike below ~11 so exp() stays within Float16 range on the BNNS sampling path
-        logits[prediction.token] = NSNumber(value: prediction.confident ? 10.0 : 0.1)
-
-        let cache = DecodingCache(
-            keyCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
-            valueCache: try MLMultiArray(shape: [1, 2, 1, 1], dataType: .float16, initialValue: FloatType(0)),
-            alignmentWeights: nil
-        )
-        return TextDecoderMLMultiArrayOutputType(logits: logits, cache: cache)
     }
 }

--- a/Tests/WhisperKitTests/UnitTests.swift
+++ b/Tests/WhisperKitTests/UnitTests.swift
@@ -815,9 +815,27 @@ final class UnitTests: XCTestCase {
 
     // MARK: - Prompt prefill decode loop tests
 
-    /// Prepares a scripted decoder and decoding inputs equivalent to a window decoded with `promptTokens` set,
-    /// mirroring the prefill setup in `TranscribeTask` but without requiring a model.
-    private func makePromptDecodingContext(options: DecodingOptions) async throws -> (decoder: ScriptedTextDecoder, inputs: any DecodingInputsType, sampler: GreedyTokenSampler, encoderOutput: MLMultiArray) {
+    /// Prepares a scripted decoder and decoding inputs equivalent to a window decoded with the
+    /// given prompt options, mirroring the prefill setup in `TranscribeTask` but without a model.
+    ///
+    /// Timestamps are always disabled here. `CustomTokenizer` packs its special tokens into a
+    /// tiny range (`timeTokenBegin` is 7), so the content token ids these tests use (100, 200,
+    /// 300, ...) all read as timestamp tokens. A timestamp-enabled test needs a tokenizer whose
+    /// content ids sit below `timeTokenBegin`, otherwise the prefill takes the timestamp-skip
+    /// branch in `decodeText` for every step.
+    private func makePromptDecodingContext(
+        promptTokens: [Int]? = nil,
+        prefixTokens: [Int]? = nil,
+        sampleLength: Int = 20,
+        firstTokenLogProbThreshold: Float? = nil
+    ) async throws -> (decoder: ScriptedTextDecoder, inputs: any DecodingInputsType, sampler: GreedyTokenSampler, encoderOutput: MLMultiArray, options: DecodingOptions) {
+        let options = DecodingOptions(
+            sampleLength: sampleLength,
+            withoutTimestamps: true,
+            promptTokens: promptTokens,
+            prefixTokens: prefixTokens,
+            firstTokenLogProbThreshold: firstTokenLogProbThreshold
+        )
         let decoder = ScriptedTextDecoder()
         decoder.isModelMultilingual = true
         decoder.tokenizer = CustomTokenizer(specialTokenBegin: 1000)
@@ -826,19 +844,13 @@ final class UnitTests: XCTestCase {
         let inputs = try await decoder.prefillDecoderInputs(sotPrompt, withOptions: options)
         let sampler = GreedyTokenSampler(temperature: 0, eotToken: decoder.tokenizer!.specialTokens.endToken, decodingOptions: options)
         let encoderOutput = try MLMultiArray(shape: [1, 2, 1, 4], dataType: .float16, initialValue: FloatType(0))
-        return (decoder, inputs, sampler, encoderOutput)
+        return (decoder, inputs, sampler, encoderOutput, options)
     }
 
     func testDecodeTextWithPromptTokensIgnoresEOTSampledDuringPrefill() async throws {
         // Regression test for #501/#489: an EOT sampled while the prompt prefill is being
         // force-fed is a throwaway prediction and must not complete the segment.
-        let options = DecodingOptions(
-            sampleLength: 20,
-            withoutTimestamps: true,
-            promptTokens: [200, 201],
-            firstTokenLogProbThreshold: nil
-        )
-        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201])
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // initialPrompt = [startOfPrev, 200, 201, SOT, language, task, noTimestamps]
@@ -867,13 +879,7 @@ final class UnitTests: XCTestCase {
     func testDecodeTextWithPrefixTokensIgnoresEOTSampledDuringPrefill() async throws {
         // `prefixTokens` extend the forced prompt the same way `promptTokens` do, and the
         // prefill gates are unconditional. A promptTokens-only guard would miss this path.
-        let options = DecodingOptions(
-            sampleLength: 20,
-            withoutTimestamps: true,
-            prefixTokens: [300, 301],
-            firstTokenLogProbThreshold: nil
-        )
-        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(prefixTokens: [300, 301])
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // initialPrompt = [SOT, language, task, noTimestamps, 300, 301]
@@ -896,16 +902,60 @@ final class UnitTests: XCTestCase {
         XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 1, "Decode loop should not stop during prefill")
     }
 
+    func testDecodeTextWithPromptTokensSampleLengthBudgetsSampledTokens() async throws {
+        // sampleLength excludes prefill steps
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], sampleLength: 2)
+        let specialTokens = decoder.tokenizer!.specialTokens
+
+        decoder.script = [ScriptedTextDecoder.Prediction(token: 100, confident: true)]
+
+        let result = try await decoder.decodeText(from: encoderOutput, using: inputs, sampler: sampler, options: options)
+
+        XCTAssertEqual(
+            result.tokens,
+            [specialTokens.startOfTranscriptToken, specialTokens.englishToken, specialTokens.transcribeToken, specialTokens.noTimestampsToken, 100, 100, specialTokens.endToken],
+            "The full prefill should be consumed and exactly sampleLength tokens decoded"
+        )
+        XCTAssertEqual(decoder.predictionCount, inputs.initialPrompt.count + 1, "Loop should run the full prefill plus sampleLength sampled tokens")
+    }
+
+    func testPrefillWithMaxPromptAndPrefixLeavesRoomToSample() async throws {
+        // Max prompt + prefix must still leave room to sample
+        let promptTokens = Array(0..<((Constants.maxTokenContext / 2) - 1))
+        let prefixTokens = Array(500..<(500 + Constants.maxTokenContext / 2))
+        let (_, inputs, _, _, _) = try await makePromptDecodingContext(promptTokens: promptTokens, prefixTokens: prefixTokens)
+
+        XCTAssertEqual(inputs.initialPrompt.count, Constants.maxTokenContext - 2, "Combined prefill should be capped below the decoding window")
+
+        let sotSequenceLength = 4 // SOT, language, task, noTimestamps
+        let expectedPrefixCount = Constants.maxTokenContext - 2 - (1 + promptTokens.count + sotSequenceLength)
+        XCTAssertEqual(
+            Array(inputs.initialPrompt.suffix(expectedPrefixCount)),
+            Array(prefixTokens.suffix(expectedPrefixCount)),
+            "The prefix should keep its suffix when trimmed to the remaining budget"
+        )
+    }
+
+    func testDecodeTextWithEmptyInitialPromptThrows() async throws {
+        // The decode loop needs at least one prompt token to start from. An empty initial
+        // prompt is caller error, so it must surface as an error rather than trapping.
+        let (decoder, _, sampler, encoderOutput, options) = try await makePromptDecodingContext()
+        let emptyInputs = try decoder.prepareDecoderInputs(withPrompt: [])
+
+        do {
+            _ = try await decoder.decodeText(from: encoderOutput, using: emptyInputs, sampler: sampler, options: options)
+            XCTFail("Decoding an empty initial prompt should throw")
+        } catch let error as WhisperError {
+            guard case .prepareDecoderInputsFailed = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
     func testDecodeTextWithPromptTokensStopsOnEOTAtFirstDecodedToken() async throws {
         // An EOT sampled at the last prefill step is the first real prediction (e.g. silence)
         // and must still complete the segment immediately, without appending extra tokens.
-        let options = DecodingOptions(
-            sampleLength: 20,
-            withoutTimestamps: true,
-            promptTokens: [200, 201],
-            firstTokenLogProbThreshold: nil
-        )
-        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201])
         let specialTokens = decoder.tokenizer!.specialTokens
 
         decoder.script = [ScriptedTextDecoder.Prediction(token: specialTokens.endToken, confident: true)]
@@ -923,13 +973,7 @@ final class UnitTests: XCTestCase {
     func testDecodeTextWithPromptTokensChecksFirstTokenLogProbAtFirstDecodedToken() async throws {
         // Regression test for #489/#428: low-confidence throwaway predictions during the
         // forced prompt prefill must not trigger the firstTokenLogProbThreshold fallback.
-        let options = DecodingOptions(
-            sampleLength: 20,
-            withoutTimestamps: true,
-            promptTokens: [200, 201],
-            firstTokenLogProbThreshold: -1.5
-        )
-        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
         let specialTokens = decoder.tokenizer!.specialTokens
 
         // Unconfident throwaway predictions while the prompt is being forced,
@@ -956,13 +1000,7 @@ final class UnitTests: XCTestCase {
         // filtered out), must not prepend a bare `<|startofprev|>` and must decode normally.
         let specialOnlyPrompt = [1500] // >= specialTokenBegin (1000), filtered out during prefill
         for promptTokens in [[Int](), specialOnlyPrompt] {
-            let options = DecodingOptions(
-                sampleLength: 20,
-                withoutTimestamps: true,
-                promptTokens: promptTokens,
-                firstTokenLogProbThreshold: nil
-            )
-            let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+            let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: promptTokens)
             let specialTokens = decoder.tokenizer!.specialTokens
 
             XCTAssertEqual(
@@ -991,13 +1029,7 @@ final class UnitTests: XCTestCase {
     func testDecodeTextWithPromptTokensTriggersFirstTokenLogProbFallbackOnFirstDecodedToken() async throws {
         // The firstTokenLogProbThreshold fallback must still fire when the first
         // actually decoded token (after the prompt) is low-confidence.
-        let options = DecodingOptions(
-            sampleLength: 20,
-            withoutTimestamps: true,
-            promptTokens: [200, 201],
-            firstTokenLogProbThreshold: -1.5
-        )
-        let (decoder, inputs, sampler, encoderOutput) = try await makePromptDecodingContext(options: options)
+        let (decoder, inputs, sampler, encoderOutput, options) = try await makePromptDecodingContext(promptTokens: [200, 201], firstTokenLogProbThreshold: -1.5)
 
         decoder.script = [ScriptedTextDecoder.Prediction(token: 100, confident: false)]
 
@@ -1616,21 +1648,21 @@ final class UnitTests: XCTestCase {
 
     func testSampleLength() async throws {
         let desiredDecodingLoops = 5
-        let targetTokenCount = 7 // Account for the first token and the end of transcript token, which dont require decoding loops
 
-        let options = [
-            DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: false, skipSpecialTokens: false),
-            DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: false),
-            DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: false, skipSpecialTokens: true),
-            DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: true),
+        // Expected length = prefill + sampleLength + EOT
+        let optionsAndExpectedCounts = [
+            (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: false, skipSpecialTokens: false), 1 + desiredDecodingLoops + 1),
+            (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: false), 4 + desiredDecodingLoops + 1),
+            (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: false, skipSpecialTokens: true), 1 + desiredDecodingLoops + 1),
+            (DecodingOptions(sampleLength: desiredDecodingLoops, usePrefillPrompt: true, skipSpecialTokens: true), 4 + desiredDecodingLoops + 1),
         ]
 
-        for option in options {
+        for (option, expectedTokenCount) in optionsAndExpectedCounts {
             let result = try await XCTUnwrapAsync(
                 await transcribe(with: .tiny, options: option),
                 "Failed to transcribe"
             )
-            XCTAssertEqual(result.segments.first?.tokens.count, targetTokenCount)
+            XCTAssertEqual(result.segments.first?.tokens.count, expectedTokenCount)
         }
     }
 
@@ -3395,7 +3427,6 @@ final class UnitTests: XCTestCase {
 
         let allFilters = decoder.createLogitsFilters(
             options: options,
-            prefilledIndex: 0,
             initialPromptIndex: 1,
             tokenizer: tokenizer
         )
@@ -3417,7 +3448,6 @@ final class UnitTests: XCTestCase {
 
         let allFilters = decoder.createLogitsFilters(
             options: options,
-            prefilledIndex: 0,
             initialPromptIndex: 1,
             tokenizer: tokenizer
         )
@@ -3439,7 +3469,6 @@ final class UnitTests: XCTestCase {
 
         let allFilters = decoder.createLogitsFilters(
             options: options,
-            prefilledIndex: 0,
             initialPromptIndex: 1,
             tokenizer: tokenizer
         )
@@ -3464,7 +3493,6 @@ final class UnitTests: XCTestCase {
 
         let allFilters = decoder.createLogitsFilters(
             options: options,
-            prefilledIndex: 0,
             initialPromptIndex: 1,
             tokenizer: tokenizer
         )
@@ -3488,7 +3516,6 @@ final class UnitTests: XCTestCase {
 
         let allFilters = decoder.createLogitsFilters(
             options: options,
-            prefilledIndex: 0,
             initialPromptIndex: 1,
             tokenizer: tokenizer
         )


### PR DESCRIPTION
Fixes #372, fixes #489, fixes #501, fixes #392.

## Problem

Setting `DecodingOptions.promptTokens` returns an empty transcription with no error. Issue #501 has a decoder trace and reliable repro on `large-v3 turbo`; Issue #489 has audio to reproduce.

The decode loop force-feeds the initial prompt one token per step, and the token sampled at each of those steps is a throwaway that the next forced token overwrites. Two early-exit checks still honored those throwaways:

1. A sampled `<|endoftext|>` during prefill ended the segment before a single content token was decoded.
2. The first-token confidence check ran at step 0 (a throwaway) instead of the first decoded token, so `firstTokenLogProbThreshold` could trigger a spurious fallback.

## Fix

- Ignore `completed` while the prompt is still being forced: `(sampleResult.completed && !isPrefill)`. The last prefill step produces the first real prediction, so a real EOT there (for example silence) still ends the segment immediately.
- Anchor the first-token check at that first real prediction: `tokenIndex == max(0, initialPromptIndex - 1)`. This restores the anchor the check had before PR #467 removed the KV-cache prefill.
- Skip the prompt when it is empty after trimming, instead of prepending a bare `<|startofprev|>` that biases the model toward ending early.

Related fixes that fell out of the same work:

- `sampleLength` now counts sampled tokens, as documented; prefill steps no longer consume the budget. `testSampleLength` expectations updated to match.
- The prefix is capped so a maxed prompt plus prefix always leaves room to sample.
- Window resets clear the full context, since the loop can now use positions past `sampleLength`.
- `SuppressBlankFilter` anchors at `initialPromptIndex` (it was permanently inactive), the dead always-0 `prefilledIndex` bookkeeping is deleted, and an empty initial prompt throws instead of trapping.

## Crash fix (Issue #392)

`MLMultiArray.fill(indexes:with:)` now bounds-checks indices. `suppressTokens: [-1]`, the reference implementation's "suppress non-speech tokens" sentinel, wrote before the start of the logits buffer and crashed on iOS 26. It is now safely ignored and logged at debug level; expanding the sentinel remains unsupported.

## Relationship to existing PRs

This combines the correct parts of PR #502 (the EOT gate, used as-is) and PR #428 (the first-token re-anchor, off-by-one corrected), applied unconditionally so `prefixTokens` are covered too, where PR #497 guards on `promptTokens` only. PR #438 disables the threshold when prompts are set instead of re-anchoring it, and PR #483 bundles PR #428 and PR #438. PR #460 fixes the Issue #392 crash by filtering ids before they reach the filter; this PR guards at the `fill` layer, which also covers ids past the vocabulary and the other `fill` callers.

## Tests

Tested using a text decoder mock (`MockTextDecoder`) that feeds scripted logits through the real decode loop:

- `testEOTDuringPromptPrefillIsIgnored`: EOT sampled during prefill is ignored and the prompt is fully consumed
- `testEOTDuringPrefixPrefillIsIgnored`: same protection for `prefixTokens`
- `testEOTAtFirstDecodedTokenCompletesSegment`: a real EOT at the first decoded token still ends the segment
- `testFirstTokenLogProbIgnoresPrefillPredictions`: prefill throwaways do not trigger the confidence fallback
- `testFirstTokenLogProbFallbackFiresOnFirstDecodedToken`: a low-confidence first decoded token still does
- `testMaxPromptAndPrefixLeaveRoomToSample`: a maxed prompt plus prefix is capped below the decoding window
- `testEmptyInitialPromptThrows`: an empty initial prompt throws instead of trapping

Tested using a real model (tiny): a prompted `testSampleLength` case, the new `testEmptyPromptTokens`, and the existing `testPromptTokens`.

## Credits

This builds directly on the analysis and fixes from @hakanensari (PR #502), @yangzichao (PR #497), @sborisov88 (PR #428), and @alan890104 (PR #438). All four are credited as co-authors in the commit.
