### PR TITLE
Support the legacy single-function SpeechDecoder and MultiCodeDecoder assets

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -98,7 +98,8 @@ jobs:
         if: ${{ matrix.run-config['condition'] == true }}
         run: |
           set -o pipefail
-          xcodebuild clean build-for-testing -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcbeautify --renderer github-actions
+          # Annotate warnings from a single job only; duplicate check runs each re-post identical annotations on the PR diff
+          xcodebuild clean build-for-testing -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['clean-destination'] }}' | xcbeautify --renderer ${{ (matrix.run-config['name'] == 'macOS' && inputs.macos-runner == 'macos-26') && 'github-actions' || 'terminal' }}
       - name: Test - ${{ matrix.run-config['name'] }}
         if: ${{ matrix.run-config['condition'] == true }}
         env:
@@ -106,7 +107,7 @@ jobs:
           TEST_RUNNER_HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -o pipefail
-          xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}' | xcbeautify --renderer github-actions
+          xcodebuild test -testPlan UnitTestsPlan -scheme argmax-oss-swift-Package -destination '${{ matrix.run-config['test-destination'] }}' | xcbeautify
       - name: Upload Test Results
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/Sources/ArgmaxCore/ModelUtilities.swift
+++ b/Sources/ArgmaxCore/ModelUtilities.swift
@@ -9,21 +9,40 @@ public struct ModelUtilities {
 
     // MARK: - Model Dimension Introspection
 
-    /// Read a dimension from a model input's multiarray constraint shape.
-    public static func getModelInputDimension(_ model: MLModel?, named: String, position: Int) -> Int? {
+    /// Read the full multiarray constraint shape of a model input.
+    ///
+    /// Returns `nil` when the input is absent or is not a multiarray, which lets
+    /// callers use presence of the shape as a schema probe (e.g. "does this asset
+    /// declare a `qk_mask` input?").
+    public static func getModelInputShape(_ model: MLModel?, named: String) -> [Int]? {
         guard let inputDescription = model?.modelDescription.inputDescriptionsByName[named] else { return nil }
         guard inputDescription.type == .multiArray else { return nil }
         guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }
-        let shape = shapeConstraint.shape.map { $0.intValue }
+        return shapeConstraint.shape.map { $0.intValue }
+    }
+
+    /// Read the full multiarray constraint shape of a model output.
+    public static func getModelOutputShape(_ model: MLModel?, named: String) -> [Int]? {
+        guard let outputDescription = model?.modelDescription.outputDescriptionsByName[named] else { return nil }
+        guard outputDescription.type == .multiArray else { return nil }
+        guard let shapeConstraint = outputDescription.multiArrayConstraint else { return nil }
+        return shapeConstraint.shape.map { $0.intValue }
+    }
+
+    /// Read a dimension from a model input's multiarray constraint shape.
+    /// Returns `nil` if the input is absent or `position` is out of range, so that
+    /// probing an unexpected-rank input reports "unknown" instead of trapping.
+    public static func getModelInputDimension(_ model: MLModel?, named: String, position: Int) -> Int? {
+        guard let shape = getModelInputShape(model, named: named) else { return nil }
+        guard position >= 0, position < shape.count else { return nil }
         return shape[position]
     }
 
     /// Read a dimension from a model output's multiarray constraint shape.
+    /// Returns `nil` if the output is absent or `position` is out of range.
     public static func getModelOutputDimension(_ model: MLModel?, named: String, position: Int) -> Int? {
-        guard let inputDescription = model?.modelDescription.outputDescriptionsByName[named] else { return nil }
-        guard inputDescription.type == .multiArray else { return nil }
-        guard let shapeConstraint = inputDescription.multiArrayConstraint else { return nil }
-        let shape = shapeConstraint.shape.map { $0.intValue }
+        guard let shape = getModelOutputShape(model, named: named) else { return nil }
+        guard position >= 0, position < shape.count else { return nil }
         return shape[position]
     }
 

--- a/Sources/TTSKit/Protocols.swift
+++ b/Sources/TTSKit/Protocols.swift
@@ -130,6 +130,11 @@ public protocol SpeechDecoding: MLModelLoading {
     /// SpeechDecoder, 4 for throughput-optimized). Read from the loaded model's
     /// `audio_codes` input shape. Implies `qk_mask` is consumed iff this is > 1.
     var codesPerStep: Int { get }
+    /// `true` when the model's `kv_cache_update_mask` input is rank 3
+    /// (`[1, codesPerStep, maxSeq]`), `false` for the rank-2 `[1, maxSeq]` mask used
+    /// by legacy single-function assets. Determines the mask the host allocates.
+    /// Not derivable from `codesPerStep`: both mask ranks exist at `codesPerStep == 1`.
+    var usesRank3UpdateMask: Bool { get }
 
     // MARK: - Decoding
 
@@ -147,4 +152,10 @@ public protocol SpeechDecoding: MLModelLoading {
         codes: [[Int32]],
         cache: SpeechDecoderCache
     ) async throws -> SpeechDecoderTimedResult
+}
+
+public extension SpeechDecoding {
+    /// Default matching the multifunction asset, so existing conformers that predate
+    /// single-function support keep their behavior without implementing this.
+    var usesRank3UpdateMask: Bool { true }
 }

--- a/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3GenerateTask.swift
@@ -345,7 +345,8 @@ open class Qwen3GenerateTask: @unchecked Sendable, SpeechGenerating {
             maxSeqLength: speechDecoder.kvCacheMaxSequenceLength,
             hiddenDim: speechDecoder.hiddenDim,
             hiddenContextLen: speechDecoder.hiddenContextLen,
-            codesPerStep: codesPerStep
+            codesPerStep: codesPerStep,
+            useRank3UpdateMask: speechDecoder.usesRank3UpdateMask
         )
 
         var generatedTokens: [Int32] = []

--- a/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3Models.swift
@@ -199,8 +199,8 @@ public enum Qwen3SpeechDecoderMode: String, Sendable, CaseIterable {
 /// Selects which MultiCodeDecoder graph expands a talker frame into its 15
 /// residual codes. `.stepped` decodes one position per prediction; `.fused`
 /// decodes the whole frame in one prediction with in-graph sampling.
-/// Loading requires a multifunction asset exposing both functions; legacy
-/// single-function assets fail to load with a function-selection error.
+/// `.fused` requires a multifunction asset; legacy single-function assets are
+/// schema-identical to `stepped` and load fine in that mode.
 @frozen
 public enum Qwen3MultiCodeDecoderMode: String, Sendable, CaseIterable {
     case stepped

--- a/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3MultiCodeDecoder.swift
@@ -29,6 +29,16 @@ struct MLTensorStepResult {
 
 /// Multi-code RVQ decoder backed by a CoreML model.
 ///
+/// Two asset layouts are supported, distinguished at load time by inspecting the
+/// asset rather than by any variant string:
+///
+/// - **Multifunction** (`W8A16-multifunction`): carries a `stepped` graph (one code
+///   position per prediction) and a `fused` graph (whole 15-code frame in one
+///   prediction with in-graph sampling), selected via
+///   `MLModelConfiguration.functionName`.
+/// - **Single-function** (legacy `W8A16`): one graph, schema-identical to the
+///   multifunction `stepped` function, so it drives the same decode path.
+///
 /// Thread safety: mutable state (`model`, dimension properties) is set once during
 /// `loadModel()` and read-only thereafter. `MLModel.prediction()` is thread-safe.
 /// Per-call state is created locally within `generateMultiCodes()` and never stored
@@ -44,33 +54,62 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
     public private(set) var codecVocabSize: Int = Qwen3TTSConstants.codecVocabSize
 
     /// Which function of the multifunction asset to load. Set before `loadModel`;
-    /// legacy single-function assets cannot be loaded (function selection fails).
+    /// ignored — beyond a compatibility check — when the asset is single-function.
     public var mode: Qwen3MultiCodeDecoderMode = .stepped
+
+    /// `true` when the loaded asset exposed CoreML functions and one was selected.
+    public private(set) var isMultifunction: Bool = false
 
     public init() {}
 
     public func loadModel(at url: URL, computeUnits: MLComputeUnits, prewarmMode: Bool = false) async throws {
         let modelConfig = MLModelConfiguration()
         modelConfig.computeUnits = computeUnits
-        // The MultiCodeDecoder ships as a multifunction asset carrying both the
-        // `stepped` and `fused` graphs; `mode.functionName` selects one. Function
-        // selection is iOS 18+ / macOS 15+, and the asset requires the same minimum,
-        // so callers on older OS cannot load it.
+        // The tensor decode path is iOS 18+ / macOS 15+, as is CoreML function
+        // selection, so both asset layouts share that floor.
         guard #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) else {
             throw TTSError.modelLoadingFailed(
-                "MultiCodeDecoder requires macOS 15 / iOS 18 (multifunction CoreML model)"
+                "MultiCodeDecoder requires macOS 15 / iOS 18"
             )
         }
-        modelConfig.functionName = mode.functionName
+
+        // Probe the asset for CoreML functions instead of assuming a layout: a
+        // multifunction asset names its graphs, a legacy single-function asset
+        // reports none and must be loaded without a `functionName`.
+        let functionNames = await Self.functionNames(at: url)
+        let selectedFunction: String?
+        if functionNames.isEmpty {
+            // Single-function asset: schema-identical to the multifunction `stepped`
+            // graph, so it can serve `.stepped` but has no in-graph sampling to offer
+            // `.fused`. Say so rather than silently running the stepped path.
+            guard mode == .stepped else {
+                throw TTSError.invalidConfiguration(
+                    "MultiCodeDecoder: \(url.lastPathComponent) is a single-function asset and " +
+                    "only supports \(Qwen3MultiCodeDecoderMode.stepped.rawValue). Use the " +
+                    "multifunction variant ('\(Qwen3VariantDefaults.multiCodeDecoder)') for " +
+                    "\(mode.rawValue)."
+                )
+            }
+            selectedFunction = nil
+        } else {
+            guard functionNames.contains(mode.functionName) else {
+                throw TTSError.modelLoadingFailed(
+                    "MultiCodeDecoder: \(url.lastPathComponent) has no function " +
+                    "'\(mode.functionName)' (available: \(functionNames.joined(separator: ", ")))."
+                )
+            }
+            selectedFunction = mode.functionName
+            modelConfig.functionName = mode.functionName
+        }
+
         let loaded: MLModel
         do {
             loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
         } catch {
+            let functionSuffix = selectedFunction.map { " (function '\($0)')" } ?? ""
             throw TTSError.modelLoadingFailed(
-                "MultiCodeDecoder: failed to load function '\(mode.functionName)' from " +
-                "\(url.lastPathComponent). This must be a multifunction CoreML asset " +
-                "with 'stepped' and 'fused' functions, running on macOS 15 / iOS 18 " +
-                "or newer. (\(error.localizedDescription))"
+                "MultiCodeDecoder: failed to load \(url.lastPathComponent)\(functionSuffix) on " +
+                "macOS 15 / iOS 18 or newer. (\(error.localizedDescription))"
             )
         }
 
@@ -78,8 +117,10 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
         guard !prewarmMode else { return }
 
         self.model = loaded
-        // The selected function determines the graph: `fused` samples the whole
-        // frame in-graph, `stepped` decodes one position per prediction.
+        self.isMultifunction = selectedFunction != nil
+        // The selected graph determines the decode path: `fused` samples the whole
+        // frame in-graph, `stepped` (and the legacy asset) decode one position per
+        // prediction.
         self.isFused = mode == .fused
 
         // Detect dimensions from model description
@@ -96,6 +137,19 @@ public class Qwen3MultiCodeDecoder: MultiCodeDecoding, @unchecked Sendable {
         // input_embeds shape: [1, embedDim, 1, 1]
         if let embedDim = ModelUtilities.getModelInputDimension(model, named: "input_embeds", position: 1) {
             self.inputEmbedDim = embedDim
+        }
+    }
+
+    /// CoreML function names exposed by the asset at `url`, or `[]` when it is a
+    /// single-function asset (or cannot be inspected — the subsequent `MLModel.load`
+    /// reports the real failure with better context).
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    private static func functionNames(at url: URL) async -> [String] {
+        do {
+            return try await MLModelAsset(url: url).functionNames
+        } catch {
+            Logging.debug("MultiCodeDecoder: could not read function names from \(url.lastPathComponent): \(error)")
+            return []
         }
     }
 

--- a/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
@@ -8,13 +8,21 @@ import Foundation
 
 // MARK: - Implementation
 
-/// RVQ-to-audio waveform decoder backed by a CoreML multifunction model.
+/// RVQ-to-audio waveform decoder backed by a CoreML model.
 ///
-/// The model bundles two graphs (`latency` and `throughput`) that differ only in
-/// how many RVQ frames they consume per call. The choice is made at load time via
-/// `MLModelConfiguration.functionName` and surfaced as `codesPerStep` after load
-/// (1 for the latency function, 4 for throughput). Multifunction CoreML requires
-/// macOS 15 / iOS 18 and so does the asset itself.
+/// Two asset layouts are supported, distinguished at load time by inspecting the
+/// asset rather than by any variant string:
+///
+/// - **Multifunction** (`W8A16-multifunction`): bundles two graphs (`latency` and
+///   `throughput`) that differ in how many RVQ frames they consume per call. The
+///   choice is made via `MLModelConfiguration.functionName` and surfaced as
+///   `codesPerStep` (1 for latency, 4 for throughput).
+/// - **Single-function** (legacy `W8A16`): one graph, one frame per call, and a
+///   rank-2 `kv_cache_update_mask` instead of the multifunction rank-3 mask.
+///
+/// Everything the host has to vary between the two — `codesPerStep`, the update-mask
+/// rank, whether a `qk_mask` input is consumed, and the cache geometry — is read from
+/// the loaded model's description, so a new asset layout needs no code change here.
 ///
 /// Thread safety: mutable state (`model`, dimension properties) is set once during
 /// `loadModel()` and read-only thereafter. `MLModel.prediction()` is thread-safe.
@@ -32,8 +40,12 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
 
     // MARK: - Mode (set by TTSKit before loadModel)
 
-    /// Which function of the multifunction `.mlmodelc` to load.
+    /// Which function of the multifunction `.mlmodelc` to load. Ignored — beyond a
+    /// compatibility check — when the asset is single-function.
     public var mode: Qwen3SpeechDecoderMode = .latencyOptimized
+
+    /// `true` when the loaded asset exposed CoreML functions and one was selected.
+    public private(set) var isMultifunction: Bool = false
 
     // MARK: - Detected from the loaded model
 
@@ -47,31 +59,62 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
     public private(set) var hiddenDim: Int = Qwen3TTSConstants.sdHiddenDim
     /// Number of RVQ frames consumed per `decodeFrame{Async}` call. 1 for latency,
     /// 4 for throughput. Read from the loaded model's `audio_codes` input shape.
-    /// Also implies the model consumes a `qk_mask` input iff > 1.
     public private(set) var codesPerStep: Int = 1
+    /// `true` when the model's `kv_cache_update_mask` input is rank 3
+    /// (`[1, codesPerStep, maxSeq]`, multifunction asset), `false` for the rank-2
+    /// `[1, maxSeq]` mask of the legacy single-function asset. Read from the model.
+    public private(set) var usesRank3UpdateMask: Bool = true
 
     public init() {}
 
     public func loadModel(at url: URL, computeUnits: MLComputeUnits, prewarmMode: Bool = false) async throws {
         let modelConfig = MLModelConfiguration()
         modelConfig.computeUnits = computeUnits
-        // Multifunction `functionName` selection is iOS 18+ / macOS 15+. The asset
-        // itself requires the same minimum, so callers on older OS cannot load it.
+        // The tensor prediction path below is iOS 18+ / macOS 15+, as is CoreML
+        // function selection, so both asset layouts share that floor.
         guard #available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *) else {
             throw TTSError.modelLoadingFailed(
-                "SpeechDecoder requires macOS 15 / iOS 18 (multifunction CoreML model)"
+                "SpeechDecoder requires macOS 15 / iOS 18"
             )
         }
-        modelConfig.functionName = mode.functionName
+
+        // Probe the asset for CoreML functions instead of assuming a layout: a
+        // multifunction asset names its graphs, a legacy single-function asset
+        // reports none and must be loaded without a `functionName`.
+        let functionNames = await Self.functionNames(at: url)
+        let selectedFunction: String?
+        if functionNames.isEmpty {
+            // Single-function asset. It only implements the 1-frame-per-call graph, so
+            // a throughput request cannot be honored — surface that instead of silently
+            // producing latency-mode audio under a throughput-mode config.
+            guard mode == .latencyOptimized else {
+                throw TTSError.invalidConfiguration(
+                    "SpeechDecoder: \(url.lastPathComponent) is a single-function asset and " +
+                    "only supports \(Qwen3SpeechDecoderMode.latencyOptimized.rawValue). Use the " +
+                    "multifunction variant ('\(Qwen3VariantDefaults.speechDecoder)') for " +
+                    "\(mode.rawValue)."
+                )
+            }
+            selectedFunction = nil
+        } else {
+            guard functionNames.contains(mode.functionName) else {
+                throw TTSError.modelLoadingFailed(
+                    "SpeechDecoder: \(url.lastPathComponent) has no function " +
+                    "'\(mode.functionName)' (available: \(functionNames.joined(separator: ", ")))."
+                )
+            }
+            selectedFunction = mode.functionName
+            modelConfig.functionName = mode.functionName
+        }
+
         let loaded: MLModel
         do {
             loaded = try await MLModel.load(contentsOf: url, configuration: modelConfig)
         } catch {
+            let functionSuffix = selectedFunction.map { " (function '\($0)')" } ?? ""
             throw TTSError.modelLoadingFailed(
-                "SpeechDecoder: failed to load function '\(mode.functionName)' from " +
-                "\(url.lastPathComponent). This must be a multifunction CoreML asset " +
-                "with 'latency' and 'throughput' functions, running on macOS 15 / iOS 18 " +
-                "or newer. (\(error.localizedDescription))"
+                "SpeechDecoder: failed to load \(url.lastPathComponent)\(functionSuffix) on " +
+                "macOS 15 / iOS 18 or newer. (\(error.localizedDescription))"
             )
         }
 
@@ -79,9 +122,10 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
         guard !prewarmMode else { return }
 
         self.model = loaded
+        self.isMultifunction = selectedFunction != nil
 
         // Read required dimensions from the model description. Every input below has a
-        // fixed shape in a well-formed multifunction SpeechDecoder asset, so a missing
+        // fixed shape in a well-formed SpeechDecoder asset of either layout, so a missing
         // dimension means the asset is malformed — fail loudly instead of silently
         // keeping the defaults. In particular, silently defaulting `codesPerStep` to 1
         // would mis-drive a throughput-optimized model (consuming 1 of its 4 frames per
@@ -96,8 +140,58 @@ public class Qwen3SpeechDecoder: SpeechDecoding, @unchecked Sendable {
         self.kvCacheEmbedDim = try Self.requireInputDimension(named: "key_cache", position: 1, in: loaded, assetName: assetName)
         self.kvCacheMaxSequenceLength = try Self.requireInputDimension(named: "key_cache", position: 3, in: loaded, assetName: assetName)
 
+        // Update-mask layout: rank 3 `[1, codesPerStep, maxSeq]` (multifunction) or
+        // rank 2 `[1, maxSeq]` (legacy single-function). The host allocates the mask,
+        // so getting this wrong is a hard CoreML input-shape error on first prediction.
+        guard let updateMaskShape = ModelUtilities.getModelInputShape(loaded, named: "kv_cache_update_mask") else {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder: missing expected input 'kv_cache_update_mask' in \(assetName)."
+            )
+        }
+        switch updateMaskShape.count {
+            case 2: self.usesRank3UpdateMask = false
+            case 3: self.usesRank3UpdateMask = true
+            default:
+                throw TTSError.modelLoadingFailed(
+                    "SpeechDecoder: unsupported 'kv_cache_update_mask' rank " +
+                    "\(updateMaskShape.count) (shape \(updateMaskShape)) in \(assetName); " +
+                    "expected rank 2 or 3."
+                )
+        }
+        // A multi-frame graph cannot be driven by a single-column rank-2 mask.
+        guard codesPerStep == 1 || usesRank3UpdateMask else {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder: \(assetName) consumes \(codesPerStep) frames per call but " +
+                "declares a rank-2 'kv_cache_update_mask', which can only encode one position."
+            )
+        }
+
+        // The `qk_mask` (intra-step causal triangle) is meaningful only for graphs that
+        // consume more than one frame per call, so the host derives it from `codesPerStep`.
+        // Check the asset agrees rather than trusting the invariant silently.
+        let declaresQkMask = ModelUtilities.getModelInputShape(loaded, named: "qk_mask") != nil
+        guard declaresQkMask == (codesPerStep > 1) else {
+            throw TTSError.modelLoadingFailed(
+                "SpeechDecoder: \(assetName) consumes \(codesPerStep) frames per call but " +
+                "\(declaresQkMask ? "declares" : "does not declare") a 'qk_mask' input."
+            )
+        }
+
         // Scale streaming buffer to the audio output per call.
         self.minimumBufferDuration = 0.08 * TimeInterval(codesPerStep)
+    }
+
+    /// CoreML function names exposed by the asset at `url`, or `[]` when it is a
+    /// single-function asset (or cannot be inspected — the subsequent `MLModel.load`
+    /// reports the real failure with better context).
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    private static func functionNames(at url: URL) async -> [String] {
+        do {
+            return try await MLModelAsset(url: url).functionNames
+        } catch {
+            Logging.debug("SpeechDecoder: could not read function names from \(url.lastPathComponent): \(error)")
+            return []
+        }
     }
 
     /// Read a required fixed-shape input dimension from a loaded model, throwing a

--- a/Sources/TTSKit/TTSKit.swift
+++ b/Sources/TTSKit/TTSKit.swift
@@ -388,12 +388,22 @@ open class TTSKit: @unchecked Sendable {
             let resolvedRepo = modelRepo ?? config.modelRepo
             let resolvedToken = modelToken ?? config.modelToken
 
+            // Carry the component variants and version directory over: `downloadPatterns`
+            // is derived from them, so dropping them here would fetch the preset defaults
+            // and then fail to load the variants actually configured.
             let downloadConfig = TTSKitConfig(
                 model: resolvedModel,
                 downloadBase: downloadBase ?? config.downloadBase,
                 modelRepo: resolvedRepo,
                 modelToken: resolvedToken,
                 modelEndpoint: endpoint,
+                versionDir: config.versionDir,
+                codeDecoderVariant: config.codeDecoderVariant,
+                multiCodeDecoderVariant: config.multiCodeDecoderVariant,
+                codeEmbedderVariant: config.codeEmbedderVariant,
+                multiCodeEmbedderVariant: config.multiCodeEmbedderVariant,
+                textProjectorVariant: config.textProjectorVariant,
+                speechDecoderVariant: config.speechDecoderVariant,
                 downloadRevision: config.downloadRevision,
                 downloadAdditionalPatterns: config.downloadAdditionalPatterns,
                 useBackgroundDownloadSession: config.useBackgroundDownloadSession

--- a/Sources/TTSKit/Utilities/KVCache.swift
+++ b/Sources/TTSKit/Utilities/KVCache.swift
@@ -255,25 +255,36 @@ public extension KVCache {
 ///   throughput).
 /// - An optional `qkMask` of shape `[1, codesPerStep, maxSeqLength]` that encodes
 ///   the intra-step causal triangle; only allocated when `codesPerStep > 1` (the
-///   throughput function). The latency function does not consume `qk_mask`.
+///   throughput function). Single-frame graphs do not consume `qk_mask`.
 ///
-/// Always uses the rank-3 `kvCacheUpdateMask` shape since the new multifunction
-/// SpeechDecoder asset requires it for both functions (`[1, 1, maxSeqLength]` for
-/// the latency function, `[1, 4, maxSeqLength]` for throughput).
+/// The `kvCacheUpdateMask` rank comes from the loaded asset: rank 3 for the
+/// multifunction asset (both functions), rank 2 for the legacy single-function one.
 public class SpeechDecoderCache: KVCache, @unchecked Sendable {
     public let hiddenContext: MLMultiArray // [1, hiddenDim, 1, contextLen]
     public let hiddenDim: Int
     public let hiddenContextLen: Int
     /// Intra-step causal mask `[1, codesPerStep, maxSeqLength]`. `nil` when
-    /// `codesPerStep == 1` (latency function does not consume a `qk_mask` input).
+    /// `codesPerStep == 1` (single-frame graphs do not consume a `qk_mask` input).
     public let qkMask: MLMultiArray?
 
+    /// - Parameters:
+    ///   - cacheDim: K/V cache embedding dimension (`key_cache` axis 1).
+    ///   - maxSeqLength: Cache capacity in positions (`key_cache` axis 3).
+    ///   - hiddenDim: Hidden-context width (`hidden_context` axis 1).
+    ///   - hiddenContextLen: Past hidden states the graph attends to (`hidden_context`
+    ///     axis 3): 4 for latency, 1 for throughput.
+    ///   - codesPerStep: RVQ frames per decode call (`audio_codes` axis 2). Also the
+    ///     positions written per `update()`, and gates `qkMask`.
+    ///   - useRank3UpdateMask: `kv_cache_update_mask` rank. Not implied by
+    ///     `codesPerStep` — at `codesPerStep == 1` the legacy asset wants rank 2 and
+    ///     the multifunction latency function wants rank 3.
     public init(
         cacheDim: Int = Qwen3TTSConstants.sdCacheDim,
         maxSeqLength: Int = Qwen3TTSConstants.sdMaxSeq,
         hiddenDim: Int = Qwen3TTSConstants.sdHiddenDim,
         hiddenContextLen: Int = Qwen3TTSConstants.sdHiddenContextLen,
-        codesPerStep: Int = 1
+        codesPerStep: Int = 1,
+        useRank3UpdateMask: Bool = true
     ) throws {
         self.hiddenDim = hiddenDim
         self.hiddenContextLen = hiddenContextLen
@@ -292,16 +303,13 @@ public class SpeechDecoderCache: KVCache, @unchecked Sendable {
             qkMask = nil
         }
 
-        // Speech decoder is non-stateful; always uses the rank-3 update mask
-        // (latency = [1, 1, maxSeqLength], throughput = [1, codesPerStep, maxSeqLength]).
         try super.init(
             cacheDim: cacheDim,
             maxSeqLength: maxSeqLength,
             codesPerStep: codesPerStep,
-            useRank3UpdateMask: true,
+            useRank3UpdateMask: useRank3UpdateMask,
             isStateful: false
         )
-
     }
 
     /// Reset all state (KV cache, masks, hidden context buffer, qk mask).

--- a/Tests/TTSKitTests/TTSKitUnitTests.swift
+++ b/Tests/TTSKitTests/TTSKitUnitTests.swift
@@ -370,6 +370,53 @@ final class TTSKitUnitTests: XCTestCase {
         XCTAssertEqual(cache.qkMask?.shape, [1, 4, 16] as [NSNumber])
     }
 
+    /// Legacy single-function asset: rank-2 `[1, maxSeqLength]` update mask, no qkMask.
+    func testSpeechDecoderCacheLegacyRank2MaskShapes() throws {
+        let cache = try SpeechDecoderCache(
+            cacheDim: 64, maxSeqLength: 16, hiddenDim: 32, hiddenContextLen: 4,
+            codesPerStep: 1, useRank3UpdateMask: false
+        )
+        XCTAssertEqual(cache.codesPerStep, 1)
+        XCTAssertFalse(cache.useRank3UpdateMask)
+        XCTAssertEqual(cache.kvCacheUpdateMask.shape, [1, 16] as [NSNumber])
+        XCTAssertNil(cache.qkMask)
+    }
+
+    /// Legacy mask semantics: single active column that advances one position per update.
+    func testSpeechDecoderCacheLegacyRank2MaskAdvances() throws {
+        let seq = 8
+        let cache = try SpeechDecoderCache(
+            cacheDim: 4, maxSeqLength: seq, hiddenDim: 4, hiddenContextLen: 4,
+            codesPerStep: 1, useRank3UpdateMask: false
+        )
+        let update = cache.kvCacheUpdateMask
+        let updatePtr = update.dataPointer.bindMemory(to: FloatType.self, capacity: update.count)
+        XCTAssertEqual(update.count, seq)
+        for j in 0..<seq {
+            XCTAssertEqual(Float(updatePtr[j]), j == 0 ? 1.0 : 0.0, accuracy: 0.001, "initial mask[\(j)]")
+        }
+
+        cache.update()
+        XCTAssertEqual(cache.cacheLength, 1)
+        for j in 0..<seq {
+            XCTAssertEqual(Float(updatePtr[j]), j == 1 ? 1.0 : 0.0, accuracy: 0.001, "post-update mask[\(j)]")
+        }
+        let pad = cache.keyPaddingMask
+        let padPtr = pad.dataPointer.bindMemory(to: FloatType.self, capacity: pad.count)
+        XCTAssertEqual(Float(padPtr[1]), 0.0, accuracy: 0.001)
+        XCTAssertEqual(Float(padPtr[2]), -10000.0, accuracy: 0.001)
+    }
+
+    /// A rank-2 update mask cannot encode a multi-frame step, so the cache rejects it.
+    func testSpeechDecoderCacheRejectsRank2WithMultipleFrames() throws {
+        XCTAssertThrowsError(
+            try SpeechDecoderCache(
+                cacheDim: 4, maxSeqLength: 16, hiddenDim: 4, hiddenContextLen: 1,
+                codesPerStep: 4, useRank3UpdateMask: false
+            )
+        )
+    }
+
     func testSpeechDecoderCacheInitialMasksLatency() throws {
         let cache = try SpeechDecoderCache(
             cacheDim: 4, maxSeqLength: 8, hiddenDim: 4, hiddenContextLen: 4, codesPerStep: 1


### PR DESCRIPTION
#494 and #513 moved the SpeechDecoder and the MultiCodeDecoder onto multifunction
assets, which dropped support for the legacy single-function `W8A16` ones. This
restores both by detecting the layout at load time instead of assuming it.

### SpeechDecoder

- Probe `MLModelAsset.functionNames`; empty → load without a `functionName`.
  Requesting `throughputOptimized` against it errors instead of silently
  producing latency-mode audio.
- Read the `kv_cache_update_mask` rank from the model (2 = legacy, 3 =
  multifunction). Not derivable from `codesPerStep` — both ranks exist at
  `codesPerStep == 1`, so `SpeechDecoderCache` takes it as a parameter.
- `ModelUtilities` dimension reads are now bounds-safe; probing an
  unexpected-rank input used to trap.

### MultiCodeDecoder

Same probe: the legacy asset is schema-identical to the multifunction `stepped`
graph, so it loads without a `functionName` and drives the same decode path.
`.fused` has no counterpart in a single-function asset, so asking for it reports
a configuration error naming the multifunction variant rather than quietly
running stepped. `.stepped` stays the default; both variants are supported.

### Downloader

`setupModels` built a fresh `TTSKitConfig` for the download that dropped
`versionDir` and the six component variants. `downloadPatterns` is derived from
those, so any pinned variant was ignored — the downloader fetched the preset
defaults and the load then failed on the variant actually requested.

This is pre-existing (it reproduces on `main`), but it makes the legacy support
above unreachable through `TTSKit(config:)`, so it is fixed here. It also means a
user who already has `W8A16` and pins it currently pulls the ~1.1 GB
multifunction assets they don't need before failing to load; after the fix that
run downloads nothing.

### Validation

Cache deleted and re-downloaded from scratch: all 40 files match their original
SHA-256. Same text/seed at `--temperature 0`, vs `main`:

| comparison | result |
| --- | --- |
| multifunction stepped / fused / throughputOptimized vs `main` | bit-exact |
| legacy `W8A16` vs multifunction stepped | corr 0.99999, max abs 7.4e-3 |
| pinned `W8A16` against a cache that already has it | 0 bytes downloaded |

Both guards fire: legacy + `fused` and legacy + `throughputOptimized` each report
the single-function configuration error. 4 tests added for rank-2 geometry. The
macOS 14 path stays deleted — both layouts need the macOS 15 / iOS 18 `MLTensor`
floor.

One commit is unrelated to the decoders: it gates `xcbeautify --renderer
github-actions` to a single matrix job, since eight jobs were annotating the same
warning eight times.
