### PR TITLE
Qwen3-TTS Base variant with voice cloning via speaker-embedding packs

### DIFF
--- a/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
+++ b/Examples/TTS/TTSKitExample/TTSKitExample/ViewModel.swift
@@ -1211,6 +1211,7 @@ extension TTSModelVariant {
         switch self {
             case .qwen3TTS_0_6b: return "~1 GB"
             case .qwen3TTS_1_7b: return "~2.2 GB"
+            case .qwen3TTS_0_6b_base: return "~1 GB"
         }
     }
 }

--- a/Sources/ArgmaxCLI/TTSCLI.swift
+++ b/Sources/ArgmaxCLI/TTSCLI.swift
@@ -39,6 +39,9 @@ struct TTSCLI: AsyncParsableCommand {
     @Option(name: .long, help: "Language (english, chinese, japanese, korean)")
     var language: Qwen3Language = .english
 
+    @Option(name: .long, help: "Voice-clone pack JSON path (Base model variant only); overrides --speaker")
+    var voicePack: String?
+
     @Option(name: .long, help: "Output audio file path")
     var outputPath: String = "output"
 
@@ -232,6 +235,21 @@ struct TTSCLI: AsyncParsableCommand {
             print("  Seed: \(effectiveSeed)")
         }
 
+        // Register a cloned voice from a pack file (Base model variant).
+        var cloneVoiceName: String?
+        if let voicePack {
+            let packURL = URL(fileURLWithPath: FileManager.resolveAbsolutePath(voicePack))
+            let pack = try Qwen3VoicePack.load(from: packURL)
+            config.voiceClones[pack.name] = pack
+            cloneVoiceName = pack.name
+            if !model.supportsVoiceCloning {
+                print("Warning: --voice-pack requires the Base model variant (--model 0.6b-base); the pack will likely not clone correctly on \(model.rawValue).")
+            }
+            if verbose {
+                print("  Voice pack: \(pack.name) (\(pack.xVector.count)-dim x-vector, refCodes: \(pack.refCodes?.count ?? 0) frames)")
+            }
+        }
+
         // Initialize pipeline (downloads if needed, loads tokenizer + 6 models concurrently)
         config.seed = effectiveSeed
         let tts = try await TTSKit(config)
@@ -248,18 +266,19 @@ struct TTSCLI: AsyncParsableCommand {
         )
 
         let result: SpeechResult
+        let effectiveVoice = cloneVoiceName ?? speaker.rawValue
         if play {
             result = try await tts.play(
                 text: inputText,
-                speaker: speaker,
-                language: language,
+                voice: effectiveVoice,
+                language: language.rawValue,
                 options: options
             )
         } else {
             result = try await tts.generate(
                 text: inputText,
-                speaker: speaker,
-                language: language,
+                voice: effectiveVoice,
+                language: language.rawValue,
                 options: options
             )
         }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Config.swift
@@ -25,11 +25,14 @@ public enum TTSModelFamily: String, Sendable {
 public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Sendable {
     case qwen3TTS_0_6b = "0.6b"
     case qwen3TTS_1_7b = "1.7b"
+    /// The open **Base** 0.6B variant: no built-in speakers, but supports voice
+    /// cloning by injecting a `Qwen3VoicePack` x-vector at the speaker slot.
+    case qwen3TTS_0_6b_base = "0.6b-base"
 
     /// The model architecture family this variant belongs to.
     public var family: TTSModelFamily {
         switch self {
-            case .qwen3TTS_0_6b, .qwen3TTS_1_7b: return .qwen3
+            case .qwen3TTS_0_6b, .qwen3TTS_1_7b, .qwen3TTS_0_6b_base: return .qwen3
         }
     }
 
@@ -37,6 +40,7 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
         switch self {
             case .qwen3TTS_0_6b: return "Qwen3-TTS-0.6B"
             case .qwen3TTS_1_7b: return "Qwen3-TTS-1.7B"
+            case .qwen3TTS_0_6b_base: return "Qwen3-TTS-0.6B-Base"
         }
     }
 
@@ -45,6 +49,7 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
         switch self {
             case .qwen3TTS_0_6b: return "Qwen3 TTS 0.6B"
             case .qwen3TTS_1_7b: return "Qwen3 TTS 1.7B"
+            case .qwen3TTS_0_6b_base: return "Qwen3 TTS 0.6B (Voice Cloning)"
         }
     }
 
@@ -52,8 +57,18 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
     /// Only the 1.7B variant has the capacity to follow style instructions.
     public var supportsVoiceDirection: Bool {
         switch self {
-            case .qwen3TTS_0_6b: return false
+            case .qwen3TTS_0_6b, .qwen3TTS_0_6b_base: return false
             case .qwen3TTS_1_7b: return true
+        }
+    }
+
+    /// Whether this variant supports voice cloning via `Qwen3VoicePack`.
+    /// Only the Base variant's talker was trained to accept a raw speaker
+    /// embedding at the speaker slot; CustomVoice variants use speaker tokens.
+    public var supportsVoiceCloning: Bool {
+        switch self {
+            case .qwen3TTS_0_6b_base: return true
+            case .qwen3TTS_0_6b, .qwen3TTS_1_7b: return false
         }
     }
 
@@ -66,7 +81,7 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
         return true
         #else
         switch self {
-            case .qwen3TTS_0_6b: return true
+            case .qwen3TTS_0_6b, .qwen3TTS_0_6b_base: return true
             case .qwen3TTS_1_7b: return false
         }
         #endif
@@ -81,6 +96,7 @@ public enum TTSModelVariant: String, CustomStringConvertible, CaseIterable, Send
         switch self {
             case .qwen3TTS_0_6b: return "12hz-0.6b-customvoice"
             case .qwen3TTS_1_7b: return "12hz-1.7b-customvoice"
+            case .qwen3TTS_0_6b_base: return "12hz-0.6b-base"
         }
     }
 
@@ -197,6 +213,16 @@ open class TTSKitConfig {
     /// Which multifunction MultiCodeDecoder function to load. `.stepped` (default)
     /// decodes one position per call; `.fused` decodes the whole frame in one call.
     public var multiCodeDecoderMode: Qwen3MultiCodeDecoderMode
+
+    // MARK: - Voice cloning
+
+    /// Cloned voices available for generation, keyed by voice name.
+    ///
+    /// When `generate(voice:)` receives a key from this dictionary, the pack's
+    /// x-vector is injected as the speaker-slot prompt embedding instead of a
+    /// built-in speaker token. Requires a variant with
+    /// `supportsVoiceCloning == true` (the Base model).
+    public var voiceClones: [String: Qwen3VoicePack] = [:]
 
     // MARK: - Compute
 

--- a/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
@@ -61,6 +61,10 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
     public let tokenizer: any TTSTokenizer
     public let suppressTokenIds: Set<Int>
 
+    /// Cloned voices available to this task, keyed by voice name (Base variant only).
+    /// A `voice` argument matching a key here takes precedence over built-in speakers.
+    public let voiceClones: [String: Qwen3VoicePack]
+
     /// Timings captured at model-load time (modelLoading + tokenizerLoading populated).
     public let loadTimings: SpeechTimings
 
@@ -82,7 +86,8 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         tokenizer: any TTSTokenizer,
         suppressTokenIds: Set<Int>,
         loadTimings: SpeechTimings = SpeechTimings(),
-        progress: Progress? = nil
+        progress: Progress? = nil,
+        voiceClones: [String: Qwen3VoicePack] = [:]
     ) {
         self.textProjector = textProjector
         self.codeEmbedder = codeEmbedder
@@ -95,6 +100,7 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         self.suppressTokenIds = suppressTokenIds
         self.loadTimings = loadTimings
         self.progress = progress ?? Progress()
+        self.voiceClones = voiceClones
     }
 
     // MARK: - SpeechGenerating defaults
@@ -276,7 +282,8 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
                 speaker: speaker, lang: lang,
                 instruction: options.instruction,
                 firstTextEmbed: tokenizeResult.firstTextEmbed,
-                embedDim: embedDim
+                embedDim: embedDim,
+                clonePack: voiceClones[voice]
             )
             totalPrefillTokens = combinedEmbeds.count
 
@@ -624,12 +631,18 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
 
     /// Build the full combined embedding sequence (text track + codec track) for prefill.
     /// The returned array includes both the invariant prefix and the variable last token.
+    ///
+    /// When `clonePack` is non-nil (Base variant voice cloning), the codec track uses
+    /// the no-think/auto-language prefix and the pack's x-vector is injected directly
+    /// as the speaker-slot embedding instead of a built-in speaker token — mirroring
+    /// upstream `generate_voice_clone` with `language="Auto"`.
     func buildCombinedEmbeddings(
         speaker: Qwen3Speaker,
         lang: Qwen3Language,
         instruction: String?,
         firstTextEmbed: [FloatType],
-        embedDim: Int
+        embedDim: Int,
+        clonePack: Qwen3VoicePack? = nil
     ) async throws -> [[FloatType]] {
         let zeroCodecEmbed = EmbedUtilities.zeroEmbed(dim: embedDim)
 
@@ -655,21 +668,35 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
         let textPadEmbed = try await textProjector.project(tokenId: Qwen3TTSConstants.textPAD)
         let textBosEmbed = try await textProjector.project(tokenId: Qwen3TTSConstants.textBOS)
 
-        let codecIds: [Int32] = [
-            Qwen3TTSConstants.codecThink,
-            Qwen3TTSConstants.codecThinkBos,
-            lang.tokenID,
-            Qwen3TTSConstants.codecThinkEos,
-            speaker.tokenID,
-            Qwen3TTSConstants.codecPAD,
-            Qwen3TTSConstants.codecBOS
-        ]
         var codecTrackEmbeds: [[FloatType]] = []
-        for codecId in codecIds {
-            try await codecTrackEmbeds.append(codeEmbedder.embed(tokenId: codecId))
+        if let clonePack {
+            // Base-variant clone prompt: no-think prefix (auto language), then the
+            // x-vector as the raw speaker embedding, then PAD + BOS.
+            for codecId in [Qwen3TTSConstants.codecNothink,
+                            Qwen3TTSConstants.codecThinkBos,
+                            Qwen3TTSConstants.codecThinkEos] {
+                try await codecTrackEmbeds.append(codeEmbedder.embed(tokenId: codecId))
+            }
+            codecTrackEmbeds.append(clonePack.speakerEmbed)
+            for codecId in [Qwen3TTSConstants.codecPAD, Qwen3TTSConstants.codecBOS] {
+                try await codecTrackEmbeds.append(codeEmbedder.embed(tokenId: codecId))
+            }
+        } else {
+            let codecIds: [Int32] = [
+                Qwen3TTSConstants.codecThink,
+                Qwen3TTSConstants.codecThinkBos,
+                lang.tokenID,
+                Qwen3TTSConstants.codecThinkEos,
+                speaker.tokenID,
+                Qwen3TTSConstants.codecPAD,
+                Qwen3TTSConstants.codecBOS
+            ]
+            for codecId in codecIds {
+                try await codecTrackEmbeds.append(codeEmbedder.embed(tokenId: codecId))
+            }
         }
 
-        let numPads = codecIds.count - 2
+        let numPads = codecTrackEmbeds.count - 2
         for _ in 0..<numPads {
             textTrackEmbeds.append(textPadEmbed)
         }
@@ -714,7 +741,8 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
             lang: lang,
             instruction: instruction,
             firstTextEmbed: dummyFirstTextEmbed,
-            embedDim: embedDim
+            embedDim: embedDim,
+            clonePack: voiceClones[voice]
         )
         let invariantEmbeds = Array(allEmbeds.dropLast())
 

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
@@ -22,6 +22,7 @@ public enum Qwen3TTSConstants {
     public static let codecBOS: Int32 = 2149
     public static let codecEOS: Int32 = 2150
     public static let codecThink: Int32 = 2154
+    public static let codecNothink: Int32 = 2155
     public static let codecThinkBos: Int32 = 2156
     public static let codecThinkEos: Int32 = 2157
 

--- a/Sources/TTSKit/Qwen3TTS/Qwen3VoicePack.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3VoicePack.swift
@@ -1,0 +1,73 @@
+//  For licensing see accompanying LICENSE.md file.
+//  Copyright © 2026 Argmax, Inc. All rights reserved.
+
+import ArgmaxCore
+import Foundation
+
+// MARK: - Qwen3 Voice Pack
+
+/// A cloned-voice enrollment artifact for the Qwen3-TTS **Base** model variant.
+///
+/// Produced server-side by the enrollment pipeline (reference wav → speaker
+/// encoder): the x-vector conditions the talker on the target voice by being
+/// injected directly as a prompt embedding at the speaker slot (the Base
+/// variant's speaker-encoder `enc_dim` equals the talker hidden size, so no
+/// projection is needed).
+///
+/// `refCodes`/`refText` carry the optional in-context-learning (ICL) reference
+/// for higher-fidelity cloning; they are stored in the pack format now so packs
+/// don't need regenerating when the ICL prompt path lands.
+public struct Qwen3VoicePack: Codable, Sendable {
+    /// Embedding dimension the x-vector must match (talker hidden size).
+    public static let xVectorDim = 1024
+    /// Number of RVQ code groups per frame in `refCodes`.
+    public static let codeGroups = 16
+
+    /// Display / lookup name of the cloned voice.
+    public var name: String
+
+    /// 1024-dim speaker embedding from the Base model's speaker encoder.
+    /// Injected untransformed as the speaker-slot prompt embedding.
+    public var xVector: [Float]
+
+    /// Optional reference codec frames (each `codeGroups` codes) for ICL mode.
+    public var refCodes: [[Int32]]?
+
+    /// Exact transcript of the reference audio (required for ICL mode —
+    /// a wrong transcript poisons the conditioning).
+    public var refText: String?
+
+    public init(name: String, xVector: [Float], refCodes: [[Int32]]? = nil, refText: String? = nil) {
+        self.name = name
+        self.xVector = xVector
+        self.refCodes = refCodes
+        self.refText = refText
+    }
+
+    /// Load a voice pack from a JSON file and validate its dimensions.
+    public static func load(from url: URL) throws -> Qwen3VoicePack {
+        let data = try Data(contentsOf: url)
+        let pack = try JSONDecoder().decode(Qwen3VoicePack.self, from: data)
+        try pack.validate()
+        return pack
+    }
+
+    /// Validate embedding and code-frame dimensions.
+    public func validate() throws {
+        guard xVector.count == Self.xVectorDim else {
+            throw TTSError.generationFailed(
+                "Voice pack '\(name)': xVector has \(xVector.count) dims, expected \(Self.xVectorDim)")
+        }
+        if let refCodes {
+            for (index, frame) in refCodes.enumerated() where frame.count != Self.codeGroups {
+                throw TTSError.generationFailed(
+                    "Voice pack '\(name)': refCodes[\(index)] has \(frame.count) codes, expected \(Self.codeGroups)")
+            }
+        }
+    }
+
+    /// The x-vector converted to the embed element type used by the pipeline.
+    public var speakerEmbed: [FloatType] {
+        xVector.map { FloatType($0) }
+    }
+}

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -727,7 +727,8 @@ open class TTSKit: @unchecked Sendable {
                     tokenizer: tokenizer,
                     suppressTokenIds: Qwen3TTSConstants.suppressTokenIds,
                     loadTimings: currentTimings,
-                    progress: progress
+                    progress: progress,
+                    voiceClones: config.voiceClones
                 )
         }
     }


### PR DESCRIPTION
### Summary

Adds a `.qwen3TTS_0_6b_base` variant and `Qwen3VoicePack`, so a cloned voice can be generated by injecting an enrollment x-vector as the speaker-slot embedding. Mirrors upstream `generate_voice_clone(language="Auto")`.

**Blocked on #518** — the `12hz-0.6b-base` assets aren't on `argmaxinc/ttskit-coreml`, so CI can't exercise this path and no one outside a self-hosted setup can run it. Opening as a draft to show the shape of the change rather than to merge as-is.

### What's new

- `Qwen3VoicePack` (73 lines): carries the 1024-dim x-vector, validates dimensions, optional ICL ref codes/text for a future prompt path.
- `TTSKitConfig.voiceClones` — cloned voices keyed by name; when `generate(voice:)` gets a matching key, prompt assembly uses the no-think prefix and injects the x-vector instead of a built-in speaker token.
- `TTSModelVariant.supportsVoiceCloning`, `true` only for the Base variant.
- CLI: `--voice-pack`.

### Testing

`swift build` clean; 99 TTSKit unit tests pass. The 22 `TTSKitIntegrationTests` failures on my machine are a local Hub-cache permission problem, unrelated to this change. Functionally validated end-to-end against self-converted Base assets in a shipping app on iPhone and iPad.
