### PR TITLE
TTSKit: mark the CoreML import in Qwen3SpeechDecoder as @preconcurrency

### DIFF
--- a/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
+++ b/Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift
@@ -3,7 +3,7 @@
 
 import Accelerate
 import ArgmaxCore
-import CoreML
+@preconcurrency import CoreML
 import Foundation
 
 // MARK: - Implementation


### PR DESCRIPTION
Building with Xcode 26.3 fails because MLModelAsset is not Sendable:

  Sources/TTSKit/Qwen3TTS/Qwen3SpeechDecoder.swift:190:30: error: non-Sendable type 'MLModelAsset' cannot exit caller isolation inheriting-isolated context in call to nonisolated property 'functionNames'
  MacOSX26.sdk/System/Library/Frameworks/CoreML.framework/Headers/MLModelAsset.h:40:12: note: class 'MLModelAsset' does not conform to the 'Sendable' protocol

The asset never escapes functionNames(at:), and Xcode 26.4 and later accept the code as is, so this only shows up on that toolchain. The compiler's own fix-it is @preconcurrency, which is what the sibling Qwen3CodeDecoder.swift and the other CoreML users in this package already do.