### PR TITLE
decoder: a prefill prediction must not complete the segment

### DIFF
--- a/Sources/ArgmaxCLI/ArgmaxCLI.swift
+++ b/Sources/ArgmaxCLI/ArgmaxCLI.swift
@@ -4,7 +4,7 @@
 import ArgumentParser
 import Foundation
 
-let VERSION: String = "development"
+let VERSION: String = "v1.0.0"
 
 var subcommands: [ParsableCommand.Type] {
 #if BUILD_SERVER_CLI

--- a/Sources/WhisperKit/Core/TextDecoder.swift
+++ b/Sources/WhisperKit/Core/TextDecoder.swift
@@ -575,7 +575,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
 
             let isPrefill = tokenIndex < initialPromptIndex - 1 // Prefill stops at the last token of the initial prompt
             let isLastPrefillToken = tokenIndex == initialPromptIndex - 1
-            let isFirstToken = tokenIndex == prefilledIndex
+            let isFirstToken = tokenIndex == max(prefilledIndex, initialPromptIndex - 1)
 
             // Check if current index is part of the initial prompt
             if tokenIndex < initialPromptIndex {
@@ -666,7 +666,7 @@ open class TextDecoder: TextDecoding, WhisperMLModel {
                     false
                 }
             let isSegmentCompleted =
-                sampleResult.completed ||
+                (sampleResult.completed && !isPrefill) ||
                 currentTokens.count >= Constants.maxTokenContext - 1 ||
                 isFirstTokenLogProbTooLow
 


### PR DESCRIPTION
## What

Any transcription with `promptTokens` returns an empty string. Two lines in
`TextDecoder.decodeText`.

## Why

The decoder forces the prompt tokens one index at a time, and the prediction it
makes while doing so is discarded on the next iteration — the loop overwrites
`nextToken` with `currentTokens[tokenIndex]`. But `isSegmentCompleted` honours
that prediction anyway, so a single `<|endoftext|>` guess anywhere inside the
prompt ends the segment before decoding has begun.

Reproduced on `openai_whisper-large-v3-v20240930_turbo_632MB` with a 20-token
Portuguese prompt, instrumenting the loop:

```
prefilledIndex=0 initialPromptIndex=25 tokens=25
break at idx=12 isPrefill=true completed=true token=50257 '<|endoftext|>'
```

Output is `<|startoftranscript|><|pt|><|transcribe|><|0.00|><|endoftext|>` — five
tokens, empty text. The same audio without a prompt transcribes normally,
because the four-token prefill is short enough that the model never guesses
end-of-text inside it. `usePrefillPrompt: false` also "works", but only because
it drops the language token, so the model is no longer told what it is hearing.

## The second line

`isFirstToken` compares `tokenIndex` against `prefilledIndex`, which is the
first *forced* index rather than the first *sampled* one. Without a prompt those
coincide, so `firstTokenLogProbThreshold` has been measuring the intended token
by accident; with a prompt it measures a token from the middle of the prompt.

## Effect

Eight Portuguese utterances containing English technical terms, with a prompt
exemplifying that vocabulary:

| | word accuracy | technical terms recovered |
|---|---|---|
| before (prompt ignored, output empty) | — | — |
| no prompt | 85.8% | 46% |
| with prompt | 89.5% | 85% |

Latency unchanged: 0.98-1.38 s per utterance, model resident.
