### PR TITLE
Use Unicode sentence segmentation for TextChunker boundaries

### DIFF
--- a/Sources/ArgmaxCore/FoundationExtensions.swift
+++ b/Sources/ArgmaxCore/FoundationExtensions.swift
@@ -73,10 +73,11 @@ extension String {
     /// reaches `minTokenCount`.
     ///
     /// Sentence segmentation keeps decimals, emails, and ellipses intact. The final
-    /// segment is only accepted when it ends in a terminator (. ! ?) after trailing
-    /// whitespace and closing quotes/brackets are stripped, so a window truncated
-    /// mid-sentence is not treated as a boundary. Clause enders only count when they
-    /// terminate a word, which avoids splitting mid-word hyphens.
+    /// segment is only accepted when it ends at a paragraph break or in a terminator
+    /// (. ! ? and non-ASCII equivalents) after trailing whitespace and closing
+    /// quotes/brackets are stripped, so a window truncated mid-sentence is not treated
+    /// as a boundary. Clause enders only count when they terminate a word, which
+    /// avoids splitting mid-word hyphens.
     ///
     /// - Parameters:
     ///   - minTokenCount: Minimum number of tokens the candidate must contain.
@@ -85,7 +86,13 @@ extension String {
     ///   boundary, or `nil`. The prefix is returned untrimmed because `TextChunker`
     ///   advances its token stream by the prefix's encoded length; trim only for display.
     public func lastNaturalBoundary(minTokenCount: Int, encode: (String) -> [Int]) -> String? {
-        let sentenceTerminators: Set<Character> = [".", "!", "?"]
+        let sentenceTerminators: Set<Character> = [
+            ".", "!", "?",
+            "\u{2026}", // … Horizontal ellipsis
+            "\u{3002}", // 。 Ideographic full stop
+            "\u{FF01}", // ！ Fullwidth exclamation mark
+            "\u{FF1F}", // ？ Fullwidth question mark
+        ]
         let clauseEnders: Set<Character> = [
             ",", ";", ":", "-",
             "\u{2013}", // – En dash
@@ -94,7 +101,9 @@ extension String {
             "\"", "'",
             "\u{201D}", // ” Right double quotation mark
             "\u{2019}", // ’ Right single quotation mark
-            ")", "]",
+            ")", "]", "}",
+            "\u{00BB}", // » Right-pointing double angle quotation mark
+            "\u{300D}", // 」 Right corner bracket
         ]
 
         var sentenceRanges: [Range<String.Index>] = []
@@ -106,11 +115,16 @@ extension String {
             let range = sentenceRanges[index]
 
             // Skip a truncated final fragment left by the caller's token window: the
-            // last meaningful character (ignoring trailing whitespace and closing
-            // quotes/brackets) must be a terminator. A bare trailing space is not enough.
+            // segment must end at a paragraph break, or its last meaningful character
+            // (ignoring trailing whitespace and closing quotes/brackets) must be a
+            // terminator. A bare trailing space is not enough.
             if index == sentenceRanges.count - 1 {
-                guard let lastMeaningful = self[range].last(where: { !$0.isWhitespace && !closers.contains($0) }),
-                      sentenceTerminators.contains(lastMeaningful)
+                let segment = self[range]
+                let endsAtParagraphBreak = segment.reversed()
+                    .prefix(while: { $0.isWhitespace || closers.contains($0) })
+                    .contains(where: \.isNewline)
+                let lastMeaningful = segment.last(where: { !$0.isWhitespace && !closers.contains($0) })
+                guard endsAtParagraphBreak || lastMeaningful.map(sentenceTerminators.contains) == true
                 else { continue }
             }
 

--- a/Sources/ArgmaxCore/FoundationExtensions.swift
+++ b/Sources/ArgmaxCore/FoundationExtensions.swift
@@ -67,31 +67,78 @@ extension Array where Element: Hashable {
 extension String {
     /// Returns the text up to and including the last natural boundary in the string.
     ///
-    /// Boundaries are tested in priority order: sentence enders (. ! ? \n), clause
-    /// enders (, ; : - –), then word boundaries (space). A candidate is only accepted
-    /// when its encoded token count reaches `minTokenCount`.
+    /// Boundaries are tested in priority order: sentence boundaries (from Unicode
+    /// sentence segmentation), then clause enders (, ; : - and en dash), then word
+    /// boundaries (space). A candidate is only accepted when its encoded token count
+    /// reaches `minTokenCount`.
+    ///
+    /// Sentence segmentation keeps decimals, emails, and ellipses intact. The final
+    /// segment is only accepted when it ends in a terminator (. ! ?) after trailing
+    /// whitespace and closing quotes/brackets are stripped, so a window truncated
+    /// mid-sentence is not treated as a boundary. Clause enders only count when they
+    /// terminate a word, which avoids splitting mid-word hyphens.
     ///
     /// - Parameters:
     ///   - minTokenCount: Minimum number of tokens the candidate must contain.
     ///   - encode: Closure that tokenizes a string and returns its token IDs.
-    /// - Returns: The trimmed substring up to the last qualifying boundary, or `nil`.
+    /// - Returns: The untrimmed prefix up to (and including) the last qualifying
+    ///   boundary, or `nil`. The prefix is returned untrimmed because `TextChunker`
+    ///   advances its token stream by the prefix's encoded length; trim only for display.
     public func lastNaturalBoundary(minTokenCount: Int, encode: (String) -> [Int]) -> String? {
-        let sentenceEnders: [Character] = [".", "!", "?", "\n"]
-        let clauseEnders: [Character] = [",", ";", ":", "-", "–"]
+        let sentenceTerminators: Set<Character> = [".", "!", "?"]
+        let clauseEnders: Set<Character> = [
+            ",", ";", ":", "-",
+            "\u{2013}", // – En dash
+        ]
+        let closers: Set<Character> = [
+            "\"", "'",
+            "\u{201D}", // ” Right double quotation mark
+            "\u{2019}", // ’ Right single quotation mark
+            ")", "]",
+        ]
 
-        for enders in [sentenceEnders, clauseEnders] {
-            if let idx = lastIndex(where: { enders.contains($0) }) {
-                let candidate = String(self[...idx]).trimmingCharacters(in: .whitespacesAndNewlines)
-                if encode(candidate).count >= minTokenCount {
-                    return candidate
-                }
+        var sentenceRanges: [Range<String.Index>] = []
+        enumerateSubstrings(in: startIndex..<endIndex, options: [.bySentences]) { _, range, _, _ in
+            sentenceRanges.append(range)
+        }
+
+        for index in stride(from: sentenceRanges.count - 1, through: 0, by: -1) {
+            let range = sentenceRanges[index]
+
+            // Skip a truncated final fragment left by the caller's token window: the
+            // last meaningful character (ignoring trailing whitespace and closing
+            // quotes/brackets) must be a terminator. A bare trailing space is not enough.
+            if index == sentenceRanges.count - 1 {
+                guard let lastMeaningful = self[range].last(where: { !$0.isWhitespace && !closers.contains($0) }),
+                      sentenceTerminators.contains(lastMeaningful)
+                else { continue }
+            }
+
+            let prefix = String(self[..<range.upperBound])
+            if encode(prefix.trimmingCharacters(in: .whitespacesAndNewlines)).count >= minTokenCount {
+                return prefix
             }
         }
 
-        if let idx = lastIndex(of: " ") {
-            let candidate = String(self[..<idx]).trimmingCharacters(in: .whitespacesAndNewlines)
-            if encode(candidate).count >= minTokenCount {
-                return candidate
+        // Clause enders are not sentence boundaries; only accept word-terminating ones.
+        let characters = Array(self)
+        var characterIndex = characters.count - 1
+        while characterIndex >= 0 {
+            let isAtEnd = characterIndex + 1 == characters.count
+            let isFollowedByWhitespace = !isAtEnd && characters[characterIndex + 1].isWhitespace
+            if clauseEnders.contains(characters[characterIndex]), isAtEnd || isFollowedByWhitespace {
+                let prefix = String(characters[0...characterIndex])
+                if encode(prefix.trimmingCharacters(in: .whitespacesAndNewlines)).count >= minTokenCount {
+                    return prefix
+                }
+            }
+            characterIndex -= 1
+        }
+
+        if let spaceIndex = lastIndex(of: " ") {
+            let prefix = String(self[..<spaceIndex])
+            if encode(prefix.trimmingCharacters(in: .whitespacesAndNewlines)).count >= minTokenCount {
+                return prefix
             }
         }
 

--- a/Sources/ArgmaxCore/FoundationExtensions.swift
+++ b/Sources/ArgmaxCore/FoundationExtensions.swift
@@ -72,7 +72,9 @@ extension String {
     /// boundaries (space). A candidate is only accepted when its encoded token count
     /// reaches `minTokenCount`.
     ///
-    /// Sentence segmentation keeps decimals, emails, and ellipses intact. The final
+    /// Sentence segmentation is locale-aware (`.localized`), so common abbreviations
+    /// like "Mr." or "U.S." do not end a sentence. It keeps decimals, emails, and
+    /// ellipses intact. The final
     /// segment is only accepted when it ends at a paragraph break or in a terminator
     /// (. ! ? and non-ASCII equivalents) after trailing whitespace and closing
     /// quotes/brackets are stripped, so a window truncated mid-sentence is not treated
@@ -107,7 +109,7 @@ extension String {
         ]
 
         var sentenceRanges: [Range<String.Index>] = []
-        enumerateSubstrings(in: startIndex..<endIndex, options: [.bySentences]) { _, range, _, _ in
+        enumerateSubstrings(in: startIndex..<endIndex, options: [.bySentences, .localized]) { _, range, _, _ in
             sentenceRanges.append(range)
         }
 

--- a/Sources/TTSKit/Utilities/TextChunker.swift
+++ b/Sources/TTSKit/Utilities/TextChunker.swift
@@ -92,20 +92,21 @@ public struct TextChunker {
                 break
             }
 
-            // Decode a window of targetChunkSize tokens, then find the best boundary within it
+            // Decode a window of targetChunkSize tokens, then find the best boundary.
+            // Keep the window untrimmed so the accepted prefix matches the token stream
+            // exactly; trim only when appending the display chunk below.
             let window = Array(tokens.prefix(targetChunkSize))
             let windowText = decodeTokens(window)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
 
-            let accepted = windowText.lastNaturalBoundary(minTokenCount: minChunkSize, encode: encodeText) ?? windowText
-
+            let acceptedPrefix = windowText.lastNaturalBoundary(minTokenCount: minChunkSize, encode: encodeText) ?? windowText
+            let accepted = acceptedPrefix.trimmingCharacters(in: .whitespacesAndNewlines)
             if !accepted.isEmpty {
                 chunks.append(accepted)
             }
 
-            // Re-tokenize the accepted text to advance by its exact token count,
-            // avoiding drift from imperfect encode/decode round-trips
-            let consumed = encodeText(accepted).count
+            // Re-tokenize the accepted prefix to advance by its exact token count,
+            // avoiding drift from imperfect encode/decode round-trips.
+            let consumed = encodeText(acceptedPrefix).count
             tokens.removeFirst(min(max(consumed, 1), tokens.count))
         }
 

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -91,6 +91,20 @@ final class TTSKitUnitTests: XCTestCase {
         )
     }
 
+    /// Asserts whitespace-normalized chunks reassemble to the input text.
+    private func assertReconstructs(
+        _ chunks: [String],
+        _ text: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let joined = chunks.joined(separator: " ")
+            .split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        let original = text
+            .split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        XCTAssertEqual(joined, original, "Chunks must reconstruct the input", file: file, line: line)
+    }
+
     func testChunkerShortText() {
         let chunker = makeChunker(targetChunkSize: 50, minChunkSize: 5)
         XCTAssertEqual(chunker.chunk("Hello world."), ["Hello world."])
@@ -109,9 +123,7 @@ final class TTSKitUnitTests: XCTestCase {
         let text = "This is the first sentence. This is the second sentence. And here is a third one."
         let chunks = chunker.chunk(text)
         XCTAssertGreaterThan(chunks.count, 1, "Should split into multiple chunks")
-        let recombined = chunks.joined(separator: " ")
-        XCTAssertTrue(recombined.contains("first sentence"))
-        XCTAssertTrue(recombined.contains("third one"))
+        assertReconstructs(chunks, text)
     }
 
     func testChunkerMergesTinyTrailing() {
@@ -122,6 +134,66 @@ final class TTSKitUnitTests: XCTestCase {
         let text = "A reasonably long sentence that is here. X."
         let chunks = chunker.chunk(text)
         XCTAssertEqual(chunks.count, 1, "Tiny trailing chunk should merge with previous")
+        assertReconstructs(chunks, text)
+    }
+
+    func testChunkerReconstructsAcrossParagraphBreaks() {
+        // Paragraph whitespace must not leak boundary characters into the next chunk:
+        //
+        //   bad:  ["First sentence.", ". Second sentence."]
+        //   good: ["First sentence.", "Second sentence."]
+        //
+        let text = "First sentence.\n\nSecond sentence."
+        let chunker = makeChunker(targetChunkSize: 20, minChunkSize: 5)
+        let chunks = chunker.chunk(text)
+        XCTAssertEqual(chunks, ["First sentence.", "Second sentence."])
+        assertReconstructs(chunks, text)
+    }
+
+    func testChunkerDoesNotSplitDecimalsEmailsEllipses() {
+        // Periods inside decimals, emails, and ellipses are not sentence boundaries:
+        //
+        //   bad:  ["It costs $8.", "50 today. Email info@test.", "org ..."]
+        //   good: ["It costs $8.50 today.", "Email info@test.org for offers."]
+        //
+        let text = "It costs $8.50 today. Email info@test.org for offers. Probably... the end."
+        let chunker = makeChunker(targetChunkSize: 45, minChunkSize: 5)
+        let chunks = chunker.chunk(text)
+        assertReconstructs(chunks, text)
+        XCTAssertTrue(chunks.contains { $0.contains("$8.50") }, "Decimal split across chunks: \(chunks)")
+        XCTAssertTrue(chunks.contains { $0.contains("info@test.org") }, "Email split across chunks: \(chunks)")
+        XCTAssertTrue(chunks.contains { $0.contains("Probably...") }, "Ellipsis split across chunks: \(chunks)")
+        for chunk in chunks {
+            XCTAssertFalse(chunk.hasPrefix("50 "), "Decimal fraction stranded: \(chunk)")
+            XCTAssertFalse(chunk.hasPrefix("org "), "Email TLD stranded: \(chunk)")
+        }
+    }
+
+    func testChunkerQuoteAttachedSentenceEnd() {
+        // A closing quote after a sentence ender stays on the sentence's chunk:
+        //
+        //   bad:  ["He said \"Hello.", "\" Then left."]
+        //   good: ["He said \"Hello.\"", "Then left."]
+        //
+        let text = "He said \"Hello.\" Then left."
+        let chunker = makeChunker(targetChunkSize: 20, minChunkSize: 5)
+        let chunks = chunker.chunk(text)
+        XCTAssertEqual(chunks, ["He said \"Hello.\"", "Then left."])
+        assertReconstructs(chunks, text)
+    }
+
+    func testChunkerSkipsTruncatedSentenceEndingInWhitespace() {
+        // "First sentence. Second incomplete " = 34 chars, so a 34-char window ends on a
+        // trailing space mid-sentence. That fragment must not count as a full sentence:
+        //
+        //   bad:  ["First sentence. Second incomplete and more"]
+        //   good: ["First sentence.", "Second incomplete and more words here."]
+        //
+        let text = "First sentence. Second incomplete and more words here."
+        let chunker = makeChunker(targetChunkSize: 34, minChunkSize: 5)
+        let chunks = chunker.chunk(text)
+        XCTAssertEqual(chunks.first, "First sentence.")
+        assertReconstructs(chunks, text)
     }
 
     // MARK: - Embedding Math
@@ -1032,11 +1104,7 @@ final class TTSKitUnitTests: XCTestCase {
         let sentences = (1...10).map { "Sentence number \($0) is here." }
         let text = sentences.joined(separator: " ")
         let chunks = chunker.chunk(text)
-        let rejoined = chunks.joined(separator: " ")
-        for sentence in sentences {
-            XCTAssertTrue(rejoined.contains(sentence.dropLast(1)), // drop period; joins may vary
-                "Missing content: \(sentence)")
-        }
+        assertReconstructs(chunks, text)
     }
 
     func testChunkerWordBoundaryFallback() {

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -129,6 +129,14 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), window)
     }
 
+    func testBoundaryDoesNotSplitAfterAbbreviation() {
+        // Locale-aware segmentation (.localized) knows "Mr." does not end a
+        // sentence, so the sentence tier offers no boundary here and the
+        // word-space fallback splits before the last word instead.
+        let window = "He met Mr. Smith yesterday and then"
+        XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), "He met Mr. Smith yesterday and")
+    }
+
     func testBoundaryStillRejectsMidSentenceWindowEdge() {
         // A window truncated mid-sentence must fall back to an earlier boundary.
         let window = "First sentence. Second incomplete and more"

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -86,7 +86,7 @@ final class TTSKitUnitTests: XCTestCase {
         TextChunker(
             targetChunkSize: targetChunkSize,
             minChunkSize: minChunkSize,
-            encode: { $0.unicodeScalars.map { Int($0.value) } },
+            encode: scalarEncode,
             decode: { String($0.compactMap { Unicode.Scalar($0) }.map { Character($0) }) }
         )
     }
@@ -102,7 +102,37 @@ final class TTSKitUnitTests: XCTestCase {
             .split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
         let original = text
             .split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
-        XCTAssertEqual(joined, original, "Chunks must reconstruct the input", file: file, line: line)
+        XCTAssertEqual(joined, original, "Chunks must reconstruct the input (whitespace-normalized)", file: file, line: line)
+    }
+
+    /// Encodes 1 unicode scalar per token, matching `makeChunker`.
+    private let scalarEncode: (String) -> [Int] = { $0.unicodeScalars.map { Int($0.value) } }
+
+    func testBoundaryAcceptsCJKTerminatorAtWindowEdge() {
+        // The window edge coincides with the ideographic full stop, so the final
+        // segment is a complete sentence and the boundary is the window end.
+        let window = "第一句话。第二句话。"
+        XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), window)
+    }
+
+    func testBoundaryAcceptsParagraphBreakAtWindowEdge() {
+        // A paragraph break at the window edge is a valid boundary even though
+        // the line has no terminator character.
+        let window = "A heading with no period\n"
+        XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), window)
+    }
+
+    func testBoundaryAcceptsBracketClosersAfterTerminator() {
+        // Closing brackets and guillemets after the terminator do not disqualify
+        // the final segment.
+        let window = "He said «All done.»"
+        XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), window)
+    }
+
+    func testBoundaryStillRejectsMidSentenceWindowEdge() {
+        // A window truncated mid-sentence must fall back to an earlier boundary.
+        let window = "First sentence. Second incomplete and more"
+        XCTAssertEqual(window.lastNaturalBoundary(minTokenCount: 1, encode: scalarEncode), "First sentence. ")
     }
 
     func testChunkerShortText() {


### PR DESCRIPTION
`TextChunker` used to scan backward for the last `.`/`!`/`?` in the token window, so any period counted as a sentence end. It split inside emails and decimals, and stranded closing quotes on the next chunk. This replaces the scan with the built in `enumerateSubstrings(options: .bySentences)` and advances the token stream by the exact encoded length of each emitted chunk, so joined chunks always reconstruct the input.

Whats improved with this PR:
```
input:  "It costs $8.50 today. Email info@test.org for offers."
before: [ 'It costs $8.50 today. Email info@test.' , 'org for offers.' ]
after:  [ 'It costs $8.50 today.' , 'Email info@test.org for offers.' ]
```

```
input:  He said "Hello." Then left.
before: [ 'He said "Hello.' , '" Then left.' ]
after:  [ 'He said "Hello."' , 'Then left.' ]
```

A window truncated mid-sentence also no longer counts as a boundary: it must end in a terminator (including CJK fullwidth ones) after trailing whitespace and closing quotes/brackets, or at a paragraph break. Otherwise, the old fallbacks (clause enders, then spaces) apply.

**Note:**
* Boundaries come from the platform [ICU tables](https://unicode-org.github.io/icu/userguide/boundaryanalysis/), so placement can shift slightly between OS versions. Text is always fully preserved.
* ICU has no abbreviation dictionary, so "Mr." can still end a sentence, but taking the rightmost boundary in the window papers over this whenever a later real boundary exists.

Also added reconstruction assertions plus cases for paragraph breaks, emails/decimals, quotes, and CJK terminators at the window edge.